### PR TITLE
Search.sh print gamepath to stderr + NFCUI search integration

### DIFF
--- a/scripts/nfcui/nfcui.sh
+++ b/scripts/nfcui/nfcui.sh
@@ -564,10 +564,11 @@ _EOF_
 # Returns a text string
 # Example: text="$(_commandPalette)"
 _commandPalette() {
-  local menuOptions selected recursion fileSelected
+  local menuOptions selected recursion fileSelected gamePath
   menuOptions=(
     "Pick"      "Pick a game, core or arcade file (supports .zip files)"
     "Commands"  "Craft a custom command using the command palette"
+    "Search"    "Search for a game"
     "Input"     "Input text manually (requires a keyboard)"
   )
 
@@ -597,6 +598,11 @@ _commandPalette() {
       text="$(recursion="${recursion}" _craftCommand)"
       exitcode="${?}"; [[ "${exitcode}" -ge 1 ]] && { "${FUNCNAME[0]}" ; return ; }
       echo "${text}"
+      ;;
+    Search)
+      gamePath="$(search.sh -print 2>&1 >"$(tty)")"
+      exitcode="${?}"; [[ "${exitcode}" -ge 1 ]] && { "${FUNCNAME[0]}" ; return ; }
+      echo "${gamePath}"
       ;;
   esac
 


### PR DESCRIPTION
I am opening a draft PR here, for this for code review. 
Currently this is set up to print the game path to stderr, because with my limited testing I was able to capture the output in bash like this
```bash
      gamePath="$(search.sh -print 2>&1 >"$(tty)")"
```
any critiques are welcome

![nfcsearch](https://github.com/wizzomafizzo/mrext/assets/2087930/978f789c-cd47-4f36-a7ac-9d851364962e)
