### PR TITLE
[NFC] Probe for serial device

### DIFF
--- a/cmd/nfc/main.go
+++ b/cmd/nfc/main.go
@@ -734,7 +734,11 @@ func main() {
 	writeOpt := flag.String("write", "", "write text to tag")
 	flag.Parse()
 
-	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{})
+	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{
+		Nfc: config.NfcConfig{
+			ProbeDevice: true,
+		},
+	})
 	if err != nil {
 		logger.Error("error loading user config: %s", err)
 		fmt.Println("Error loading config:", err)

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -103,21 +103,33 @@ check if it shows as connected in the log view.
 If you are using a PN532 NFC module connected with a USB to TTL cable, then the following config may be needed 
 in `nfc.ini` in the `Scripts` folder:
 
+```ini
+[nfc]
+probe_device=yes
+allow_commands=no
 ```
+
+Create this file if it doesn't exist.
+
+If nfc.sh is unable to auto detect your device it may be necessary to manually configure the connection string:
+
+```ini
 [nfc]
 connection_string="pn532_uart:/dev/ttyUSB0"
 allow_commands=no
 ```
 
-Create this file if it doesn't exist. Be aware the `ttyUSB0` part may be different if you have other devices connected
-such as tty2oled.
+Be aware the ttyUSB0 part may be different if you have other devices connected such as tty2oled. For a list of possible devices try:
+
+`ls /dev/serial/by-id` or `ls /dev |grep ttyUSB`
 
 ## Configuration
 
 The NFC script supports a `nfc.ini` file in the `Scripts` folder. This file can be used to configure the NFC service.
 
 If one doesn't exist, create a new one. This example has all the default values:
-```
+
+```ini
 [nfc]
 connection_string=""
 allow_commands=no
@@ -139,6 +151,10 @@ disabled and only works from the `nfc.csv` file described below.
 ### disable_sounds
 
 Disables the success and fail sounds played when a tag is scanned.
+
+### probe_device
+
+Enables auto detection of a serial based reader device
 
 ## Setting up tags
 
@@ -326,7 +342,7 @@ You can get the UID of a tag by checking the output in the `nfc` Script display 
 The NFC script currently supports writing to NTAG tags through the command line option `-write <text>`.
 
 For example, from the console or SSH:
-```
+```bash
 /media/fat/Scripts/nfc.sh -write "_Console/SNES"
 ```
 This will write the text `_Console/SNES` to the next detected tag.
@@ -340,7 +356,7 @@ file `/tmp/NFCSCAN`. The contents of the file is in the format `<uid>,<text>`.
 
 You can monitor the file for changes to detect when a tag is scanned with the `inotifywait` command that is
 shipped on the MiSTer Linux image. For example:
-```
+```bash
 while inotifywait -e modify /tmp/NFCSCAN; do
     echo "Tag scanned"
 done

--- a/pkg/config/user.go
+++ b/pkg/config/user.go
@@ -43,6 +43,7 @@ type NfcConfig struct {
 	ConnectionString string `ini:"connection_string,omitempty"`
 	AllowCommands    bool   `ini:"allow_commands,omitempty"`
 	DisableSounds    bool   `ini:"disable_sounds,omitempty"`
+	ProbeDevice      bool   `ini:"probe_device,omitempty"`
 }
 
 type SystemsConfig struct {

--- a/scripts/nfcui/nfcui.sh
+++ b/scripts/nfcui/nfcui.sh
@@ -690,6 +690,7 @@ _Settings() {
     "Commands"    "Toggles the ability to run Linux commands from NFC tags"
     "Sounds"      "Toggles sounds played when a tag is scanned"
     "Connection"  "Hardware configuration for certain NFC readers"
+    "Probe"       "Auto detection of a serial based reader device"
   )
 
   while true; do
@@ -700,6 +701,7 @@ _Settings() {
       Commands) _commandSetting ;;
       Sounds) _soundSetting ;;
       Connection) _connectionSetting ;;
+      Probe) _probeSetting ;;
     esac
   done
 }
@@ -851,6 +853,40 @@ _connectionSetting() {
         sed -i "s/^connection_string=.*/connection_string=\"${customString}\"/" "${settings}"
       else
         echo "connection_string=\"${customString}\"" >> "${settings}"
+      fi
+      ;;
+  esac
+}
+
+_probeSetting() {
+  local menuOptions selected
+  menuOptions=(
+    "Enable"   "Enable detection of a serial based reader device"   "off"
+    "Disable"  "Disable detection of a serial based reader device"  "off"
+  )
+
+  [[ -f "${settings}" ]] || echo "[nfc]" > "${settings}" || { _error "Can't create settings file" ; return 1 ; }
+
+  if grep -q "^probe_device=yes" "${settings}"; then
+    menuOptions[2]="on"
+  else
+    menuOptions[5]="on"
+  fi
+
+  selected="$(_radiolist -- "${menuOptions[@]}" )"
+  case "${selected}" in
+    Enable)
+      if grep -q "^probe_device=" "${settings}"; then
+        sed -i "s/^probe_device=.*/probe_device=yes/" "${settings}"
+      else
+        echo "probe_device=yes" >> "${settings}"
+      fi
+      ;;
+    Disable)
+      if grep -q "^probe_device=" "${settings}"; then
+        sed -i "s/^probe_device=.*/probe_device=no/" "${settings}"
+      else
+        echo "probe_device=no" >> "${settings}"
       fi
       ;;
   esac


### PR DESCRIPTION
Make it easier to use serial based NFC readers by adding a new option to `nfc.ini`

```ini
[nfc]
probe_device=yes
```

```
2023/11/14 22:20:25 INFO attempting to probe for NFC device
2023/11/14 22:20:25 INFO trying pn532_uart:/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
2023/11/14 22:20:25 INFO success using serial: pn532_uart:/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
2023/11/14 22:20:25 INFO successful connect after 0 tries
```
