### PR TITLE
Stop reading NTAG once we have reached the end of the NDEF record

### DIFF
--- a/cmd/nfc/ntag.go
+++ b/cmd/nfc/ntag.go
@@ -52,6 +52,14 @@ func readNtag(pnd nfc.Device, logger *service.Logger) ([]byte, error) {
 
 		allBlocks = append(allBlocks, blocks...)
 		currentBlock = currentBlock + 4
+
+		if bytes.Contains(allBlocks, NDEF_END) {
+			// Once we find the end of the NDEF text record there is no need to
+			// continue reading the rest of the card.
+			// This should make things "load" quicker
+			logger.Debug("found end of ndef record")
+			break
+		}
 	}
 
 	return allBlocks, nil


### PR DESCRIPTION
This should in theory read the larger capacity NTAGs quicker if the text record is short. We already do similar for mifare:
https://github.com/wizzomafizzo/mrext/blob/main/cmd/nfc/mifare.go#L63-L68