### PR TITLE
feat() report back to /ws menu navigation

### DIFF
--- a/cmd/remote/games/tracker.go
+++ b/cmd/remote/games/tracker.go
@@ -3,14 +3,15 @@ package games
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+
 	"github.com/wizzomafizzo/mrext/cmd/remote/websocket"
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/service"
 	"github.com/wizzomafizzo/mrext/pkg/tracker"
-	"net/http"
-	"os"
-	"path/filepath"
 )
 
 type fakeDb struct {
@@ -36,8 +37,9 @@ func (f *fakeDb) AddEvent(ev tracker.EventAction) error {
 	case tracker.EventActionGameStop:
 		websocket.Broadcast(f.logger, "gameRunning:")
 		SendAnnounceGame(f.cfg, f.logger, &ev)
+	case tracker.EventActionMenuNavigation:
+		websocket.Broadcast(f.logger, "menuNavigation:"+ev.Target)
 	}
-
 	return nil
 }
 

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1649,12 +1649,12 @@ This field is blank if no game is running.
 
 #### Menu status
 
-Format: `menu:{system}/{name}`
+Format: `menuNavigation:{folder}/{menuItem}`
 
 | Attribute | Type   | Description |
 |-----------|---------|------------------|
-| `system`  | string | System ID of currently running core. |
-| `name`    | string | Filename of currently running game. |
+| `folder`  | string | The folder you are currently browsing, _arcade or _console for rbg, /games/genesis when browsing roms in the genesis core |
+| `menuItem`| string | The actual name of the mra or rbf file or rom file you are browsing |
 
 ### Events
 

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1606,8 +1606,7 @@ Example response:
 
 ## WebSocket
 
-Remote's WebSocket interface is available on the `/ws` endpoint. It's used for monitoring game and core status of the
-MiSTer, search indexing status, and a more granular lower latency keyboard input method.
+Remote's WebSocket interface is available on the `/ws` endpoint. It's used for monitoring game and core and current menu status of the MiSTer, search indexing status, and a more granular lower latency keyboard input method.
 
 Multiple WebSocket connections are supported.
 
@@ -1647,6 +1646,15 @@ Format: `gameRunning:{system}/{name}`
 | `name`    | string | Filename of currently running game. |
 
 This field is blank if no game is running.
+
+#### Menu status
+
+Format: `menu:{system}/{name}`
+
+| Attribute | Type   | Description |
+|-----------|---------|------------------|
+| `system`  | string | System ID of currently running core. |
+| `name`    | string | Filename of currently running game. |
 
 ### Events
 

--- a/pkg/tracker/files.go
+++ b/pkg/tracker/files.go
@@ -118,9 +118,12 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 		return nil, err
 	}
 
-	err = watcher.Add(config.CurrentPathFile)
-	if err != nil {
-		return nil, err
+	_, fileExistsError := os.Stat(config.CurrentPathFile)
+	if fileExistsError == nil {
+		err = watcher.Add(config.CurrentPathFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return watcher, nil

--- a/pkg/tracker/files.go
+++ b/pkg/tracker/files.go
@@ -81,7 +81,9 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 					return
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					if event.Name == config.CoreNameFile {
+					if event.Name == config.CurrentPathFile {
+						tr.trackMenu()
+					} else if event.Name == config.CoreNameFile {
 						tr.LoadCore()
 					} else if event.Name == config.ActiveGameFile {
 						tr.loadGame()
@@ -112,6 +114,11 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 	}
 
 	err = watcher.Add(config.ActiveGameFile)
+	if err != nil {
+		return nil, err
+	}
+
+	err = watcher.Add(config.CurrentPathFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -315,7 +315,7 @@ func (tr *Tracker) trackMenu() {
 		return
 	}
 
-	tr.addEvent(EventActionMenuNavigation, fullPath+currentPath)
+	tr.addEvent(EventActionMenuNavigation, fullPath+":"+currentPath)
 }
 
 // LoadCore loads the current running core and set it as active.

--- a/scripts/armbuild/Dockerfile
+++ b/scripts/armbuild/Dockerfile
@@ -40,3 +40,4 @@ RUN cd /home/build && \
 ENV PATH="${PATH}:/home/build/go/bin"
 
 WORKDIR /build
+RUN git config --global --add safe.directory /build


### PR DESCRIPTION
This PR adds a new WS kind of message to inform the browser of the current menu item.
The messages are in the format:

menuNavigation:folder:menuItem

<img width="731" alt="image" src="https://github.com/wizzomafizzo/mrext/assets/1194048/bf8c6d75-7f52-4dae-8f9e-8d6ea21af35b">

it works for console and files too

<img width="690" alt="image" src="https://github.com/wizzomafizzo/mrext/assets/1194048/86f31d3d-ad86-418d-b2c2-d85b46571ac0">

The timing is pretty much ok, between 20 and 25ms pass between pressing UP on the remote and getting the message back on the remote