### PR TITLE
Always index launchsync systems

### DIFF
--- a/cmd/launchsync/syncfiles.go
+++ b/cmd/launchsync/syncfiles.go
@@ -219,9 +219,7 @@ func makeIndex(cfg *config.UserConfig, syncs []syncFile) error {
 	var systems []games.System
 	for _, sync := range syncs {
 		for _, game := range sync.games {
-			if !gamesdb.SystemIndexed(*game.system) {
-				systems = append(systems, *game.system)
-			}
+			systems = append(systems, *game.system)
 		}
 	}
 


### PR DESCRIPTION
Currently there is no way from within launchsync itself to force a re-index of systems, so for now we will always do it instead of using the cache.