### PR TITLE
Adds Groovy to supported Systems for Zaparoo gamesdb indexing/launcher

### DIFF
--- a/docs/systems.md
+++ b/docs/systems.md
@@ -10,7 +10,7 @@ This is a list of all systems supported by the MiSTer Extensions scripts. Please
 **Computers:** [Amiga](#amiga), [Amstrad CPC](#amstrad-cpc), [Amstrad PCW](#amstrad-pcw), [Apogee BK-01](#apogee-bk-01), [Apple I](#apple-i), [Apple IIe](#apple-iie), [Atari 800XL](#atari-800xl), [Atom](#atom), [BBC Micro/Master](#bbc-micromaster), [BK0011M](#bk0011m), [Casio PV-2000](#casio-pv-2000), [Commodore 16](#commodore-16), [Commodore 64](#commodore-64), [Commodore PET 2001](#commodore-pet-2001), [Commodore VIC-20](#commodore-vic-20), [EDSAC](#edsac), [Electron](#electron), [Galaksija](#galaksija), [Interact](#interact), [Jupiter Ace](#jupiter-ace), [Laser 350/500/700](#laser-350500700), [Lynx 48/96K](#lynx-4896k), [M5](#m5), [MSX](#msx), [Macintosh Plus](#macintosh-plus), [Mattel Aquarius](#mattel-aquarius), [MultiComp](#multicomp), [Orao](#orao), [Oric](#oric), [PC (486SX)](#pc-486sx), [PC/XT](#pcxt), [PDP-1](#pdp-1), [PMD 85-2A](#pmd-85-2a), [RX-78 Gundam](#rx-78-gundam), [SAM Coupe](#sam-coupe), [SV-328](#sv-328), [Sinclair QL](#sinclair-ql), [Specialist/MX](#specialistmx), [TI-99/4A](#ti-994a), [TRS-80](#trs-80), [TRS-80 CoCo 2](#trs-80-coco-2), [TS-1500](#ts-1500), [TS-Config](#ts-config), [Tandy MC-10](#tandy-mc-10), [Tatung Einstein](#tatung-einstein), [Tutor](#tutor), [UK101](#uk101), [Vector-06C](#vector-06c), [X68000](#x68000), [ZX Spectrum](#zx-spectrum), [ZX Spectrum Next](#zx-spectrum-next)
 
 
-**Other:** [Arcade](#arcade), [Arduboy](#arduboy), [CHIP-8](#chip-8)
+**Other:** [Arcade](#arcade), [Arduboy](#arduboy), [CHIP-8](#chip-8), [Groovy](#groovy)
 
 
 ## Core Groups
@@ -503,6 +503,17 @@ Core groups are aliases to multiple systems. They work as system IDs for all con
 | Label | Files | Delay | Type | Index |
 | --- | --- | --- | --- | --- |
 | - | .32x | 1 | f | 1 |
+
+[Back to top](#systems)
+
+## Groovy
+
+**ID**: Groovy  | **Folders**: Groovy | **RBF**: _Utility/Groovy
+
+
+| Label | Files | Delay | Type | Index |
+| --- | --- | --- | --- | --- |
+| - | .gmc | 2 | f | 1 |
 
 [Back to top](#systems)
 

--- a/pkg/games/systems.go
+++ b/pkg/games/systems.go
@@ -2710,6 +2710,26 @@ var Systems = map[string]System{
 			},
 		},
 	},
+	"Groovy": {
+		Id:          "Groovy",
+		Name:        "Groovy",
+		Category:    CategoryOther,
+		ReleaseDate: "2024-03-02",
+		Alias:       []string{"Groovy"},
+		Folder:      []string{"Groovy"},
+		Rbf:         "_Utility/Groovy",
+		Slots: []Slot{
+			{
+				Label: "GMC",
+				Exts:  []string{".gmc"},
+				Mgl: &MglParams{
+					Delay:  3,
+					Method: "f",
+					Index:  1,
+				},
+			},
+		},
+	},
 	// TODO: Life
 	//       Has loadable files, but no folder?
 	// TODO: ScummVM

--- a/releases/external/taptui.sh
+++ b/releases/external/taptui.sh
@@ -118,6 +118,7 @@ consoles=(
   "GameboyColor"      "Gameboy Color"
   "Genesis"           "Genesis"
   "Sega32X"           "Genesis 32X"
+  "Groovy"            "Groovy"
   "Intellivision"     "Intellivision"
   "Interact"          "Interact"
   "Jupiter"           "Jupiter Ace"

--- a/scripts/nfcui/nfcui.sh
+++ b/scripts/nfcui/nfcui.sh
@@ -100,6 +100,7 @@ consoles=(
   "GameboyColor"      "Gameboy Color"
   "Genesis"           "Genesis"
   "Sega32X"           "Genesis 32X"
+  "Groovy"            "Groovy"
   "Intellivision"     "Intellivision"
   "Interact"          "Interact"
   "Jupiter"           "Jupiter Ace"
@@ -159,6 +160,7 @@ consoles=(
   "X68000"            "X68000"
   "ZXSpectrum"        "ZX Spectrum"
   "ZXNext"            "ZX Spectrum Next"
+  "Genesis"           "Genesis"
 )
 
 nfcjokes=(


### PR DESCRIPTION
Adds support for the Groovy core's GMC file format. To later be implemented into Zaparoo for database parsing and easy flashing/MGL loads.

GMC files are command schemas similar to Zapscript that can be loaded as ROM-like commands via the Groovy Core's OSD. This is also supported via MGL format for launching.

```
<mistergamedescription><rbf>_Utility/Groovy</rbf><file delay="3" type="f" index="1" path="unload.gmc"/></mistergamedescription>
```
Tested against [networked machine server](https://github.com/BossRighteous/GroovyMiSTerCommand), from MiSTer when loading MGL from OSD menu.

Confirmed against CONF_STR
https://github.com/psakhis/Groovy_MiSTer/blob/main/Groovy.sv#L214

Will allow indexed MAME/RetroArch games with appropriate GMC files to be loaded externally from the MiSTer via Zaparoo services.


