### PR TITLE
Remote - Ignore casing of file extensions for remote's game lists.

### DIFF
--- a/cmd/remote/games/browse.go
+++ b/cmd/remote/games/browse.go
@@ -181,7 +181,7 @@ func listPath(logger *service.Logger, path string) ([]menu.Item, error) {
 			continue
 		}
 
-		if !file.isDir && !utils.Contains(validFiletypes, filepath.Ext(file.name)) {
+		if !file.isDir && !utils.ContainsFold(validFiletypes, filepath.Ext(file.name)) {
 			continue
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -121,6 +121,16 @@ func Contains[T comparable](xs []T, x T) bool {
 	return false
 }
 
+// ContainsFold returns true if slice of strings contains value (case insensitive).
+func ContainsFold(xs []string, x string) bool {
+	for _, v := range xs {
+		if strings.EqualFold(v, x) {
+			return true
+		}
+	}
+	return false
+}
+
 // RandomElem picks and returns a random element from a slice.
 func RandomElem[T any](xs []T) (T, error) {
 	var item T

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -126,6 +126,25 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestContainsFold(t *testing.T) {
+	var tests = []struct {
+		xs   []string
+		x    string
+		want bool
+	}{
+		{[]string{}, "Game", false},
+		{[]string{"Game"}, "Game", true},
+		{[]string{"Game"}, "NewGame", false},
+		{[]string{"Umbrella", "Ball"}, "Ball", true},
+		{[]string{"Frog", "Lamp"}, "Fruit", false},
+	}
+	for _, tt := range tests {
+		if got := ContainsFold(tt.xs, tt.x); got != tt.want {
+			t.Errorf("ContainsFold(%s, %s) = %v, want %v", tt.xs, tt.x, got, tt.want)
+		}
+	}
+}
+
 func TestRandomElem(t *testing.T) {
 	t1 := []string{}
 	if el, err := RandomElem(t1); err == nil {


### PR DESCRIPTION
Candidate fix for https://github.com/wizzomafizzo/mrext/issues/120.

Remote checks for a list of accepted extensions of games per system, but it was doing a case sensitive comparison so some games were not listed.

First Go code written 😅 .

Tested in my MiSTer ✅ .
