### PR TITLE
Remote - Do not try to extract file extensions from directories

### DIFF
--- a/cmd/remote/games/browse.go
+++ b/cmd/remote/games/browse.go
@@ -175,7 +175,13 @@ func listPath(logger *service.Logger, path string) ([]menu.Item, error) {
 	items := make([]menu.Item, 0)
 
 	for _, file := range files {
-		friendlyName := strings.TrimSuffix(file.name, filepath.Ext(file.name))
+
+		var friendlyName string
+		if file.isDir {
+			friendlyName = file.name
+		} else {
+			friendlyName = strings.TrimSuffix(file.name, filepath.Ext(file.name))
+		}
 
 		if strings.HasPrefix(file.name, ".") {
 			continue


### PR DESCRIPTION
Candidate fix for https://github.com/wizzomafizzo/mrext/issues/121.

Tested very quickly, might need more QA later, leaving as draft.

Issue occuring of directory names being trimmed when the period genuinely belongs to the name.