### PR TITLE
Place symlink to cores in the correct place

### DIFF
--- a/pkg/mister/launchers.go
+++ b/pkg/mister/launchers.go
@@ -177,7 +177,23 @@ func TrySetupArcadeCoresLink(path string) error {
 		return fmt.Errorf("parent is not a directory: %s", path)
 	}
 
-	coresLinkPath := filepath.Join(path, filepath.Base(config.ArcadeCoresFolder))
+	// MiSTer looks for the cores in the outermost folder that starts with '_'
+	rootFolder := path
+	current := path
+
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+
+		if s.HasPrefix(filepath.Base(parent), "_") {
+			rootFolder = parent
+		}
+		current = parent
+	}
+
+	coresLinkPath := filepath.Join(rootFolder, filepath.Base(config.ArcadeCoresFolder))
 	coresLink, err := os.Lstat(coresLinkPath)
 
 	coresLinkExists := false
@@ -194,28 +210,18 @@ func TrySetupArcadeCoresLink(path string) error {
 		return err
 	}
 
-	files, err := os.ReadDir(path)
+	anyArcadeCores, err := HasAnyArcadeCores(rootFolder)
+
 	if err != nil {
 		return err
 	}
 
-	mraCount := 0
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if s.HasSuffix(s.ToLower(file.Name()), ".mra") {
-			mraCount++
-		}
-	}
-
-	if mraCount > 0 && !coresLinkExists {
+	if anyArcadeCores && !coresLinkExists {
 		err = os.Symlink(config.ArcadeCoresFolder, coresLinkPath)
 		if err != nil {
 			return err
 		}
-	} else if mraCount == 0 && coresLinkExists {
+	} else if !anyArcadeCores && coresLinkExists {
 		err = os.Remove(coresLinkPath)
 		if err != nil {
 			return err
@@ -223,6 +229,32 @@ func TrySetupArcadeCoresLink(path string) error {
 	}
 
 	return nil
+}
+
+func HasAnyArcadeCores(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			found, err := HasAnyArcadeCores(filepath.Join(path, e.Name()))
+			if err != nil {
+				return false, err
+			}
+			if found {
+				return true, nil
+			}
+			continue
+		}
+
+		if s.HasSuffix(s.ToLower(e.Name()), ".mra") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func DeleteLauncher(path string) error {

--- a/pkg/mister/launchers.go
+++ b/pkg/mister/launchers.go
@@ -179,7 +179,23 @@ func TrySetupArcadeCoresLink(path string) error {
 		return fmt.Errorf("parent is not a directory: %s", path)
 	}
 
-	coresLinkPath := filepath.Join(path, filepath.Base(config.ArcadeCoresFolder))
+	// MiSTer looks for the cores in the outermost folder that starts with '_'
+	rootFolder := path
+	current := path
+
+	for {
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+
+		if s.HasPrefix(filepath.Base(parent), "_") {
+			rootFolder = parent
+		}
+		current = parent
+	}
+
+	coresLinkPath := filepath.Join(rootFolder, filepath.Base(config.ArcadeCoresFolder))
 	coresLink, err := os.Lstat(coresLinkPath)
 
 	coresLinkExists := false
@@ -196,28 +212,17 @@ func TrySetupArcadeCoresLink(path string) error {
 		return fmt.Errorf("inspect arcade cores link: %w", err)
 	}
 
-	files, err := os.ReadDir(path)
+	anyArcadeCores, err := hasAnyArcadeCores(rootFolder)
 	if err != nil {
 		return fmt.Errorf("read launcher directory: %w", err)
 	}
 
-	mraCount := 0
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if s.HasSuffix(s.ToLower(file.Name()), ".mra") {
-			mraCount++
-		}
-	}
-
-	if mraCount > 0 && !coresLinkExists {
+	if anyArcadeCores && !coresLinkExists {
 		err = os.Symlink(config.ArcadeCoresFolder, coresLinkPath)
 		if err != nil {
 			return fmt.Errorf("create arcade cores link: %w", err)
 		}
-	} else if mraCount == 0 && coresLinkExists {
+	} else if !anyArcadeCores && coresLinkExists {
 		err = os.Remove(coresLinkPath)
 		if err != nil {
 			return fmt.Errorf("remove arcade cores link: %w", err)
@@ -225,6 +230,32 @@ func TrySetupArcadeCoresLink(path string) error {
 	}
 
 	return nil
+}
+
+func hasAnyArcadeCores(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("read arcade launcher directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			found, findErr := hasAnyArcadeCores(filepath.Join(path, entry.Name()))
+			if findErr != nil {
+				return false, findErr
+			}
+			if found {
+				return true, nil
+			}
+			continue
+		}
+
+		if s.HasSuffix(s.ToLower(entry.Name()), ".mra") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func CreateLauncher(

--- a/pkg/mister/launchers_test.go
+++ b/pkg/mister/launchers_test.go
@@ -20,6 +20,8 @@
 package mister
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -81,6 +83,45 @@ func TestGenerateMglPreservesSetNameOverrideAndReset(t *testing.T) {
 	}
 	if !strings.Contains(got, `<reset delay="1" hold="1"/>`) {
 		t.Fatalf("reset missing: %s", got)
+	}
+}
+
+func TestTrySetupArcadeCoresLinkUsesOutermostMenuFolder(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "_Favorites")
+	nested := filepath.Join(root, "Arcade", "Action")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	launcher := filepath.Join(nested, "Game.mra")
+	if err := os.WriteFile(launcher, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := TrySetupArcadeCoresLink(nested); err != nil {
+		t.Fatal(err)
+	}
+	rootLink := filepath.Join(root, filepath.Base(config.ArcadeCoresFolder))
+	info, err := os.Lstat(rootLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", rootLink)
+	}
+	if _, err := os.Lstat(filepath.Join(nested, filepath.Base(config.ArcadeCoresFolder))); !os.IsNotExist(err) {
+		t.Fatalf("nested cores link exists: %v", err)
+	}
+
+	if err := os.Remove(launcher); err != nil {
+		t.Fatal(err)
+	}
+	if err := TrySetupArcadeCoresLink(nested); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(rootLink); !os.IsNotExist(err) {
+		t.Fatalf("unused root cores link remains: %v", err)
 	}
 }
 


### PR DESCRIPTION

Currently when creating a link for an arcade core, it places a symlink for cores at the same location as the .mra file. However, it seems MiSTer actually only looks for the cores folder in the root folder. This causes it to break when you have links to arcade cores in subfolders.

I don't have go set up on linux at the moment, so I wasn't able to test a build, but it should be fine?

Below is the MisterFPGA/mister-debug discord conversation on the subject:

> **oprel — 2:30 PM**
> Hi all! I think I found a bug with MiSTer's arcade shortcuts while working on a my launchsync files. Could anyone else give this a try to see if it also breaks for them before I put in a bug report?
> 
> When creating a shortcut for an arcade core in a subfolder it looks for the cores folder in the wrong place. This means that the arcade game won't run even though it is set up correctly.
> 
> ```
> How to reproduce:
> /media/fat# mkdir _Folder
> /media/fat# mkdir _Folder/_SubFolder
> /media/fat# ln -s "/media/fat/_Arcade/Bubble Bobble (Japan, Ver 0.1).mra" _Folder/_SubFolder /media/fat# ln -s "/media/fat/_Arcade/cores" _Folder/_SubFolder /media/fat# ls _Folder/_SubFolder
> 'Bubble Bobble (Japan, Ver 0.1).mra'   cores
> ```
> 
> When you try to launch Bubble Bobble inside _SubFolder it just boots you back to the main menu, sometimes with some glitchy menu graphics. However, if _Folder has a link to cores it works just fine! 
> **Zakk — 2:41 PM**
> yeah, it's how main looks for stuff. I think other favorites type scripts always symlinked the arcade cores dir into their subdirs when it looks for arcade rbfs it looks in <directory>/cores 
> **oprel — 2:44 PM**
> Ah yeah, but I'm saying it's looking for _Folder/cores/ instead of _Folder/_SubFolder/cores/, which doesn't seem intentional 
>**davewongillies [FPGA],  — 2:45 PM**
> I know if feels non-obvious but I think its probably better than needing it in the subfolders, otherwise you'd need to link it in every subfolder, instead of the parent 
> **Zakk — 2:47 PM**
> yeah, it's intentional. it's there so subdirs share the core directory with the 'root'
> **oprel — 2:48 PM**
> Yeah, less links would be nice? So it's just a bug with how LaunchSync creates shortcuts  then? And maybe the docs could be a bit clearer on how it handles subfolders.
> **Zakk — 2:51 PM**
> I dunno what launchsync does, so I can't say. I just know that given any string of paths, it looks for the arcade rbf in a 'cores' directory that should be in the first directory in the path that starts with "_"
> **davewongillies [FPGA],  — 2:53 PM**
> I think its probably a bug in a package that Wizzo uses in all his extensions as the same thing happens with Mister Remote as well
> **oprel — 2:53 PM**
> Alright, I'll probably look at launchsync's source then and submit a fix quoting this conversation if that's okay.
> **Zakk — 2:53 PM**
> I'll prepare my invoice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved arcade core-link setup by locating menu folders more reliably and managing links when launchers change.
  * Improved game launching and core selection reliability with clearer error handling and safer command execution.
  * Added support for catalog-based core generation and recursive discovery of arcade files.

* **Bug Fixes**
  * Prevented invalid system data from being used during core generation.
  * Improved handling of keyboard, command-interface, file, and network operation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->