### PR TITLE
Add remote mouse support (movement, clicks)

### DIFF
--- a/cmd/remote/control/control.go
+++ b/cmd/remote/control/control.go
@@ -22,6 +22,7 @@ package control
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -132,7 +133,7 @@ type ScreenResponse struct {
 }
 
 func HandleScreen(logger *service.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		width, height, err := mister.GetScreenResolution()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -158,8 +159,16 @@ type MouseMoveArgs struct {
 	Y int `json:"y"`
 }
 
-func SendMouseMove(mouse input.Mouse, x int, y int) error {
-	return mouse.Move(int32(x), int32(y))
+func SendMouseMove(mouse input.Mouse, x, y int) error {
+	if int64(x) < math.MinInt32 || int64(x) > math.MaxInt32 ||
+		int64(y) < math.MinInt32 || int64(y) > math.MaxInt32 {
+		return fmt.Errorf("mouse movement is outside int32 range: %d,%d", x, y)
+	}
+	// #nosec G115 -- both coordinates are range-checked above.
+	if err := mouse.Move(int32(x), int32(y)); err != nil {
+		return fmt.Errorf("move mouse: %w", err)
+	}
+	return nil
 }
 
 func HandleMouseMove(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {
@@ -184,8 +193,11 @@ func HandleMouseMove(mouse input.Mouse, logger *service.Logger) http.HandlerFunc
 // SendMousePosition moves the cursor to an absolute position given as
 // per-mille (0-1000) of the screen along each axis, independent of the current
 // video resolution.
-func SendMousePosition(mouse input.Mouse, x int, y int) error {
-	return mouse.MoveToPermille(x, y)
+func SendMousePosition(mouse input.Mouse, x, y int) error {
+	if err := mouse.MoveToPermille(x, y); err != nil {
+		return fmt.Errorf("position mouse: %w", err)
+	}
+	return nil
 }
 
 func HandleMousePosition(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {
@@ -208,30 +220,35 @@ func HandleMousePosition(mouse input.Mouse, logger *service.Logger) http.Handler
 }
 
 func SendMouseButton(mouse input.Mouse, button string) error {
+	var err error
 	switch button {
 	case "click", "left":
-		return mouse.LeftClick()
+		err = mouse.LeftClick()
 	case "double_click", "double":
-		return mouse.DoubleClick()
+		err = mouse.DoubleClick()
 	case "right":
-		return mouse.RightClick()
+		err = mouse.RightClick()
 	case "middle":
-		return mouse.MiddleClick()
+		err = mouse.MiddleClick()
 	case "left_down":
-		return mouse.LeftDown()
+		err = mouse.LeftDown()
 	case "left_up":
-		return mouse.LeftUp()
+		err = mouse.LeftUp()
 	case "right_down":
-		return mouse.RightDown()
+		err = mouse.RightDown()
 	case "right_up":
-		return mouse.RightUp()
+		err = mouse.RightUp()
 	case "middle_down":
-		return mouse.MiddleDown()
+		err = mouse.MiddleDown()
 	case "middle_up":
-		return mouse.MiddleUp()
+		err = mouse.MiddleUp()
 	default:
 		return fmt.Errorf("unknown mouse button: %s", button)
 	}
+	if err != nil {
+		return fmt.Errorf("send %s mouse button event: %w", button, err)
+	}
+	return nil
 }
 
 func HandleMouseButton(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {

--- a/cmd/remote/control/control.go
+++ b/cmd/remote/control/control.go
@@ -181,13 +181,11 @@ func HandleMouseMove(mouse input.Mouse, logger *service.Logger) http.HandlerFunc
 	}
 }
 
+// SendMousePosition moves the cursor to an absolute position given as
+// per-mille (0-1000) of the screen along each axis, independent of the current
+// video resolution.
 func SendMousePosition(mouse input.Mouse, x int, y int) error {
-	width, height, err := mister.GetScreenResolution()
-	if err != nil {
-		return fmt.Errorf("failed to read screen resolution: %s", err)
-	}
-
-	return mouse.MoveTo(x, y, width, height)
+	return mouse.MoveToPermille(x, y)
 }
 
 func HandleMousePosition(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {

--- a/cmd/remote/control/control.go
+++ b/cmd/remote/control/control.go
@@ -20,6 +20,7 @@
 package control
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 	"github.com/bendahl/uinput"
 	"github.com/gorilla/mux"
 	"github.com/wizzomafizzo/mrext/pkg/input"
+	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/service"
 )
 
@@ -121,6 +123,130 @@ func SendKeyboard(kbd input.Keyboard, key string) error {
 		return wrapKeyboard("send computer OSD key", kbd.ComputerOSD())
 	default:
 		return fmt.Errorf("unknown key: %s", key)
+	}
+}
+
+type ScreenResponse struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+func HandleScreen(logger *service.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		width, height, err := mister.GetScreenResolution()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("failed to read screen resolution: %s", err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(ScreenResponse{
+			Width:  width,
+			Height: height,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("failed to encode screen response: %s", err)
+			return
+		}
+	}
+}
+
+type MouseMoveArgs struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+func SendMouseMove(mouse input.Mouse, x int, y int) error {
+	return mouse.Move(int32(x), int32(y))
+}
+
+func HandleMouseMove(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var args MouseMoveArgs
+		err := json.NewDecoder(r.Body).Decode(&args)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Error("invalid mouse move request: %s", err)
+			return
+		}
+
+		err = SendMouseMove(mouse, args.X, args.Y)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("failed to move mouse: %s", err)
+			return
+		}
+	}
+}
+
+func SendMousePosition(mouse input.Mouse, x int, y int) error {
+	width, height, err := mister.GetScreenResolution()
+	if err != nil {
+		return fmt.Errorf("failed to read screen resolution: %s", err)
+	}
+
+	return mouse.MoveTo(x, y, width, height)
+}
+
+func HandleMousePosition(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var args MouseMoveArgs
+		err := json.NewDecoder(r.Body).Decode(&args)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Error("invalid mouse position request: %s", err)
+			return
+		}
+
+		err = SendMousePosition(mouse, args.X, args.Y)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("failed to set mouse position: %s", err)
+			return
+		}
+	}
+}
+
+func SendMouseButton(mouse input.Mouse, button string) error {
+	switch button {
+	case "click", "left":
+		return mouse.LeftClick()
+	case "double_click", "double":
+		return mouse.DoubleClick()
+	case "right":
+		return mouse.RightClick()
+	case "middle":
+		return mouse.MiddleClick()
+	case "left_down":
+		return mouse.LeftDown()
+	case "left_up":
+		return mouse.LeftUp()
+	case "right_down":
+		return mouse.RightDown()
+	case "right_up":
+		return mouse.RightUp()
+	case "middle_down":
+		return mouse.MiddleDown()
+	case "middle_up":
+		return mouse.MiddleUp()
+	default:
+		return fmt.Errorf("unknown mouse button: %s", button)
+	}
+}
+
+func HandleMouseButton(mouse input.Mouse, logger *service.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		button := vars["button"]
+
+		err := SendMouseButton(mouse, button)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("failed to send mouse button: %s", err)
+			return
+		}
 	}
 }
 

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -76,7 +76,7 @@ func wsConnectPayload(trk *tracker.Tracker) func() []string {
 	}
 }
 
-func wsMsgHandler(kbd input.Keyboard) func(string) string {
+func wsMsgHandler(kbd input.Keyboard, mouse input.Mouse) func(string) string {
 	return func(msg string) string {
 		parts := strings.SplitN(msg, ":", 2)
 		cmd := parts[0]
@@ -130,10 +130,60 @@ func wsMsgHandler(kbd input.Keyboard) func(string) string {
 			}
 
 			return ""
+		case "mouseMove":
+			x, y, err := parseMouseCoords(args)
+			if err != nil {
+				return "invalid"
+			}
+
+			err = control.SendMouseMove(mouse, x, y)
+			if err != nil {
+				return "invalid"
+			}
+
+			return ""
+		case "mousePos":
+			x, y, err := parseMouseCoords(args)
+			if err != nil {
+				return "invalid"
+			}
+
+			err = control.SendMousePosition(mouse, x, y)
+			if err != nil {
+				return "invalid"
+			}
+
+			return ""
+		case "mouseBtn":
+			err := control.SendMouseButton(mouse, args)
+			if err != nil {
+				return "invalid"
+			}
+
+			return ""
 		default:
 			return "invalid"
 		}
 	}
+}
+
+func parseMouseCoords(args string) (int, int, error) {
+	parts := strings.SplitN(args, ",", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid mouse coords: %s", args)
+	}
+
+	x, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	y, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return x, y, nil
 }
 
 func startService(logger *service.Logger, cfg *config.UserConfig) (func() error, error) {
@@ -143,9 +193,22 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		return nil, fmt.Errorf("initialize keyboard: %w", err)
 	}
 
+	mouse, err := input.NewMouse()
+	if err != nil {
+		logger.Error("failed to initialize mouse: %s", err)
+		if closeErr := kbd.Close(); closeErr != nil {
+			logger.Error("failed to close keyboard: %s", closeErr)
+		}
+		return nil, fmt.Errorf("initialize mouse: %w", err)
+	}
+
 	trk, stopTracker, err := games.StartTracker(logger, cfg)
 	if err != nil {
 		logger.Error("failed to start tracker: %s", err)
+		if closeErr := kbd.Close(); closeErr != nil {
+			logger.Error("failed to close keyboard: %s", closeErr)
+		}
+		mouse.Close()
 		return nil, fmt.Errorf("start tracker: %w", err)
 	}
 
@@ -159,7 +222,7 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 	}
 
 	router := mux.NewRouter()
-	setupAPI(router.PathPrefix("/api").Subrouter(), kbd, trk, logger, cfg)
+	setupAPI(router.PathPrefix("/api").Subrouter(), kbd, mouse, trk, logger, cfg)
 	router.PathPrefix("/").Handler(http.HandlerFunc(appHandler))
 
 	corsHandler := cors.New(cors.Options{
@@ -186,6 +249,7 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		if err := kbd.Close(); err != nil {
 			logger.Error("failed to close keyboard: %s", err)
 		}
+		mouse.Close()
 
 		if stopMDNS != nil {
 			err := stopMDNS()
@@ -211,11 +275,12 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 func setupAPI(
 	sub *mux.Router,
 	kbd input.Keyboard,
+	mouse input.Mouse,
 	trk *tracker.Tracker,
 	logger *service.Logger,
 	cfg *config.UserConfig,
 ) {
-	sub.HandleFunc("/ws", websocket.Handle(logger, wsConnectPayload(trk), wsMsgHandler(kbd)))
+	sub.HandleFunc("/ws", websocket.Handle(logger, wsConnectPayload(trk), wsMsgHandler(kbd, mouse)))
 
 	sub.HandleFunc("/screenshots", screenshots.AllScreenshots(logger)).Methods("GET")
 	sub.HandleFunc("/screenshots", screenshots.TakeScreenshot(logger)).Methods("POST")
@@ -253,6 +318,11 @@ func setupAPI(
 
 	sub.HandleFunc("/controls/keyboard/{key}", control.HandleKeyboard(kbd)).Methods("POST")
 	sub.HandleFunc("/controls/keyboard-raw/{key}", control.HandleRawKeyboard(kbd, logger)).Methods("POST")
+
+	sub.HandleFunc("/controls/screen", control.HandleScreen(logger)).Methods("GET")
+	sub.HandleFunc("/controls/mouse/move", control.HandleMouseMove(mouse, logger)).Methods("POST")
+	sub.HandleFunc("/controls/mouse/position", control.HandleMousePosition(mouse, logger)).Methods("POST")
+	sub.HandleFunc("/controls/mouse/{button}", control.HandleMouseButton(mouse, logger)).Methods("POST")
 
 	sub.HandleFunc("/menu/view", menu.ListFolder(logger)).Methods("POST")
 	sub.HandleFunc("/menu/files/create", menu.HandleCreateFile(logger)).Methods("POST")

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -167,20 +167,20 @@ func wsMsgHandler(kbd input.Keyboard, mouse input.Mouse) func(string) string {
 	}
 }
 
-func parseMouseCoords(args string) (int, int, error) {
+func parseMouseCoords(args string) (x, y int, err error) {
 	parts := strings.SplitN(args, ",", 2)
 	if len(parts) != 2 {
 		return 0, 0, fmt.Errorf("invalid mouse coords: %s", args)
 	}
 
-	x, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	x, err = strconv.Atoi(strings.TrimSpace(parts[0]))
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("parse mouse x coordinate: %w", err)
 	}
 
-	y, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	y, err = strconv.Atoi(strings.TrimSpace(parts[1]))
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("parse mouse y coordinate: %w", err)
 	}
 
 	return x, y, nil
@@ -208,7 +208,9 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		if closeErr := kbd.Close(); closeErr != nil {
 			logger.Error("failed to close keyboard: %s", closeErr)
 		}
-		mouse.Close()
+		if closeErr := mouse.Close(); closeErr != nil {
+			logger.Error("failed to close mouse: %s", closeErr)
+		}
 		return nil, fmt.Errorf("start tracker: %w", err)
 	}
 
@@ -249,7 +251,9 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		if err := kbd.Close(); err != nil {
 			logger.Error("failed to close keyboard: %s", err)
 		}
-		mouse.Close()
+		if err := mouse.Close(); err != nil {
+			logger.Error("failed to close mouse: %s", err)
+		}
 
 		if stopMDNS != nil {
 			err := stopMDNS()

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -963,6 +963,134 @@ Example request:
 curl --request POST --url "http://mister:8182/api/controls/keyboard-raw/-16"
 ```
 
+### Controls (mouse)
+
+Mouse input is sent to the MiSTer through a pair of virtual input devices: a
+relative mouse (for movement deltas and all button events) and an absolute
+touchpad (for positioning the cursor at an exact screen coordinate).
+
+Whether a running core reacts to relative movement, absolute positioning or
+both depends on the core itself. Most cores and the main menu expect relative
+PS/2 style mouse movement, so prefer `/controls/mouse/move` for general use and
+treat `/controls/mouse/position` as best-effort.
+
+#### Get current screen resolution
+
+Returns the active screen resolution reported by the MiSTer framebuffer, which
+matches the current video output. Use this to determine the coordinate space
+for absolute mouse positioning.
+
+```plaintext
+GET /controls/screen
+```
+
+On success, returns `200` with a JSON body.
+
+Example request:
+
+```shell
+curl --request GET --url "http://mister:8182/api/controls/screen"
+```
+
+Example response:
+
+```json
+{
+  "width": 1920,
+  "height": 1080
+}
+```
+
+#### Move mouse (relative)
+
+Moves the mouse cursor relative to its current position, in pixels. Negative
+values move left (`x`) and up (`y`).
+
+```plaintext
+POST /controls/mouse/move
+```
+
+Arguments (JSON):
+
+| Attribute | Type   | Required | Description                        |
+|-----------|--------|----------|------------------------------------|
+| `x`       | number | Yes      | Horizontal movement delta, pixels. |
+| `y`       | number | Yes      | Vertical movement delta, pixels.   |
+
+On success, returns `200`.
+
+Example request:
+
+```shell
+curl --request POST --url "http://mister:8182/api/controls/mouse/move" --data '{"x":10,"y":-5}'
+```
+
+#### Move mouse (absolute position)
+
+Moves the mouse cursor to an absolute screen position, given as pixel
+coordinates within the current screen resolution (see
+`GET /controls/screen`). The origin `0,0` is the top-left corner.
+
+```plaintext
+POST /controls/mouse/position
+```
+
+Arguments (JSON):
+
+| Attribute | Type   | Required | Description                            |
+|-----------|--------|----------|----------------------------------------|
+| `x`       | number | Yes      | Horizontal position in pixels.         |
+| `y`       | number | Yes      | Vertical position in pixels.           |
+
+On success, returns `200`.
+
+If the position is outside the current screen resolution, returns `500`.
+
+Example request:
+
+```shell
+curl --request POST --url "http://mister:8182/api/controls/mouse/position" --data '{"x":960,"y":540}'
+```
+
+#### Send mouse button
+
+Sends a mouse button action.
+
+```plaintext
+POST /controls/mouse/{button}
+```
+
+Arguments:
+
+| Attribute | Type   | Required | Description       |
+|-----------|--------|----------|-------------------|
+| `button`  | string | Yes      | Button action.    |
+
+Available button actions:
+
+| Name           | Description                                    |
+|----------------|------------------------------------------------|
+| `click`        | Single left click (alias: `left`).             |
+| `double_click` | Double left click (alias: `double`).           |
+| `right`        | Single right click.                            |
+| `middle`       | Single middle click.                           |
+| `left_down`    | Press and hold the left button.                |
+| `left_up`      | Release the left button.                       |
+| `right_down`   | Press and hold the right button.               |
+| `right_up`     | Release the right button.                       |
+| `middle_down`  | Press and hold the middle button.              |
+| `middle_up`    | Release the middle button.                      |
+
+On success, returns `200`.
+
+If the button action is not recognised, returns `500`.
+
+Example request:
+
+```shell
+curl --request POST --url "http://mister:8182/api/controls/mouse/double_click"
+```
+
 ### Menu
 
 #### List menu folder
@@ -1708,3 +1836,39 @@ Format: `kbdRawUp:{code}`
 | Attribute | Type   | Description                                                                   |
 |-----------|--------|-------------------------------------------------------------------------------|
 | `code`    | number | uinput code of key, as described in the `/controls/keyboard-raw` REST method. |
+
+#### Move mouse (relative)
+
+Moves the mouse cursor relative to its current position, in pixels. Useful for
+low-latency continuous movement (e.g. dragging a pointer). Negative values move
+left (`x`) and up (`y`).
+
+Format: `mouseMove:{x},{y}`
+
+| Attribute | Type   | Description                        |
+|-----------|--------|------------------------------------|
+| `x`       | number | Horizontal movement delta, pixels. |
+| `y`       | number | Vertical movement delta, pixels.   |
+
+#### Move mouse (absolute position)
+
+Moves the mouse cursor to an absolute screen position, in pixels within the
+current screen resolution. See the `/controls/screen` REST method for the
+coordinate space.
+
+Format: `mousePos:{x},{y}`
+
+| Attribute | Type   | Description                    |
+|-----------|--------|--------------------------------|
+| `x`       | number | Horizontal position in pixels. |
+| `y`       | number | Vertical position in pixels.   |
+
+#### Send mouse button
+
+Sends a mouse button action.
+
+Format: `mouseBtn:{button}`
+
+| Attribute | Type   | Description                                                                |
+|-----------|--------|----------------------------------------------------------------------------|
+| `button`  | string | Button action, as described in the `/controls/mouse/{button}` REST method. |

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -41,6 +41,11 @@
     * [Controls (keyboard)](#controls-keyboard)
       * [Send named keyboard key or combo](#send-named-keyboard-key-or-combo)
       * [Send raw keyboard key](#send-raw-keyboard-key)
+    * [Controls (mouse)](#controls-mouse)
+      * [Get current screen resolution](#get-current-screen-resolution)
+      * [Move mouse (relative)](#move-mouse-relative)
+      * [Move mouse (absolute position)](#move-mouse-absolute-position)
+      * [Send mouse button](#send-mouse-button)
     * [Menu](#menu)
       * [List menu folder](#list-menu-folder)
       * [Create menu folder](#create-menu-folder)
@@ -76,6 +81,9 @@
       * [Send raw keyboard key](#send-raw-keyboard-key-1)
       * [Send raw keyboard key down](#send-raw-keyboard-key-down)
       * [Send raw keyboard key up](#send-raw-keyboard-key-up)
+      * [Move mouse (relative)](#move-mouse-relative-1)
+      * [Move mouse (absolute position)](#move-mouse-absolute-position-1)
+      * [Send mouse button](#send-mouse-button-1)
 <!-- TOC -->
 
 ## REST

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -976,9 +976,14 @@ treat `/controls/mouse/position` as best-effort.
 
 #### Get current screen resolution
 
-Returns the active screen resolution reported by the MiSTer framebuffer, which
-matches the current video output. Use this to determine the coordinate space
-for absolute mouse positioning.
+Returns the resolution of the MiSTer's Linux framebuffer, which reflects the
+HDMI **output** resolution produced by the scaler (e.g. the `video_mode` set in
+`MiSTer.ini`).
+
+*Note: this is the video output resolution, not the running core's internal
+render resolution. The core's native resolution is only available inside the
+FPGA and is not exposed to userspace, so it cannot be read here. Absolute mouse
+positioning does not use this value (see below).*
 
 ```plaintext
 GET /controls/screen
@@ -1027,9 +1032,11 @@ curl --request POST --url "http://mister:8182/api/controls/mouse/move" --data '{
 
 #### Move mouse (absolute position)
 
-Moves the mouse cursor to an absolute screen position, given as pixel
-coordinates within the current screen resolution (see
-`GET /controls/screen`). The origin `0,0` is the top-left corner.
+Moves the mouse cursor to an absolute screen position, given as **per-mille**
+(`0`–`1000`) of the screen along each axis, where `0,0` is the top-left corner
+and `1000,1000` is the bottom-right. This is resolution-independent: send where
+to point as a fraction of the screen and it is mapped onto the pointer range.
+Values outside `0`–`1000` are clamped.
 
 ```plaintext
 POST /controls/mouse/position
@@ -1037,19 +1044,17 @@ POST /controls/mouse/position
 
 Arguments (JSON):
 
-| Attribute | Type   | Required | Description                            |
-|-----------|--------|----------|----------------------------------------|
-| `x`       | number | Yes      | Horizontal position in pixels.         |
-| `y`       | number | Yes      | Vertical position in pixels.           |
+| Attribute | Type   | Required | Description                                   |
+|-----------|--------|----------|-----------------------------------------------|
+| `x`       | number | Yes      | Horizontal position, per-mille (`0`–`1000`).  |
+| `y`       | number | Yes      | Vertical position, per-mille (`0`–`1000`).    |
 
 On success, returns `200`.
-
-If the position is outside the current screen resolution, returns `500`.
 
 Example request:
 
 ```shell
-curl --request POST --url "http://mister:8182/api/controls/mouse/position" --data '{"x":960,"y":540}'
+curl --request POST --url "http://mister:8182/api/controls/mouse/position" --data '{"x":500,"y":500}'
 ```
 
 #### Send mouse button
@@ -1852,16 +1857,16 @@ Format: `mouseMove:{x},{y}`
 
 #### Move mouse (absolute position)
 
-Moves the mouse cursor to an absolute screen position, in pixels within the
-current screen resolution. See the `/controls/screen` REST method for the
-coordinate space.
+Moves the mouse cursor to an absolute screen position, given as per-mille
+(`0`–`1000`) of the screen along each axis. Resolution-independent; see the
+`/controls/mouse/position` REST method.
 
 Format: `mousePos:{x},{y}`
 
-| Attribute | Type   | Description                    |
-|-----------|--------|--------------------------------|
-| `x`       | number | Horizontal position in pixels. |
-| `y`       | number | Vertical position in pixels.   |
+| Attribute | Type   | Description                                  |
+|-----------|--------|----------------------------------------------|
+| `x`       | number | Horizontal position, per-mille (`0`–`1000`). |
+| `y`       | number | Vertical position, per-mille (`0`–`1000`).   |
 
 #### Send mouse button
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -20,6 +20,7 @@ Remote is a web-based interface with a stack of modern features to manage all as
 * Control MiSTer directly with a virtual remote control interface
   * Includes all common media keys and hotkeys
   * Full on-screen keyboard and keypad
+  * Virtual mouse trackpad with clicks, drag and desktop mouse capture
 * Launch cores and game shortcuts with an in-app version of the MiSTer menu
   * Move, rename and delete anything in the menu
 * Search and launch your entire game collection

--- a/pkg/input/mouse.go
+++ b/pkg/input/mouse.go
@@ -1,0 +1,121 @@
+package input
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bendahl/uinput"
+)
+
+const doubleClickDelay = 100 * time.Millisecond
+
+// AbsMax is the maximum value of the virtual touchpad's axes. Absolute
+// positions are scaled from screen pixel coordinates to this range, so the
+// touchpad device doesn't need to be recreated when the resolution changes.
+const AbsMax = 1023
+
+type Mouse struct {
+	// Rel is a standard relative movement mouse device.
+	Rel uinput.Mouse
+	// Abs is a touchpad device used for absolute positioning.
+	Abs uinput.TouchPad
+}
+
+func NewMouse() (Mouse, error) {
+	var ms Mouse
+
+	rel, err := uinput.CreateMouse("/dev/uinput", []byte("mrext-mouse"))
+	if err != nil {
+		return ms, err
+	}
+
+	abs, err := uinput.CreateTouchPad(
+		"/dev/uinput", []byte("mrext-touchpad"),
+		0, AbsMax, 0, AbsMax,
+	)
+	if err != nil {
+		_ = rel.Close()
+		return ms, err
+	}
+
+	ms.Rel = rel
+	ms.Abs = abs
+
+	return ms, nil
+}
+
+func (m *Mouse) Close() {
+	_ = m.Rel.Close()
+	_ = m.Abs.Close()
+}
+
+// Move moves the mouse cursor relative to its current position.
+func (m *Mouse) Move(x int32, y int32) error {
+	return m.Rel.Move(x, y)
+}
+
+// MoveTo moves the mouse cursor to an absolute screen position, where x and y
+// are pixel coordinates within a width x height screen resolution.
+func (m *Mouse) MoveTo(x int, y int, width int, height int) error {
+	if width <= 1 || height <= 1 {
+		return fmt.Errorf("invalid screen resolution: %dx%d", width, height)
+	}
+
+	if x < 0 || x >= width || y < 0 || y >= height {
+		return fmt.Errorf("position out of bounds: %d,%d", x, y)
+	}
+
+	absX := int32(x * AbsMax / (width - 1))
+	absY := int32(y * AbsMax / (height - 1))
+
+	return m.Abs.MoveTo(absX, absY)
+}
+
+func (m *Mouse) LeftClick() error {
+	return m.Rel.LeftClick()
+}
+
+func (m *Mouse) DoubleClick() error {
+	err := m.Rel.LeftClick()
+	if err != nil {
+		return err
+	}
+	time.Sleep(doubleClickDelay)
+	return m.Rel.LeftClick()
+}
+
+func (m *Mouse) RightClick() error {
+	return m.Rel.RightClick()
+}
+
+func (m *Mouse) MiddleClick() error {
+	return m.Rel.MiddleClick()
+}
+
+func (m *Mouse) LeftDown() error {
+	return m.Rel.LeftPress()
+}
+
+func (m *Mouse) LeftUp() error {
+	return m.Rel.LeftRelease()
+}
+
+func (m *Mouse) RightDown() error {
+	return m.Rel.RightPress()
+}
+
+func (m *Mouse) RightUp() error {
+	return m.Rel.RightRelease()
+}
+
+func (m *Mouse) MiddleDown() error {
+	return m.Rel.MiddlePress()
+}
+
+func (m *Mouse) MiddleUp() error {
+	return m.Rel.MiddleRelease()
+}
+
+func (m *Mouse) Wheel(delta int32) error {
+	return m.Rel.Wheel(false, delta)
+}

--- a/pkg/input/mouse.go
+++ b/pkg/input/mouse.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/bendahl/uinput"
@@ -10,8 +9,8 @@ import (
 const doubleClickDelay = 100 * time.Millisecond
 
 // AbsMax is the maximum value of the virtual touchpad's axes. Absolute
-// positions are scaled from screen pixel coordinates to this range, so the
-// touchpad device doesn't need to be recreated when the resolution changes.
+// positions are given as per-mille (0-1000) of the screen and scaled into
+// this range, so positioning is independent of the actual screen resolution.
 const AbsMax = 1023
 
 type Mouse struct {
@@ -54,19 +53,23 @@ func (m *Mouse) Move(x int32, y int32) error {
 	return m.Rel.Move(x, y)
 }
 
-// MoveTo moves the mouse cursor to an absolute screen position, where x and y
-// are pixel coordinates within a width x height screen resolution.
-func (m *Mouse) MoveTo(x int, y int, width int, height int) error {
-	if width <= 1 || height <= 1 {
-		return fmt.Errorf("invalid screen resolution: %dx%d", width, height)
+// MoveToPermille moves the mouse cursor to an absolute position given as
+// per-mille (0-1000) of the screen along each axis. This is independent of the
+// screen resolution: the caller sends where on the screen to point as a
+// fraction, and it maps onto the touchpad's absolute range.
+func (m *Mouse) MoveToPermille(x int, y int) error {
+	clamp := func(v int) int {
+		if v < 0 {
+			return 0
+		}
+		if v > 1000 {
+			return 1000
+		}
+		return v
 	}
 
-	if x < 0 || x >= width || y < 0 || y >= height {
-		return fmt.Errorf("position out of bounds: %d,%d", x, y)
-	}
-
-	absX := int32(x * AbsMax / (width - 1))
-	absY := int32(y * AbsMax / (height - 1))
+	absX := int32(clamp(x) * AbsMax / 1000)
+	absY := int32(clamp(y) * AbsMax / 1000)
 
 	return m.Abs.MoveTo(absX, absY)
 }

--- a/pkg/input/mouse.go
+++ b/pkg/input/mouse.go
@@ -1,127 +1,138 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
 package input
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/bendahl/uinput"
 )
 
-const doubleClickDelay = 100 * time.Millisecond
+const (
+	doubleClickDelay = 100 * time.Millisecond
+	clickHoldTime    = 60 * time.Millisecond
+	absMax           = 1023
+)
 
-// clickHoldTime is how long a button is held down during a click. uinput's own
-// click sends the press and release back-to-back with no gap, which is too fast
-// for MiSTer cores that poll the mouse (e.g. classic Mac) to reliably register,
-// so we hold the button briefly like the keyboard does for key presses.
-const clickHoldTime = 60 * time.Millisecond
-
-// AbsMax is the maximum value of the virtual touchpad's axes. Absolute
-// positions are given as per-mille (0-1000) of the screen and scaled into
-// this range, so positioning is independent of the actual screen resolution.
-const AbsMax = 1023
-
+// Mouse owns virtual relative-mouse and absolute-touchpad devices.
 type Mouse struct {
-	// Rel is a standard relative movement mouse device.
 	Rel uinput.Mouse
-	// Abs is a touchpad device used for absolute positioning.
 	Abs uinput.TouchPad
-	// mu serializes access to the shared uinput devices. It is a pointer so
-	// value copies of Mouse (as handed to each HTTP/WebSocket handler) share
-	// the same lock and can't interleave events on the devices.
-	mu *sync.Mutex
+	mu  *sync.Mutex
 }
 
 func NewMouse() (Mouse, error) {
-	var ms Mouse
+	var mouse Mouse
 
-	rel, err := uinput.CreateMouse("/dev/uinput", []byte("mrext-mouse"))
+	relative, err := uinput.CreateMouse("/dev/uinput", []byte("mrext-mouse"))
 	if err != nil {
-		return ms, err
+		return mouse, fmt.Errorf("create relative mouse: %w", err)
 	}
 
-	abs, err := uinput.CreateTouchPad(
+	absolute, err := uinput.CreateTouchPad(
 		"/dev/uinput", []byte("mrext-touchpad"),
-		0, AbsMax, 0, AbsMax,
+		0, absMax, 0, absMax,
 	)
 	if err != nil {
-		_ = rel.Close()
-		return ms, err
+		_ = relative.Close()
+		return mouse, fmt.Errorf("create absolute touchpad: %w", err)
 	}
 
-	ms.Rel = rel
-	ms.Abs = abs
-	ms.mu = &sync.Mutex{}
-
-	return ms, nil
+	mouse.Rel = relative
+	mouse.Abs = absolute
+	mouse.mu = &sync.Mutex{}
+	return mouse, nil
 }
 
-func (m *Mouse) Close() {
+func (m *Mouse) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_ = m.Rel.Close()
-	_ = m.Abs.Close()
+	return errors.Join(m.Rel.Close(), m.Abs.Close())
 }
 
-// Move moves the mouse cursor relative to its current position.
-func (m *Mouse) Move(x int32, y int32) error {
+func (m *Mouse) Move(x, y int32) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.Move(x, y)
+	if err := m.Rel.Move(x, y); err != nil {
+		return fmt.Errorf("move relative mouse: %w", err)
+	}
+	return nil
 }
 
-// MoveToPermille moves the mouse cursor to an absolute position given as
-// per-mille (0-1000) of the screen along each axis. This is independent of the
-// screen resolution: the caller sends where on the screen to point as a
-// fraction, and it maps onto the touchpad's absolute range.
-func (m *Mouse) MoveToPermille(x int, y int) error {
-	clamp := func(v int) int {
-		if v < 0 {
+// MoveToPermille moves cursor to per-mille coordinates from 0 through 1000.
+func (m *Mouse) MoveToPermille(x, y int) error {
+	clamp := func(value int) int {
+		if value < 0 {
 			return 0
 		}
-		if v > 1000 {
+		if value > 1000 {
 			return 1000
 		}
-		return v
+		return value
 	}
 
-	absX := int32(clamp(x) * AbsMax / 1000)
-	absY := int32(clamp(y) * AbsMax / 1000)
+	// #nosec G115 -- clamped values produce results from zero through absMax.
+	absoluteX := int32(clamp(x) * absMax / 1000)
+	// #nosec G115 -- clamped values produce results from zero through absMax.
+	absoluteY := int32(clamp(y) * absMax / 1000)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Abs.MoveTo(absX, absY)
+	if err := m.Abs.MoveTo(absoluteX, absoluteY); err != nil {
+		return fmt.Errorf("move absolute mouse: %w", err)
+	}
+	return nil
 }
 
-// click presses a button, holds it briefly so the core can register it, then
-// releases it. The caller must hold m.mu.
-func click(press func() error, release func() error) error {
+func click(press, release func() error) error {
 	if err := press(); err != nil {
-		return err
+		return fmt.Errorf("press mouse button: %w", err)
 	}
 	time.Sleep(clickHoldTime)
-	return release()
+	if err := release(); err != nil {
+		return fmt.Errorf("release mouse button: %w", err)
+	}
+	return nil
 }
 
-// leftClick performs a left click without taking the lock, for callers that
-// already hold m.mu (e.g. DoubleClick).
-func (m *Mouse) leftClick() error {
+func (m *Mouse) clickLeftUnlocked() error {
 	return click(m.Rel.LeftPress, m.Rel.LeftRelease)
 }
 
 func (m *Mouse) LeftClick() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.leftClick()
+	return m.clickLeftUnlocked()
 }
 
 func (m *Mouse) DoubleClick() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := m.leftClick(); err != nil {
+	if err := m.clickLeftUnlocked(); err != nil {
 		return err
 	}
 	time.Sleep(doubleClickDelay)
-	return m.leftClick()
+	return m.clickLeftUnlocked()
 }
 
 func (m *Mouse) RightClick() error {
@@ -139,41 +150,62 @@ func (m *Mouse) MiddleClick() error {
 func (m *Mouse) LeftDown() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.LeftPress()
+	if err := m.Rel.LeftPress(); err != nil {
+		return fmt.Errorf("press left mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) LeftUp() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.LeftRelease()
+	if err := m.Rel.LeftRelease(); err != nil {
+		return fmt.Errorf("release left mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) RightDown() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.RightPress()
+	if err := m.Rel.RightPress(); err != nil {
+		return fmt.Errorf("press right mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) RightUp() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.RightRelease()
+	if err := m.Rel.RightRelease(); err != nil {
+		return fmt.Errorf("release right mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) MiddleDown() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.MiddlePress()
+	if err := m.Rel.MiddlePress(); err != nil {
+		return fmt.Errorf("press middle mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) MiddleUp() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.MiddleRelease()
+	if err := m.Rel.MiddleRelease(); err != nil {
+		return fmt.Errorf("release middle mouse button: %w", err)
+	}
+	return nil
 }
 
 func (m *Mouse) Wheel(delta int32) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.Rel.Wheel(false, delta)
+	if err := m.Rel.Wheel(false, delta); err != nil {
+		return fmt.Errorf("move mouse wheel: %w", err)
+	}
+	return nil
 }

--- a/pkg/input/mouse.go
+++ b/pkg/input/mouse.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"sync"
 	"time"
 
 	"github.com/bendahl/uinput"
@@ -24,6 +25,10 @@ type Mouse struct {
 	Rel uinput.Mouse
 	// Abs is a touchpad device used for absolute positioning.
 	Abs uinput.TouchPad
+	// mu serializes access to the shared uinput devices. It is a pointer so
+	// value copies of Mouse (as handed to each HTTP/WebSocket handler) share
+	// the same lock and can't interleave events on the devices.
+	mu *sync.Mutex
 }
 
 func NewMouse() (Mouse, error) {
@@ -45,17 +50,22 @@ func NewMouse() (Mouse, error) {
 
 	ms.Rel = rel
 	ms.Abs = abs
+	ms.mu = &sync.Mutex{}
 
 	return ms, nil
 }
 
 func (m *Mouse) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	_ = m.Rel.Close()
 	_ = m.Abs.Close()
 }
 
 // Move moves the mouse cursor relative to its current position.
 func (m *Mouse) Move(x int32, y int32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.Move(x, y)
 }
 
@@ -77,11 +87,13 @@ func (m *Mouse) MoveToPermille(x int, y int) error {
 	absX := int32(clamp(x) * AbsMax / 1000)
 	absY := int32(clamp(y) * AbsMax / 1000)
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Abs.MoveTo(absX, absY)
 }
 
 // click presses a button, holds it briefly so the core can register it, then
-// releases it.
+// releases it. The caller must hold m.mu.
 func click(press func() error, release func() error) error {
 	if err := press(); err != nil {
 		return err
@@ -90,51 +102,78 @@ func click(press func() error, release func() error) error {
 	return release()
 }
 
-func (m *Mouse) LeftClick() error {
+// leftClick performs a left click without taking the lock, for callers that
+// already hold m.mu (e.g. DoubleClick).
+func (m *Mouse) leftClick() error {
 	return click(m.Rel.LeftPress, m.Rel.LeftRelease)
 }
 
+func (m *Mouse) LeftClick() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.leftClick()
+}
+
 func (m *Mouse) DoubleClick() error {
-	err := m.LeftClick()
-	if err != nil {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.leftClick(); err != nil {
 		return err
 	}
 	time.Sleep(doubleClickDelay)
-	return m.LeftClick()
+	return m.leftClick()
 }
 
 func (m *Mouse) RightClick() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return click(m.Rel.RightPress, m.Rel.RightRelease)
 }
 
 func (m *Mouse) MiddleClick() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return click(m.Rel.MiddlePress, m.Rel.MiddleRelease)
 }
 
 func (m *Mouse) LeftDown() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.LeftPress()
 }
 
 func (m *Mouse) LeftUp() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.LeftRelease()
 }
 
 func (m *Mouse) RightDown() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.RightPress()
 }
 
 func (m *Mouse) RightUp() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.RightRelease()
 }
 
 func (m *Mouse) MiddleDown() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.MiddlePress()
 }
 
 func (m *Mouse) MiddleUp() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.MiddleRelease()
 }
 
 func (m *Mouse) Wheel(delta int32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.Rel.Wheel(false, delta)
 }

--- a/pkg/input/mouse.go
+++ b/pkg/input/mouse.go
@@ -8,6 +8,12 @@ import (
 
 const doubleClickDelay = 100 * time.Millisecond
 
+// clickHoldTime is how long a button is held down during a click. uinput's own
+// click sends the press and release back-to-back with no gap, which is too fast
+// for MiSTer cores that poll the mouse (e.g. classic Mac) to reliably register,
+// so we hold the button briefly like the keyboard does for key presses.
+const clickHoldTime = 60 * time.Millisecond
+
 // AbsMax is the maximum value of the virtual touchpad's axes. Absolute
 // positions are given as per-mille (0-1000) of the screen and scaled into
 // this range, so positioning is independent of the actual screen resolution.
@@ -74,25 +80,35 @@ func (m *Mouse) MoveToPermille(x int, y int) error {
 	return m.Abs.MoveTo(absX, absY)
 }
 
+// click presses a button, holds it briefly so the core can register it, then
+// releases it.
+func click(press func() error, release func() error) error {
+	if err := press(); err != nil {
+		return err
+	}
+	time.Sleep(clickHoldTime)
+	return release()
+}
+
 func (m *Mouse) LeftClick() error {
-	return m.Rel.LeftClick()
+	return click(m.Rel.LeftPress, m.Rel.LeftRelease)
 }
 
 func (m *Mouse) DoubleClick() error {
-	err := m.Rel.LeftClick()
+	err := m.LeftClick()
 	if err != nil {
 		return err
 	}
 	time.Sleep(doubleClickDelay)
-	return m.Rel.LeftClick()
+	return m.LeftClick()
 }
 
 func (m *Mouse) RightClick() error {
-	return m.Rel.RightClick()
+	return click(m.Rel.RightPress, m.Rel.RightRelease)
 }
 
 func (m *Mouse) MiddleClick() error {
-	return m.Rel.MiddleClick()
+	return click(m.Rel.MiddlePress, m.Rel.MiddleRelease)
 }
 
 func (m *Mouse) LeftDown() error {

--- a/pkg/mister/vmode.go
+++ b/pkg/mister/vmode.go
@@ -1,0 +1,58 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	FrameBufferDevice         = "/dev/fb0"
+	framebufferGetVScreenInfo = 0x4600
+	framebufferInfoWords      = 64
+)
+
+// GetScreenResolution returns MiSTer's current framebuffer output resolution.
+func GetScreenResolution() (int, int, error) {
+	// #nosec G304 -- framebuffer path is a fixed MiSTer device.
+	framebuffer, err := os.Open(FrameBufferDevice)
+	if err != nil {
+		return 0, 0, fmt.Errorf("open framebuffer: %w", err)
+	}
+	defer func() { _ = framebuffer.Close() }()
+
+	// Linux fb_var_screeninfo contains 40 uint32 fields beginning with xres and
+	// yres. Extra capacity ensures ioctl cannot overrun this buffer.
+	var info [framebufferInfoWords]uint32
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		framebuffer.Fd(),
+		framebufferGetVScreenInfo,
+		uintptr(unsafe.Pointer(&info[0])), // #nosec G103 -- ioctl requires kernel ABI pointer.
+	)
+	if errno != 0 {
+		return 0, 0, fmt.Errorf("read framebuffer mode: %w", errno)
+	}
+
+	return int(info[0]), int(info[1]), nil
+}

--- a/pkg/mister/vmode.go
+++ b/pkg/mister/vmode.go
@@ -33,7 +33,7 @@ const (
 )
 
 // GetScreenResolution returns MiSTer's current framebuffer output resolution.
-func GetScreenResolution() (int, int, error) {
+func GetScreenResolution() (width, height int, err error) {
 	// #nosec G304 -- framebuffer path is a fixed MiSTer device.
 	framebuffer, err := os.Open(FrameBufferDevice)
 	if err != nil {


### PR DESCRIPTION
Adds mouse control to the `remote` service, exposed over REST and WebSocket. This is the **server half**; the web UI is in mrext-client PR #1 (danifunker/mrext-client#1).

## Server changes
- `pkg/input/mouse.go` (new) — virtual relative mouse + absolute touchpad via uinput. Relative movement, absolute per-mille positioning, and single/double/right/middle clicks that **hold the button ~60ms** so cores that poll the mouse (e.g. classic Mac) register them reliably.
- `pkg/mister/vmode.go` — `GetScreenResolution()` via the framebuffer ioctl (this is the HDMI **output** resolution; documented as such).
- `cmd/remote/control/control.go` — handlers + send functions for screen, move, absolute position (per-mille), and buttons (incl. `*_down`/`*_up` for hold/drag).
- `cmd/remote/main.go` — device lifecycle, routes, and WebSocket `mouseMove` / `mousePos` / `mouseBtn` commands.
- `docs/remote-api.md` — REST + WebSocket docs.

## API
```
GET  /api/controls/screen              -> {"width":W,"height":H}   (HDMI output res)
POST /api/controls/mouse/move          {"x":dx,"y":dy}             (relative)
POST /api/controls/mouse/position      {"x":0-1000,"y":0-1000}     (per-mille, resolution-independent)
POST /api/controls/mouse/{button}      click|double_click|right|middle|left_down|left_up|...
```
WebSocket: `mouseMove:dx,dy`, `mousePos:permilleX,permilleY`, `mouseBtn:{action}`.

## Notes
- Absolute positioning is resolution-independent (per-mille): the core's true resolution lives only in the FPGA (UIO_GET_VRES) and can't be read safely from a second process, so we don't depend on it.
- Verified by cross-compiling the static `linux/arm/v7` binary and `go vet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR is part of the same feature as https://github.com/wizzomafizzo/mrext-client/pull/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added virtual mouse trackpad support for remote access, including relative movement, absolute positioning, clicks, button press/release, drag, capture, and wheel input.
  * Added screen-resolution reporting through the remote interface.
  * Expanded REST and WebSocket controls for mouse actions with input validation and error handling.
* **Documentation**
  * Updated remote API documentation with mouse endpoints, supported actions, screen resolution, and WebSocket command formats.
  * Clarified Remote’s legacy status and recommended alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->