### PR TITLE
Rewrite Favorites in Go with shared controller-friendly TUI

### DIFF
--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -30,11 +30,9 @@ jobs:
         run: |
           DL_URL=https://github.com/wizzomafizzo/mrext/releases/download/${{ steps.mrextreleaseinfo.outputs.tag_name }}
           mkdir -p _bin/releases
-          for file in lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
+          for file in favorites.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
             curl -fsSL "$DL_URL/$file" -o "_bin/releases/$file"
           done
-      - name: Update external scripts
-        run: go run github.com/magefile/mage updateExternalApps
       - name: Create databases
         run: |
           cp scripts/generate_repo.py .

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dylib
 *.test
 *.out
+__pycache__/
 go.work
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Play music in MiSTer menu. BGM supports common audio formats and internet radio 
 
 Create and manage shortcuts for favorite games and cores in MiSTer menu.
 
-<a href="https://github.com/wizzomafizzo/mrext/raw/main/scripts/favorites.sh"><img src="docs/images/download.svg" alt="Download Favorites" title="Download Favorites" width="140"></a>
-<a href="https://github.com/wizzomafizzo/mrext#favorites"><img src="docs/images/readme.svg" alt="Readme Favorites" title="Readme Favorites" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/releases/latest/download/favorites.sh"><img src="docs/images/download.svg" alt="Download Favorites" title="Download Favorites" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/blob/main/docs/favorites.md"><img src="docs/images/readme.svg" alt="Readme Favorites" title="Readme Favorites" width="140"></a>
 
 ## GamesMenu
 

--- a/cmd/favorites/main.go
+++ b/cmd/favorites/main.go
@@ -1,0 +1,140 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/favorites"
+)
+
+type cliOptions struct {
+	root    string
+	command string
+}
+
+func parseCLI(args []string) (cliOptions, error) {
+	flags := flag.NewFlagSet("favorites", flag.ContinueOnError)
+	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	if err := flags.Parse(args); err != nil {
+		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
+	}
+	positionals := flags.Args()
+	if len(positionals) > 1 || len(positionals) == 1 && positionals[0] != "refresh" {
+		return cliOptions{}, errors.New("usage: favorites.sh [--root PATH] [refresh]")
+	}
+	options := cliOptions{root: *root}
+	if len(positionals) == 1 {
+		options.command = positionals[0]
+	}
+	return options, nil
+}
+
+func loadRuntime(root string) (*config.UserConfig, *favorites.Manager, error) {
+	if root == "" {
+		cfg, err := favorites.LoadConfig()
+		if err != nil {
+			return nil, nil, fmt.Errorf("load MiSTer configuration: %w", err)
+		}
+		return cfg, favorites.NewManager(cfg), nil
+	}
+
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve local MiSTer root: %w", err)
+	}
+	scriptsFolder := filepath.Join(absoluteRoot, "Scripts")
+	// #nosec G301 -- local fixture mirrors MiSTer's shared filesystem permissions.
+	if mkdirErr := os.MkdirAll(scriptsFolder, 0o755); mkdirErr != nil {
+		return nil, nil, fmt.Errorf("create local MiSTer root: %w", mkdirErr)
+	}
+	appPath := filepath.Join(scriptsFolder, "favorites.sh")
+	cfg, err := favorites.LoadConfigAt(filepath.Join(scriptsFolder, "favorites.ini"), appPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load local configuration: %w", err)
+	}
+	cfg.Systems.GamesFolder = append([]string{absoluteRoot}, cfg.Favorites.GamesFolder...)
+	if cfg.Favorites.ExternalFolder == "/media/usb0" {
+		cfg.Favorites.ExternalFolder = filepath.Join(absoluteRoot, "external")
+	}
+	manager := favorites.NewManagerWithPaths(cfg, favorites.RuntimePaths{
+		SDRoot:            absoluteRoot,
+		StartupScript:     filepath.Join(absoluteRoot, "linux", "user-startup.sh"),
+		ArcadeCoresFolder: filepath.Join(absoluteRoot, "_Arcade", "cores"),
+	})
+	return cfg, manager, nil
+}
+
+func run(args []string) error {
+	options, err := parseCLI(args)
+	if err != nil {
+		return err
+	}
+	cfg, manager, err := loadRuntime(options.root)
+	if err != nil {
+		return fmt.Errorf("load Favorites configuration: %w", err)
+	}
+	if startupErr := manager.TryAddToStartup(); startupErr != nil {
+		return fmt.Errorf("configure startup refresh: %w", startupErr)
+	}
+
+	if options.command == "refresh" {
+		if refreshErr := manager.Refresh(); refreshErr != nil {
+			return fmt.Errorf("refresh Favorites: %w", refreshErr)
+		}
+		return nil
+	}
+	if configErr := favorites.EnsureConfigFile(cfg); configErr != nil {
+		return fmt.Errorf("create Favorites configuration: %w", configErr)
+	}
+
+	createdDefault := false
+	if cfg.Favorites.CreateDefaultFolder {
+		createdDefault, err = manager.CreateDefaultFolder()
+		if err != nil {
+			return fmt.Errorf("prepare default Favorites folder: %w", err)
+		}
+	}
+	defer func() {
+		if cleanupErr := manager.CleanupCreatedDefault(createdDefault); cleanupErr != nil {
+			_, _ = fmt.Fprintln(os.Stderr, cleanupErr)
+		}
+	}()
+
+	if setupErr := manager.SetupArcadeLinks(); setupErr != nil {
+		return fmt.Errorf("prepare arcade links: %w", setupErr)
+	}
+	if refreshErr := manager.Refresh(); refreshErr != nil {
+		return fmt.Errorf("refresh Favorites: %w", refreshErr)
+	}
+	return newUI(cfg, manager).Run()
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/favorites/settings.go
+++ b/cmd/favorites/settings.go
@@ -1,0 +1,255 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/favorites"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const pageSettings = "favorites_settings"
+
+//nolint:govet // Field order groups staged values and page runtime state.
+type settingsPage struct {
+	staged   favorites.Settings
+	original favorites.Settings
+	actions  map[int]func()
+	help     map[int]string
+	list     *tui.MenuList
+	ui       *ui
+}
+
+func (u *ui) startSettings() {
+	page := &settingsPage{
+		staged:   favorites.SettingsFromConfig(u.cfg),
+		original: favorites.SettingsFromConfig(u.cfg),
+		ui:       u,
+	}
+	page.show(0)
+}
+
+func (s *settingsPage) show(selection int) {
+	s.actions = make(map[int]func())
+	s.help = make(map[int]string)
+	s.list = tui.NewMenuList()
+	s.list.AddHeader("Favorites")
+	s.addText("Default folder", s.staged.DefaultFolder, favorites.ValidateFolderName, func(value string) {
+		s.staged.DefaultFolder = value
+	})
+	s.addList("Folder name matches", s.staged.FolderNameContains, false, func(values []string) {
+		s.staged.FolderNameContains = values
+	})
+	s.addToggle("Create default folder", &s.staged.CreateDefaultFolder)
+	s.addToggle("Arcade core links", &s.staged.ManageArcadeCoreLinks)
+	s.addToggle("Hide root files", &s.staged.HideRootFiles)
+	s.addText("USB shortcut folder", s.staged.ExternalFolder, nil, func(value string) {
+		s.staged.ExternalFolder = value
+	})
+	s.addText("Core prefix", s.staged.CorePrefix, nil, func(value string) { s.staged.CorePrefix = value })
+	s.addList("Additional game folders", s.staged.GamesFolders, true, func(values []string) {
+		s.staged.GamesFolders = values
+	})
+
+	s.list.AddHeader("Cores")
+	modes := []string{"", "llapi", "yc"}
+	s.addChoice("Alternate core", alternateCoreLabel(s.staged.AlternateCore), []tui.Choice{
+		{Label: "Standard", Help: "Use standard MiSTer cores."},
+		{Label: "LLAPI", Help: "Use installed LLAPI cores; otherwise use standard cores."},
+		{Label: "YC", Help: "Use installed YC cores; otherwise use standard cores."},
+	}, slices.Index(modes, s.staged.AlternateCore), func(index int) {
+		s.staged.AlternateCore = modes[index]
+	})
+
+	s.list.AddHeader("Interface")
+	themes := make([]tui.Choice, 0, len(tui.ThemeNames))
+	for _, name := range tui.ThemeNames {
+		themes = append(themes, tui.Choice{Label: themeLabel(name), Help: "Applied after saving settings."})
+	}
+	themeIndex := slices.Index(tui.ThemeNames, s.staged.Theme)
+	s.addChoice("Theme", themeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
+		s.staged.Theme = tui.ThemeNames[index]
+	})
+	s.addToggle("Mouse", &s.staged.Mouse)
+	s.addToggle("CRT mode", &s.staged.CRTMode)
+	s.addToggle("On-screen keyboard", &s.staged.OnScreenKeyboard)
+
+	s.list.SetCurrentItem(selection)
+	change := func() {
+		if action := s.actions[s.list.GetCurrentItem()]; action != nil {
+			action()
+		}
+	}
+	s.list.SetSelectedFunc(func(int, string, string, rune) { change() })
+	back := func() { s.back() }
+	bar := tui.NewButtonBar(s.ui.app).
+		AddButtonWithHelp("Change", "Change selected setting", change).
+		AddButtonWithHelp("Save", "Save settings and return", s.save).
+		AddButtonWithHelp("Cancel", "Discard changes and return", back).
+		SetupNavigation(back)
+	frame := tui.NewPageFrame(s.ui.app).
+		SetTitle("Favorites Manager", "Settings").
+		SetContent(s.list).
+		SetHelpText("Change settings, then save or cancel.").
+		SetButtonBar(bar).
+		SetOnEscape(back)
+	showHelp := func(index int) { frame.SetHelpText(s.help[index]) }
+	s.list.SetRowChangedFunc(showHelp)
+	showHelp(s.list.GetCurrentItem())
+	frame.SetupContentToButtonNavigation()
+	s.ui.pages.AddAndSwitchToPage(pageSettings, frame, true)
+	s.ui.app.SetFocus(s.list)
+}
+
+func (s *settingsPage) addRow(label, value string, action func()) {
+	if value == "" {
+		value = "(none)"
+	}
+	index := s.list.GetItemCount()
+	s.list.AddRow(label+": "+value, tui.MenuRowAction)
+	s.actions[index] = action
+	s.help[index] = settingsHelp[label]
+}
+
+func (s *settingsPage) addToggle(label string, value *bool) {
+	display := "Off"
+	if *value {
+		display = "On"
+	}
+	s.addRow(label, display, func() {
+		*value = !*value
+		s.show(s.list.GetCurrentItem())
+	})
+}
+
+func (s *settingsPage) addChoice(label, value string, choices []tui.Choice, selected int, apply func(int)) {
+	s.addRow(label, value, func() {
+		selection := s.list.GetCurrentItem()
+		tui.ShowChoiceModal(s.ui.pages, s.ui.app, label, choices, max(selected, 0), func(index int) {
+			apply(index)
+			s.show(selection)
+		}, func() { s.show(selection) })
+	})
+}
+
+func (s *settingsPage) addText(
+	label, value string,
+	validate func(string) error,
+	apply func(string),
+) {
+	s.addRow(label, value, func() {
+		selection := s.list.GetCurrentItem()
+		s.ui.showNameInput(tui.InputOptions{
+			Title:        "Edit " + label,
+			Prompt:       "Enter " + strings.ToLower(label) + ".",
+			InitialValue: value,
+			Validate:     validate,
+		}, func(updated string) {
+			apply(strings.TrimSpace(updated))
+			s.show(selection)
+		}, func() { s.show(selection) })
+	})
+}
+
+func (s *settingsPage) addList(
+	label string,
+	values []string,
+	allowEmpty bool,
+	apply func([]string),
+) {
+	s.addRow(label, fmt.Sprintf("%d entries (list)", len(values)), func() {
+		selection := s.list.GetCurrentItem()
+		s.editList(label, slices.Clone(values), allowEmpty, apply, func() { s.show(selection) })
+	})
+}
+
+func (s *settingsPage) back() {
+	if s.staged.Equal(&s.original) {
+		s.ui.mustShowMain()
+		return
+	}
+	tui.ShowConfirmModal(
+		s.ui.pages,
+		s.ui.app,
+		"Discard Settings",
+		"Discard unsaved settings?",
+		s.ui.mustShowMain,
+		func() { s.show(s.list.GetCurrentItem()) },
+	)
+}
+
+func (s *settingsPage) save() {
+	if _, exists := tui.AvailableThemes[s.staged.Theme]; !exists {
+		s.ui.showError(fmt.Errorf("unknown TUI theme: %s", s.staged.Theme), func() {
+			s.show(s.list.GetCurrentItem())
+		})
+		return
+	}
+	if err := favorites.SaveSettings(s.ui.cfg.IniPath, &s.staged); err != nil {
+		s.ui.showError(err, func() { s.show(s.list.GetCurrentItem()) })
+		return
+	}
+	s.apply()
+	if err := s.ui.manager.SetupArcadeLinks(); err != nil {
+		s.ui.showError(err, s.ui.mustShowMain)
+		return
+	}
+	s.ui.mustShowMain()
+}
+
+func (s *settingsPage) apply() {
+	gamesFolders := slices.Clone(s.ui.cfg.Systems.GamesFolder)
+	for _, oldFolder := range s.original.GamesFolders {
+		gamesFolders = slices.DeleteFunc(gamesFolders, func(folder string) bool { return folder == oldFolder })
+	}
+	s.staged.ApplyTo(s.ui.cfg)
+	gamesFolders = append(gamesFolders, s.staged.GamesFolders...)
+	s.ui.cfg.Systems.GamesFolder = gamesFolders
+	s.ui.options = tui.ApplicationOptions{
+		Theme:            s.ui.cfg.TUI.Theme,
+		Mouse:            s.ui.cfg.TUI.Mouse,
+		CRTMode:          s.ui.cfg.TUI.CRTMode,
+		OnScreenKeyboard: s.ui.cfg.TUI.OnScreenKeyboard,
+	}
+	_ = tui.SetCurrentTheme(s.ui.options.Theme)
+	s.ui.app.EnableMouse(s.ui.options.Mouse)
+	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
+}
+
+func alternateCoreLabel(mode string) string {
+	switch mode {
+	case "llapi":
+		return "LLAPI"
+	case "yc":
+		return "YC"
+	default:
+		return "Standard"
+	}
+}
+
+func themeLabel(name string) string {
+	if theme := tui.AvailableThemes[name]; theme != nil {
+		return theme.DisplayName
+	}
+	return name
+}

--- a/cmd/favorites/settings_help.go
+++ b/cmd/favorites/settings_help.go
@@ -1,0 +1,36 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+var settingsHelp = map[string]string{
+	"Default folder":          "Folder created at startup when no Favorites folders exist.",
+	"Folder name matches":     "Name fragments used to find Favorites folders, such as fav.",
+	"Create default folder":   "Automatically create the default folder at startup if needed.",
+	"Arcade core links":       "Maintain cores links so arcade favorites can find their RBFs.",
+	"Hide root files":         "Show only familiar MiSTer folders at the SD browser root.",
+	"USB shortcut folder":     "Folder opened by the USB shortcut, normally /media/usb0.",
+	"Core prefix":             "Prefix standard RBF paths for custom setups; normally leave empty.",
+	"Additional game folders": "Extra game-library roots to recognize alongside SD and USB roots.",
+	"Alternate core":          "Choose Standard, LLAPI, or YC for newly created game favorites.",
+	"Theme":                   "Choose a color palette to apply after saving.",
+	"Mouse":                   "Enable mouse input alongside keyboard and controller navigation.",
+	"CRT mode":                "Use a compact 75-column, 15-row layout for CRT displays.",
+	"On-screen keyboard":      "Use controller-friendly text entry; Off needs a physical keyboard.",
+}

--- a/cmd/favorites/settings_list.go
+++ b/cmd/favorites/settings_list.go
@@ -1,0 +1,119 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+func (s *settingsPage) editList(
+	label string,
+	values []string,
+	allowEmpty bool,
+	apply func([]string),
+	onReturn func(),
+) {
+	const page = "favorites_settings_list"
+	list := tui.NewMenuList()
+	for _, value := range values {
+		list.AddRow(value, tui.MenuRowItem)
+	}
+	if len(values) == 0 {
+		list.AddHeader("No entries - choose Add")
+	}
+	back := func() {
+		s.ui.pages.RemovePage(page)
+		onReturn()
+	}
+	rebuild := func() { s.editList(label, values, allowEmpty, apply, onReturn) }
+	edit := func(add bool) {
+		if !add && len(values) == 0 {
+			return
+		}
+		index := list.GetCurrentItem()
+		initial := ""
+		if !add {
+			initial = values[index]
+		}
+		s.ui.showNameInput(tui.InputOptions{
+			Title:        "One " + listEntryLabel(label),
+			InitialValue: initial,
+			Validate: func(value string) error {
+				value = strings.TrimSpace(value)
+				if value == "" || strings.ContainsAny(value, ",\r\n") {
+					return errors.New("enter one nonempty value without commas or newlines")
+				}
+				if allowEmpty && !filepath.IsAbs(value) {
+					return errors.New("enter a full filesystem path, such as /media/network")
+				}
+				return nil
+			},
+		}, func(value string) {
+			value = strings.TrimSpace(value)
+			if add {
+				values = append(values, value)
+			} else {
+				values[index] = value
+			}
+			rebuild()
+		}, rebuild)
+	}
+	remove := func() {
+		if len(values) == 0 {
+			return
+		}
+		if len(values) == 1 && !allowEmpty {
+			s.ui.showError(errors.New("keep at least one folder name match"), rebuild)
+			return
+		}
+		index := list.GetCurrentItem()
+		values = slices.Delete(values, index, index+1)
+		rebuild()
+	}
+	bar := tui.NewButtonBar(s.ui.app).
+		AddButton("Edit", func() { edit(false) }).
+		AddButton("Add", func() { edit(true) }).
+		AddButton("Remove", remove).
+		AddButton("Done", func() { apply(slices.Clone(values)); back() }).
+		AddButton("Cancel", back).
+		SetupNavigation(back)
+	frame := tui.NewPageFrame(s.ui.app).
+		SetTitle(label).
+		SetContent(list).
+		SetHelpText("One entry per row. Done keeps edits; Save settings writes them.").
+		SetButtonBar(bar).
+		SetOnEscape(back)
+	list.SetSelectedFunc(func(int, string, string, rune) { edit(false) })
+	frame.SetupContentToButtonNavigation()
+	s.ui.pages.AddAndSwitchToPage(page, tui.Centered(73, 13, frame), true)
+	s.ui.app.SetFocus(list)
+}
+
+func listEntryLabel(label string) string {
+	if label == "Folder name matches" {
+		return "name fragment"
+	}
+	return "game folder path"
+}

--- a/cmd/favorites/ui.go
+++ b/cmd/favorites/ui.go
@@ -1,0 +1,496 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/favorites"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const (
+	pageMain    = "favorites_main"
+	pageBrowser = "favorites_browser"
+	pageFolder  = "favorites_folder"
+	pageModify  = "favorites_modify"
+)
+
+//nolint:govet // Field order groups runtime dependencies and navigation state.
+type ui struct {
+	manager          *favorites.Manager
+	cfg              *config.UserConfig
+	app              *tview.Application
+	pages            *tview.Pages
+	options          tui.ApplicationOptions
+	mainSelection    int
+	browserSelection map[string]int
+}
+
+type browserChoice struct {
+	entry    *favorites.BrowseEntry
+	path     string
+	external bool
+	parent   bool
+}
+
+func newUI(cfg *config.UserConfig, manager *favorites.Manager) *ui {
+	return &ui{
+		manager: manager,
+		cfg:     cfg,
+		options: tui.ApplicationOptions{
+			Theme:            cfg.TUI.Theme,
+			Mouse:            cfg.TUI.Mouse,
+			CRTMode:          cfg.TUI.CRTMode,
+			OnScreenKeyboard: cfg.TUI.OnScreenKeyboard,
+		},
+		browserSelection: make(map[string]int),
+	}
+}
+
+func (u *ui) Run() error {
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(u.options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		u.app = app
+		u.pages = tview.NewPages()
+		if err := u.showMain(); err != nil {
+			return nil, err
+		}
+		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
+		return app, nil
+	}
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run Favorites TUI: %w", err)
+	}
+	return nil
+}
+
+func (u *ui) showMain() error {
+	items, err := u.manager.EditableItems()
+	if err != nil {
+		return fmt.Errorf("list editable Favorites: %w", err)
+	}
+	list := tui.NewMenuList().
+		AddRow("Add favorite", tui.MenuRowAdd).
+		AddHeader("Existing favorites")
+	for _, item := range items {
+		label := strings.TrimSuffix(u.manager.RelativePath(item.Path), filepath.Ext(item.Path))
+		if item.Kind == favorites.FavoriteFolder {
+			label += "/"
+		}
+		kind := tui.MenuRowItem
+		if item.Kind == favorites.FavoriteFolder {
+			kind = tui.MenuRowFolder
+		}
+		list.AddRow(truncateLeading(label, 65), kind)
+	}
+	if list.GetItemCount() > 0 {
+		list.SetCurrentItem(min(u.mainSelection, list.GetItemCount()-1))
+	}
+	activate := func() {
+		selection := list.GetCurrentItem()
+		u.mainSelection = selection
+		if selection == 0 {
+			u.showBrowser(u.managerRoot())
+			return
+		}
+		if selection >= 2 {
+			u.showModify(&items[selection-2])
+		}
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+
+	bar := tui.NewButtonBar(u.app).
+		AddButtonWithHelp("Select", "Open selected favorite or add a new one", activate).
+		AddButtonWithHelp("Create Folder", "Create a nested Favorites folder", u.startCreateFolder).
+		AddButtonWithHelp("Settings", "Configure Favorites Manager", u.startSettings).
+		AddButtonWithHelp("Exit", "Exit Favorites Manager", u.app.Stop).
+		SetupNavigation(u.app.Stop)
+	frame := tui.NewPageFrame(u.app).
+		SetTitle("Favorites Manager").
+		SetContent(list).
+		SetHelpText("Add a new favorite or select an existing one to modify.").
+		SetButtonBar(bar).
+		SetOnEscape(u.app.Stop)
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	u.pages.AddAndSwitchToPage(pageMain, frame, true)
+	u.app.SetFocus(list)
+	return nil
+}
+
+func (u *ui) managerRoot() string {
+	return u.manager.Root()
+}
+
+func (u *ui) startCreateFolder() {
+	u.createFolder(u.mustShowMain)
+}
+
+func (u *ui) createFolder(onReturn func()) {
+	u.showFolderPicker(false, "", "Select parent folder", func(parent string) {
+		u.showNameInput(tui.InputOptions{
+			Title:        "Create Folder",
+			Prompt:       "Enter a folder name. It must start with an underscore (_).",
+			InitialValue: "_",
+			Validate:     favorites.ValidateFolderName,
+		}, func(name string) {
+			if _, err := u.manager.CreateFolder(parent, name); err != nil {
+				u.showError(err, func() { u.createFolder(onReturn) })
+				return
+			}
+			onReturn()
+		}, onReturn)
+	}, onReturn)
+}
+
+func (u *ui) showBrowser(folder string) {
+	entries, err := u.manager.ListDirectory(folder)
+	if err != nil {
+		u.showError(err, u.mustShowMain)
+		return
+	}
+	choices := make([]browserChoice, 0, len(entries)+2)
+	list := tui.NewMenuList()
+
+	if samePath(folder, u.managerRoot()) {
+		external := u.manager.ExternalFolder()
+		if files, readErr := os.ReadDir(external); readErr == nil && len(files) > 0 {
+			choices = append(choices, browserChoice{path: external, external: true})
+			list.AddRow("Go to USB drive", tui.MenuRowAction)
+		}
+	}
+	if parent, parentErr := u.manager.ParentFolder(folder); parentErr == nil && !samePath(parent, folder) {
+		choices = append(choices, browserChoice{path: parent, parent: true})
+		list.AddRow("..  Parent folder", tui.MenuRowAction)
+	}
+	for index := range entries {
+		entry := entries[index]
+		choices = append(choices, browserChoice{entry: &entry, path: entry.Path})
+		kind := tui.MenuRowItem
+		if entry.IsDirectory {
+			kind = tui.MenuRowFolder
+		}
+		list.AddRow(entry.Label, kind)
+	}
+	if len(choices) == 0 {
+		list.AddHeader("No selectable files found")
+	}
+	if selection := u.browserSelection[folder]; selection < list.GetItemCount() {
+		list.SetCurrentItem(selection)
+	}
+	activate := func() {
+		if len(choices) == 0 {
+			return
+		}
+		selection := list.GetCurrentItem()
+		u.browserSelection[folder] = selection
+		choice := choices[selection]
+		if choice.external || choice.parent || choice.entry.IsDirectory {
+			next := choice.path
+			if choice.entry != nil && choice.entry.IsArchive && !strings.Contains(
+				strings.ToLower(filepath.ToSlash(next)), ".zip/",
+			) {
+				next += string(filepath.Separator)
+			}
+			u.showBrowser(next)
+			return
+		}
+		u.startAddFavorite(*choice.entry)
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+	back := func() {
+		parent, parentErr := u.manager.ParentFolder(folder)
+		if parentErr != nil || samePath(parent, folder) {
+			u.mustShowMain()
+			return
+		}
+		u.showBrowser(parent)
+	}
+	browseArchive := func() {
+		if len(choices) == 0 {
+			return
+		}
+		choice := choices[list.GetCurrentItem()]
+		if choice.entry != nil && choice.entry.IsArchive {
+			u.showBrowser(choice.path + string(filepath.Separator))
+			return
+		}
+		activate()
+	}
+	hasSelectableArchive := false
+	for _, choice := range choices {
+		if choice.entry != nil && choice.entry.IsArchive && !choice.entry.IsDirectory {
+			hasSelectableArchive = true
+			break
+		}
+	}
+	bar := tui.NewButtonBar(u.app).
+		AddButtonWithHelp("Select", "Open folder or select favorite", activate)
+	if hasSelectableArchive {
+		bar.AddButtonWithHelp("Browse", "Browse inside selected ZIP", browseArchive)
+	}
+	bar.AddButtonWithHelp("Back", "Return to previous folder", back).
+		AddButtonWithHelp("Cancel", "Return to Favorites Manager", u.mustShowMain).
+		SetupNavigation(back)
+	frame := tui.NewPageFrame(u.app).
+		SetTitle("Favorites Manager", "Select Favorite").
+		SetContent(list).
+		SetHelpText(folder).
+		SetButtonBar(bar).
+		SetOnEscape(back)
+	bar.SetHelpCallback(func(text string) {
+		if text == "" {
+			frame.SetHelpText(folder)
+		} else {
+			frame.SetHelpText(text)
+		}
+	})
+	frame.SetupContentToButtonNavigation()
+	u.pages.AddAndSwitchToPage(pageBrowser, frame, true)
+	u.app.SetFocus(list)
+}
+
+func (u *ui) startAddFavorite(entry favorites.BrowseEntry) {
+	back := func() {
+		parent, err := u.manager.ParentFolder(entry.Path)
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		u.showBrowser(parent)
+	}
+	u.showFolderPicker(true, "", "Select destination folder", func(destination string) {
+		defaultName := u.manager.DefaultName(entry.System, entry.Path)
+		u.showNameInput(tui.InputOptions{
+			Title:        "Favorite Name",
+			Prompt:       "Enter a display name for the favorite.",
+			InitialValue: defaultName,
+			Validate:     favorites.ValidateDisplayName,
+		}, func(name string) {
+			var err error
+			if entry.System == nil {
+				_, err = u.manager.CreateCoreFavorite(entry.Path, destination, name)
+			} else {
+				_, err = u.manager.CreateGameFavorite(entry.System, entry.Path, destination, name)
+			}
+			if err != nil {
+				u.showError(err, func() { u.startAddFavorite(entry) })
+				return
+			}
+			u.mustShowMain()
+		}, back)
+	}, back)
+}
+
+func (u *ui) showFolderPicker(
+	includeRoot bool,
+	ignorePath, title string,
+	onSelect func(string),
+	onCancel func(),
+) {
+	folders, err := u.manager.DestinationFolders(includeRoot, ignorePath)
+	if err != nil {
+		u.showError(err, onCancel)
+		return
+	}
+	list := tui.NewMenuList()
+	for _, folder := range folders {
+		label := u.manager.RelativePath(folder)
+		kind := tui.MenuRowFolder
+		if label == "." {
+			label = "Top level"
+			kind = tui.MenuRowAction
+		} else {
+			label += "/"
+		}
+		list.AddRow(label, kind)
+	}
+	if len(folders) == 0 {
+		list.AddHeader("No Favorites folders found")
+	}
+	activate := func() {
+		if len(folders) > 0 {
+			onSelect(folders[list.GetCurrentItem()])
+		}
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+	bar := tui.NewButtonBar(u.app).
+		AddButtonWithHelp("Select", "Use selected destination", activate)
+	if includeRoot {
+		bar.AddButtonWithHelp("Create Folder", "Create a destination folder", func() {
+			u.createFolder(func() {
+				u.showFolderPicker(includeRoot, ignorePath, title, onSelect, onCancel)
+			})
+		})
+	}
+	bar.AddButtonWithHelp("Cancel", "Cancel folder selection", onCancel).
+		SetupNavigation(onCancel)
+	frame := tui.NewPageFrame(u.app).
+		SetTitle("Favorites Manager", title).
+		SetContent(list).
+		SetHelpText(title + ".").
+		SetButtonBar(bar).
+		SetOnEscape(onCancel)
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	u.pages.AddAndSwitchToPage(pageFolder, frame, true)
+	u.app.SetFocus(list)
+}
+
+func (u *ui) showModify(item *favorites.Favorite) {
+	name := strings.TrimSuffix(filepath.Base(item.Path), filepath.Ext(item.Path))
+	info := []string{
+		formatDetail("Name", name),
+		formatDetail("Folder", u.manager.RelativePath(filepath.Dir(item.Path))),
+		formatDetail("Type", string(item.Kind)),
+	}
+	if item.System != "" {
+		info = append(info, formatDetail("System", item.System))
+	}
+	if item.SetName != "" {
+		info = append(info, formatDetail("Set name", item.SetName))
+	}
+	if item.Target != "" {
+		info = append(info, formatDetail("File", item.Target))
+	}
+	details := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText(strings.Join(info, "\n")).
+		SetWordWrap(true)
+	list := tui.NewMenuList().
+		AddRow("Rename", tui.MenuRowAction).
+		AddRow("Move", tui.MenuRowAction).
+		AddRow("Delete", tui.MenuRowAction)
+	activate := func() {
+		switch list.GetCurrentItem() {
+		case 0:
+			u.renameItem(item, name)
+		case 1:
+			u.moveItem(item)
+		case 2:
+			u.deleteItem(item)
+		}
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+	bar := tui.NewButtonBar(u.app).
+		AddButtonWithHelp("Select", "Apply selected action", activate).
+		AddButtonWithHelp("Back", "Return to Favorites Manager", u.mustShowMain).
+		SetupNavigation(u.mustShowMain)
+	content := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(details, 7, 0, false).
+		AddItem(list, 0, 1, true)
+	frame := tui.NewPageFrame(u.app).
+		SetTitle("Favorites Manager", "Modify").
+		SetContent(content).
+		SetFocusTarget(list).
+		SetHelpText("Select an action.").
+		SetButtonBar(bar).
+		SetOnEscape(u.mustShowMain)
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	u.pages.AddAndSwitchToPage(pageModify, frame, true)
+	u.app.SetFocus(list)
+}
+
+func (u *ui) renameItem(item *favorites.Favorite, initial string) {
+	validator := favorites.ValidateDisplayName
+	if item.Kind == favorites.FavoriteFolder {
+		validator = favorites.ValidateFolderName
+		initial = filepath.Base(item.Path)
+	}
+	u.showNameInput(tui.InputOptions{
+		Title:        "Rename Favorite",
+		Prompt:       "Enter a new display name.",
+		InitialValue: initial,
+		Validate:     validator,
+	}, func(name string) {
+		if _, err := u.manager.Rename(item.Path, name); err != nil {
+			u.showError(err, func() { u.showModify(item) })
+			return
+		}
+		u.mustShowMain()
+	}, func() { u.showModify(item) })
+}
+
+func (u *ui) moveItem(item *favorites.Favorite) {
+	includeRoot := item.Kind != favorites.FavoriteFolder
+	u.showFolderPicker(includeRoot, item.Path, "Move Favorite", func(destination string) {
+		if _, err := u.manager.Move(item.Path, destination); err != nil {
+			u.showError(err, func() { u.showModify(item) })
+			return
+		}
+		u.mustShowMain()
+	}, func() { u.showModify(item) })
+}
+
+func (u *ui) deleteItem(item *favorites.Favorite) {
+	message := "Delete favorite " + u.manager.RelativePath(item.Path) + "?"
+	if item.Kind == favorites.FavoriteFolder {
+		message = "Delete folder " + u.manager.RelativePath(item.Path) + "?"
+	}
+	tui.ShowConfirmModal(u.pages, u.app, "Favorites Manager", message, func() {
+		if err := u.manager.Delete(item.Path); err != nil {
+			u.showError(err, func() { u.showModify(item) })
+			return
+		}
+		u.mustShowMain()
+	}, func() { u.showModify(item) })
+}
+
+func (u *ui) showNameInput(options tui.InputOptions, onSubmit func(string), onCancel func()) {
+	options.OnScreenKeyboard = u.options.OnScreenKeyboard
+	tui.ShowInputModal(u.pages, u.app, options, onSubmit, onCancel)
+}
+
+func (u *ui) showError(err error, restore func()) {
+	tui.ShowErrorModal(u.pages, u.app, err.Error(), restore)
+}
+
+func (u *ui) mustShowMain() {
+	if err := u.showMain(); err != nil {
+		u.showError(err, u.app.Stop)
+	}
+}
+
+func formatDetail(label, value string) string {
+	theme := tui.CurrentTheme()
+	return fmt.Sprintf("[%s::b]%s:[-::-] %s", theme.LabelName, label, tview.Escape(value))
+}
+
+func truncateLeading(value string, maximum int) string {
+	characters := []rune(value)
+	if len(characters) < maximum {
+		return value
+	}
+	return "..." + string(characters[len(characters)-(maximum-3):])
+}
+
+func samePath(first, second string) bool {
+	return filepath.Clean(first) == filepath.Clean(second)
+}

--- a/cmd/favorites/ui_test.go
+++ b/cmd/favorites/ui_test.go
@@ -1,0 +1,405 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in t.TempDir.
+package main
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/favorites"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+func sendUIKey(view *ui, key tcell.Key, value rune) {
+	view.app.GetFocus().InputHandler()(tcell.NewEventKey(key, value, tcell.ModNone), func(p tview.Primitive) {
+		view.app.SetFocus(p)
+	})
+}
+
+func newWorkflowUI(t *testing.T) *ui {
+	t.Helper()
+	cfg, manager, err := loadRuntime(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, createErr := manager.CreateDefaultFolder(); createErr != nil {
+		t.Fatal(createErr)
+	}
+	app, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(cfg, manager)
+	view.app = app
+	view.pages = tview.NewPages()
+	return view
+}
+
+func submitKeyboard(view *ui) {
+	sendUIKey(view, tcell.KeyEnter, 0)
+}
+
+func TestCreateDestinationDuringAddAndMove(t *testing.T) {
+	for _, move := range []bool{false, true} {
+		view := newWorkflowUI(t)
+		source := filepath.Join(view.manager.Root(), "Core.rbf")
+		if err := os.WriteFile(source, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if move {
+			favorite, err := view.manager.CreateCoreFavorite(source, view.manager.Root(), "Favorite")
+			if err != nil {
+				t.Fatal(err)
+			}
+			view.moveItem(&favorites.Favorite{Path: favorite, Kind: favorites.FavoriteCore})
+		} else {
+			view.startAddFavorite(favorites.BrowseEntry{Path: source})
+		}
+		// Create Folder, then cancel its parent picker and resume pending operation.
+		sendUIKey(view, tcell.KeyRight, 0)
+		sendUIKey(view, tcell.KeyEnter, 0)
+		sendUIKey(view, tcell.KeyEscape, 0)
+		sendUIKey(view, tcell.KeyRight, 0)
+		sendUIKey(view, tcell.KeyEnter, 0)
+		sendUIKey(view, tcell.KeyEnter, 0)
+		for _, char := range "Nested" {
+			sendUIKey(view, tcell.KeyRune, char)
+		}
+		submitKeyboard(view)
+		sendUIKey(view, tcell.KeyEnd, 0)
+		sendUIKey(view, tcell.KeyEnter, 0)
+		name := "Favorite.rbf"
+		if !move {
+			submitKeyboard(view)
+			name = "Core.rbf"
+		}
+		path := filepath.Join(view.manager.Root(), "_@Favorites", "_Nested", name)
+		if _, err := os.Lstat(path); err != nil {
+			t.Fatalf("move=%v pending operation not retained: %v", move, err)
+		}
+	}
+}
+
+func TestCancelAddInsideArchiveReturnsToBrowser(t *testing.T) {
+	view := newWorkflowUI(t)
+	archive := filepath.Join(view.manager.Root(), "games.zip")
+	file, err := os.Create(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	if _, createErr := writer.Create("game.sfc"); createErr != nil {
+		t.Fatal(createErr)
+	}
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	for _, cancelName := range []bool{false, true} {
+		view.startAddFavorite(favorites.BrowseEntry{Path: archive + "/game.sfc"})
+		if cancelName {
+			sendUIKey(view, tcell.KeyEnter, 0)
+		}
+		sendUIKey(view, tcell.KeyEscape, 0)
+		page, _ := view.pages.GetFrontPage()
+		if page != pageBrowser || view.pages.HasPage("tui_error_modal") {
+			t.Fatalf("cancelName=%v returned to %s", cancelName, page)
+		}
+	}
+}
+
+func TestEverySettingHasContextualHelp(t *testing.T) {
+	view := newWorkflowUI(t)
+	page := &settingsPage{
+		staged: favorites.SettingsFromConfig(view.cfg), original: favorites.SettingsFromConfig(view.cfg), ui: view,
+	}
+	page.show(0)
+	for index := range page.actions {
+		help := page.help[index]
+		if help == "" || len(help) > 73 {
+			t.Fatalf("missing or overflowing help for row %d: %#v", index, help)
+		}
+	}
+	_, primitive := view.pages.GetFrontPage()
+	frame, ok := primitive.(*tui.PageFrame)
+	if !ok {
+		t.Fatal("settings frame missing")
+	}
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	frame.SetRect(0, 0, 75, 15)
+	sendUIKey(view, tcell.KeyDown, 0)
+	frame.Draw(screen)
+	var helpText strings.Builder
+	for x := range 75 {
+		value, _, _ := screen.Get(x, 12)
+		_, _ = helpText.WriteString(value)
+	}
+	if !strings.Contains(helpText.String(), page.help[2]) {
+		t.Fatalf("help did not follow selection: %q", helpText.String())
+	}
+	var buttons strings.Builder
+	for x := range 75 {
+		value, _, _ := screen.Get(x, 13)
+		_, _ = buttons.WriteString(value)
+	}
+	if strings.Contains(buttons.String(), "Help") {
+		t.Fatal("settings should have footer help, not a Help button")
+	}
+}
+
+func TestListSettingsEditOneValueAtATime(t *testing.T) {
+	for _, cancel := range []bool{false, true} {
+		view := newWorkflowUI(t)
+		page := &settingsPage{
+			staged: favorites.SettingsFromConfig(view.cfg), original: favorites.SettingsFromConfig(view.cfg), ui: view,
+		}
+		page.show(0)
+		page.actions[2]()
+		sendUIKey(view, tcell.KeyRight, 0)
+		sendUIKey(view, tcell.KeyEnter, 0)
+		for _, char := range "collection" {
+			sendUIKey(view, tcell.KeyRune, char)
+		}
+		submitKeyboard(view)
+		if cancel {
+			sendUIKey(view, tcell.KeyEscape, 0)
+		} else {
+			for range 3 {
+				sendUIKey(view, tcell.KeyRight, 0)
+			}
+			sendUIKey(view, tcell.KeyEnter, 0)
+		}
+		expected := []string{"fav"}
+		if !cancel {
+			expected = append(expected, "collection")
+		}
+		if !slices.Equal(page.staged.FolderNameContains, expected) {
+			t.Fatalf("cancel=%v staged list=%v", cancel, page.staged.FolderNameContains)
+		}
+		if !slices.Equal(view.cfg.Favorites.FolderNameContains, []string{"fav"}) {
+			t.Fatal("list editor bypassed staged settings")
+		}
+	}
+}
+
+func TestLocalRootRuntime(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "fixture")
+	options, err := parseCLI([]string{"--root", root, "refresh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if options.root != root || options.command != "refresh" {
+		t.Fatalf("options = %#v", options)
+	}
+	cfg, manager, err := loadRuntime(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manager.Root() != absoluteRoot {
+		t.Fatalf("manager root = %q", manager.Root())
+	}
+	if cfg.IniPath != filepath.Join(absoluteRoot, "Scripts", "favorites.ini") {
+		t.Fatalf("config path = %q", cfg.IniPath)
+	}
+	if cfg.AppPath != filepath.Join(absoluteRoot, "Scripts", "favorites.sh") {
+		t.Fatalf("app path = %q", cfg.AppPath)
+	}
+	if err := run([]string{"--root", root, "refresh"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(cfg.IniPath); !os.IsNotExist(err) {
+		t.Fatalf("refresh unexpectedly created configuration: %v", err)
+	}
+}
+
+func TestMainLabelTruncationPreservesFilename(t *testing.T) {
+	value := "_@Favorites/_Role Playing Games/_Translated/Very Long Favorite Name"
+	got := truncateLeading(value, 30)
+	if got != "...ted/Very Long Favorite Name" {
+		t.Fatalf("truncated label = %q", got)
+	}
+	if got := truncateLeading("short", 30); got != "short" {
+		t.Fatalf("short label = %q", got)
+	}
+}
+
+func TestInvalidCLICommand(t *testing.T) {
+	if _, err := parseCLI([]string{"invalid"}); err == nil {
+		t.Fatal("invalid command accepted")
+	}
+}
+
+func TestSettingsPageStagesAndSavesChanges(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "fat")
+	for _, folder := range []string{
+		filepath.Join(root, "Scripts"),
+		filepath.Join(root, "_Arcade", "cores"),
+	} {
+		if err := os.MkdirAll(folder, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := favorites.DefaultUserConfig()
+	cfg.AppPath = filepath.Join(root, "Scripts", "favorites.sh")
+	cfg.IniPath = filepath.Join(root, "Scripts", "favorites.ini")
+	cfg.Systems.GamesFolder = []string{root}
+	if err := os.WriteFile(cfg.IniPath, []byte(favorites.DefaultConfigFile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := favorites.NewManagerWithPaths(cfg, favorites.RuntimePaths{
+		SDRoot:            root,
+		StartupScript:     filepath.Join(root, "linux", "user-startup.sh"),
+		ArcadeCoresFolder: filepath.Join(root, "_Arcade", "cores"),
+	})
+	application, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(cfg, manager)
+	view.app = application
+	view.pages = tview.NewPages()
+	page := &settingsPage{
+		staged:   favorites.SettingsFromConfig(cfg),
+		original: favorites.SettingsFromConfig(cfg),
+		ui:       view,
+	}
+	page.show(0)
+	if !view.pages.HasPage(pageSettings) || page.list.GetItemCount() != 16 {
+		t.Fatalf("settings page rows = %d", page.list.GetItemCount())
+	}
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if initErr := screen.Init(); initErr != nil {
+		t.Fatal(initErr)
+	}
+	screen.SetSize(75, 15)
+	view.pages.SetRect(0, 0, 75, 15)
+	view.pages.Draw(screen)
+	screen.Fini()
+	page.actions[5]()
+	page.actions[10]()
+	sendUIKey(view, tcell.KeyEnd, 0)
+	sendUIKey(view, tcell.KeyEnter, 0)
+	page.actions[12]()
+	sendUIKey(view, tcell.KeyDown, 0)
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if page.staged.HideRootFiles || page.staged.AlternateCore != "yc" || page.staged.Theme != "high_contrast" {
+		t.Fatalf("staged settings = %#v", page.staged)
+	}
+	page.save()
+	if cfg.Favorites.HideRootFiles || cfg.FavoritesCores.All != "yc" || cfg.TUI.Theme != "high_contrast" {
+		t.Fatalf("applied settings = %#v", favorites.SettingsFromConfig(cfg))
+	}
+	loaded, err := favorites.LoadConfigAt(cfg.IniPath, cfg.AppPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Favorites.HideRootFiles || loaded.FavoritesCores.All != "yc" || loaded.TUI.Theme != "high_contrast" {
+		t.Fatalf("saved settings = %#v", favorites.SettingsFromConfig(loaded))
+	}
+}
+
+func TestSettingsBackConfirmsDiscard(t *testing.T) {
+	cfg := favorites.DefaultUserConfig()
+	application, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(cfg, favorites.NewManager(cfg))
+	view.app = application
+	view.pages = tview.NewPages()
+	page := &settingsPage{
+		staged:   favorites.SettingsFromConfig(cfg),
+		original: favorites.SettingsFromConfig(cfg),
+		ui:       view,
+	}
+	page.show(0)
+	page.staged.Mouse = !page.staged.Mouse
+	page.back()
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("discard confirmation was not shown")
+	}
+}
+
+func TestMainAndBrowserPagesBuildWithoutDialogProcess(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "fat")
+	for _, folder := range []string{
+		root,
+		filepath.Join(root, "games", "SNES"),
+		filepath.Join(root, "_@Favorites"),
+		filepath.Join(root, "_Arcade", "cores"),
+	} {
+		if err := os.MkdirAll(folder, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "games", "SNES", "EarthBound.sfc"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := favorites.DefaultUserConfig()
+	cfg.Systems.GamesFolder = []string{root}
+	manager := favorites.NewManagerWithPaths(cfg, favorites.RuntimePaths{
+		SDRoot:            root,
+		StartupScript:     filepath.Join(root, "linux", "user-startup.sh"),
+		ArcadeCoresFolder: filepath.Join(root, "_Arcade", "cores"),
+	})
+	application, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(cfg, manager)
+	view.app = application
+	view.pages = tview.NewPages()
+	if err := view.showMain(); err != nil {
+		t.Fatal(err)
+	}
+	if !view.pages.HasPage(pageMain) {
+		t.Fatal("main page was not created")
+	}
+	view.showBrowser(root)
+	if !view.pages.HasPage(pageBrowser) {
+		t.Fatal("browser page was not created")
+	}
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(100, 30)
+	view.pages.SetRect(0, 0, 100, 30)
+	view.pages.Draw(screen)
+}

--- a/cmd/remote/gui.go
+++ b/cmd/remote/gui.go
@@ -161,7 +161,7 @@ func displayServiceInfo(svc *service.Service, cfg *config.UserConfig) (int, erro
 				)
 			}
 			status.SetText(message)
-			footer.SetText(tui.ButtonBar([]string{toggle, "Restart", "Uninstall", "Exit"}, selected))
+			footer.SetText(tui.ButtonLabels([]string{toggle, "Restart", "Uninstall", "Exit"}, selected))
 		}
 		draw()
 

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -1,0 +1,149 @@
+# Favorites
+
+Favorites creates and manages game and core shortcuts in MiSTer's stock menu. It runs as a standalone Go application and does not require Zaparoo Core.
+
+Zaparoo Frontend also provides favorites for indexed media, but it does not create or repair stock-menu `.mgl` shortcuts. See [MIGRATE.md](../MIGRATE.md) before choosing between them.
+
+## Installation
+
+Install Favorites through the combined mrext Downloader database documented in the [README](../README.md). Downloader installs the ARMv7 binary as:
+
+```text
+/media/fat/Scripts/favorites.sh
+```
+
+The `.sh` filename is retained for compatibility with existing Downloader entries, startup hooks, and MiSTer Scripts-menu behavior. It is a native executable, not a shell script.
+
+Run `favorites` from MiSTer's Scripts menu.
+
+## Features
+
+- Add game, core, arcade-core, and existing MGL shortcuts.
+- Browse SD, USB, CIFS, symlinked game folders, and supported files inside ZIP archives.
+- Generate MGL files from Zaparoo's maintained MiSTer launcher catalog.
+- Preserve NeoGeo ZIP naming from `romsets.xml` and relative NeoGeo launcher paths.
+- Create, rename, move, and remove Favorites folders and entries.
+- Refresh broken dated core symlinks after core updates.
+- Maintain arcade `cores` links needed by MRA favorites.
+- Operate with a controller through an on-screen keyboard.
+
+## Compatibility notes
+
+The Go version preserves Python Favorites' folder discovery, top-level destinations, nested folder management, startup refresh hook, LLAPI/YC selection, root filtering, external-drive shortcut, ZIP traversal, NeoGeo names and relative paths, dated-core repair, and safe link-based core favorites. Symlinked game directories remain browsable.
+
+Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog.
+
+## Settings screen
+
+Choose `Settings` from the main screen's bottom action bar. Up and Down select a setting; Left and Right select `Change`, `Save`, or `Cancel`. The footer shows one sentence explaining the selected setting. `Change` toggles boolean values, opens an alternate-core or theme picker, or opens the appropriate editor. Pickers highlight the current value and do not change it when canceled.
+
+Changes remain staged until `Save` is selected. `Cancel` leaves the file untouched, and Back or Escape asks before discarding unsaved changes. Saving atomically updates managed Favorites, core, and TUI keys while retaining unknown INI sections and comments. Notes attached to repeated or removed keys may move to section or file comments. Theme, mouse, layout, and other runtime settings apply after saving.
+
+`Folder name matches` and `Additional game folders` are marked as lists. Their editor shows one entry per row with `Add`, `Edit`, and `Remove` controls. `Done` keeps edits in staged settings; `Cancel` discards the list edits. Enter one name fragment or full folder path at a time, without comma separators. Additional game folders are still saved as repeated `games_folder` keys for compatibility with manual configuration.
+
+`USB shortcut folder` is the filesystem target of the browser's USB shortcut, normally `/media/usb0`. If that target contains a `games` folder, the shortcut opens it instead. This setting does not mount storage or change the destination of saved favorites; the INI key remains `external_folder`.
+
+The on-screen keyboard uses Zaparoo's compact 41×8 layout, with no separate prompt floating above it. Setting explanations stay in the settings page footer.
+
+## Configuration
+
+Favorites reads `favorites.ini` beside the executable:
+
+```text
+/media/fat/Scripts/favorites.ini
+```
+
+First interactive launch creates this file when missing. Existing files are never replaced. Downloader does not install or overwrite it.
+
+```ini
+[favorites]
+default_folder = _@Favorites
+folder_name_contains = fav
+create_default_folder = true
+manage_arcade_core_links = true
+hide_root_files = true
+external_folder = /media/usb0
+core_prefix =
+; games_folder = /media/network
+
+[cores]
+all =
+
+[tui]
+theme = default
+mouse = true
+crt_mode = true
+on_screen_keyboard = true
+```
+
+### Favorites settings
+
+- `default_folder`: folder created when no matching Favorites folder exists. Must start with `_` and is always recognized as a Favorites root, regardless of `folder_name_contains`.
+- `folder_name_contains`: comma-separated, case-insensitive fragments used to recognize top-level Favorites folders. Folder names must also start with `_`.
+- `create_default_folder`: create `default_folder` when needed.
+- `manage_arcade_core_links`: create required `cores` symlinks without replacing existing files or links.
+- `hide_root_files`: show only standard MiSTer menu/game folders at SD-card root while browsing.
+- `external_folder`: target of root-browser USB shortcut. Its `games` child is preferred when present.
+- `core_prefix`: optional prefix applied to standard catalog RBF paths.
+- `games_folder`: optional additional game root. Repeat key for multiple roots. Built-in MiSTer roots remain enabled.
+
+### Alternate cores
+
+`cores.all` preserves existing Favorites configuration:
+
+- blank: standard cores
+- `llapi`: use matching LLAPI variants when installed
+- `yc`: use matching YC variants when installed
+
+Favorites falls back to standard catalog core when requested variant is unavailable.
+
+### TUI settings
+
+Available themes:
+
+- `default`
+- `high_contrast`
+- `dracula`
+- `nord`
+- `gruvbox`
+- `monogreen`
+
+`crt_mode` uses MiSTer's 75×15 layout. `on_screen_keyboard` enables controller-friendly text input. `mouse` enables pointer input where available.
+
+List screens preserve Favorites' original controller model: Up and Down always change rows, Left and Right always change the selected bottom button, and Enter activates that button. Rows and button selection remain visibly active together; no focus-switching step is required.
+
+When adding or moving a favorite file, the destination picker also offers `Create Folder`. Creating or canceling a folder returns to the pending destination selection without losing the selected favorite.
+
+The main screen retains Add Favorite as first row so existing controller flow stays unchanged, but presents it as a styled `+ Add favorite` action followed by an `Existing favorites` section instead of the legacy `<ADD NEW FAVORITE>` placeholder. Folder and navigation rows use text markers that remain understandable without color.
+
+Default styling uses MiSTer-safe named terminal colors: dark blue and blue backgrounds, white primary text, gray secondary text, yellow borders/actions/selections, and red errors. Bold labels and textual markers carry the same meaning when a display reduces the palette. Alternate themes remain optional and never provide the only indication of state.
+
+## Local development
+
+Run Favorites against a temporary MiSTer root without creating `/media/fat`:
+
+```bash
+go run ./cmd/favorites --root /tmp/favorites-mister
+```
+
+Favorites creates the root and `Scripts` directory when missing. Add fixture games under paths such as `/tmp/favorites-mister/games/SNES`. Local configuration is stored at `/tmp/favorites-mister/Scripts/favorites.ini`; all menu changes stay inside the selected root.
+
+The non-interactive refresh command also accepts this mode:
+
+```bash
+go run ./cmd/favorites --root /tmp/favorites-mister refresh
+```
+
+## Refresh command
+
+Favorites preserves non-interactive startup behavior:
+
+```bash
+/media/fat/Scripts/favorites.sh refresh
+```
+
+This removes broken unversioned core shortcuts and relinks broken dated shortcuts when an updated matching core exists. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
+
+## Safety
+
+Favorites never recursively deletes a folder containing user files. Folder deletion succeeds only when folder is empty or contains only managed `cores` symlink. Existing configuration files, non-symlink `cores` entries, and unrelated menu content are left untouched.

--- a/magefile.go
+++ b/magefile.go
@@ -82,6 +82,13 @@ var apps = []app{
 		inAll:     true,
 	},
 	{
+		name:      "favorites",
+		path:      filepath.Join(cwd, "cmd", "favorites"),
+		bin:       "favorites.sh",
+		releaseId: "mrext/favorites",
+		inAll:     true,
+	},
+	{
 		name:      "launchsync",
 		path:      filepath.Join(cwd, "cmd", "launchsync"),
 		bin:       "launchsync.sh",
@@ -108,11 +115,6 @@ var scriptApps = []scriptApp{
 		name: "bgm",
 		path: filepath.Join(cwd, "scripts", "bgm.sh"),
 		bin:  "bgm.sh",
-	},
-	{
-		name: "favorites",
-		path: filepath.Join(cwd, "scripts", "favorites.sh"),
-		bin:  "favorites.sh",
 	},
 	{
 		name: "gamesmenu",

--- a/pkg/config/user.go
+++ b/pkg/config/user.go
@@ -59,21 +59,75 @@ type RemoteConfig struct {
 	SyncSSHKeys     bool   `ini:"sync_ssh_keys,omitempty"`
 }
 
+type FavoritesConfig struct {
+	DefaultFolder         string   `ini:"default_folder,omitempty"`
+	ExternalFolder        string   `ini:"external_folder,omitempty"`
+	CorePrefix            string   `ini:"core_prefix,omitempty"`
+	FolderNameContains    []string `ini:"folder_name_contains,omitempty" delim:","`
+	GamesFolder           []string `ini:"games_folder,omitempty,allowshadow"`
+	CreateDefaultFolder   bool     `ini:"create_default_folder,omitempty"`
+	ManageArcadeCoreLinks bool     `ini:"manage_arcade_core_links,omitempty"`
+	HideRootFiles         bool     `ini:"hide_root_files,omitempty"`
+}
+
+type FavoritesCoresConfig struct {
+	All string `ini:"all,omitempty"`
+}
+
+type TUIConfig struct {
+	Theme            string `ini:"theme,omitempty"`
+	Mouse            bool   `ini:"mouse,omitempty"`
+	CRTMode          bool   `ini:"crt_mode,omitempty"`
+	OnScreenKeyboard bool   `ini:"on_screen_keyboard,omitempty"`
+}
+
 type SystemsConfig struct {
 	GamesFolder []string `ini:"games_folder,omitempty,allowshadow"`
 	SetCore     []string `ini:"set_core,omitempty,allowshadow"`
 }
 
+//nolint:govet // Field order keeps application sections grouped for configuration mapping.
 type UserConfig struct {
-	AppPath    string
-	IniPath    string
-	LaunchSync LaunchSyncConfig `ini:"launchsync,omitempty"`
-	PlayLog    PlayLogConfig    `ini:"playlog,omitempty"`
-	Random     RandomConfig     `ini:"random,omitempty"`
-	Search     SearchConfig     `ini:"search,omitempty"`
-	LastPlayed LastPlayedConfig `ini:"lastplayed,omitempty"`
-	Remote     RemoteConfig     `ini:"remote,omitempty"`
-	Systems    SystemsConfig    `ini:"systems,omitempty"`
+	AppPath        string
+	IniPath        string
+	LaunchSync     LaunchSyncConfig     `ini:"launchsync,omitempty"`
+	PlayLog        PlayLogConfig        `ini:"playlog,omitempty"`
+	Random         RandomConfig         `ini:"random,omitempty"`
+	Search         SearchConfig         `ini:"search,omitempty"`
+	LastPlayed     LastPlayedConfig     `ini:"lastplayed,omitempty"`
+	Remote         RemoteConfig         `ini:"remote,omitempty"`
+	Favorites      FavoritesConfig      `ini:"favorites,omitempty"`
+	FavoritesCores FavoritesCoresConfig `ini:"cores,omitempty"`
+	TUI            TUIConfig            `ini:"tui,omitempty"`
+	Systems        SystemsConfig        `ini:"systems,omitempty"`
+}
+
+func EnsureUserConfig(path, content string) error {
+	// #nosec G302 -- MiSTer configuration must remain editable through shared storage.
+	file, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return fmt.Errorf("create user configuration: %w", err)
+	}
+
+	removeIncomplete := true
+	defer func() {
+		_ = file.Close()
+		if removeIncomplete {
+			_ = os.Remove(path)
+		}
+	}()
+
+	if _, err := file.WriteString(content); err != nil {
+		return fmt.Errorf("write user configuration: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close user configuration: %w", err)
+	}
+	removeIncomplete = false
+	return nil
 }
 
 func LoadUserConfig(name string, defaultConfig *UserConfig) (*UserConfig, error) {
@@ -92,11 +146,14 @@ func LoadUserConfig(name string, defaultConfig *UserConfig) (*UserConfig, error)
 	if iniPath == "" {
 		iniPath = filepath.Join(filepath.Dir(exePath), name+".ini")
 	}
+	return LoadUserConfigAt(iniPath, exePath, defaultConfig)
+}
 
-	defaultConfig.AppPath = exePath
+func LoadUserConfigAt(iniPath, appPath string, defaultConfig *UserConfig) (*UserConfig, error) {
+	defaultConfig.AppPath = appPath
 	defaultConfig.IniPath = iniPath
 
-	// #nosec G703 -- configuration path is explicitly selected by caller or environment.
+	// #nosec G703 -- configuration path is explicitly selected by caller.
 	if _, statErr := os.Stat(iniPath); statErr != nil {
 		if os.IsNotExist(statErr) {
 			return defaultConfig, nil

--- a/pkg/favorites/browser.go
+++ b/pkg/favorites/browser.go
@@ -1,0 +1,253 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+var allowedRootEntries = map[string]struct{}{
+	"_arcade": {}, "_console": {}, "_computer": {}, "_dos games": {},
+	"_games": {}, "_other": {}, "_utility": {}, "_llapi": {},
+	"_ycarcade": {}, "cifs": {}, "games": {},
+}
+
+type BrowseEntry struct {
+	System      *games.System
+	Path        string
+	Name        string
+	Label       string
+	IsDirectory bool
+	IsArchive   bool
+}
+
+func (m *Manager) ExternalFolder() string {
+	folder := filepath.Clean(m.cfg.Favorites.ExternalFolder)
+	gamesFolder := filepath.Join(folder, "games")
+	if info, err := os.Stat(gamesFolder); err == nil && info.IsDir() {
+		return gamesFolder
+	}
+	return folder
+}
+
+func (m *Manager) ListDirectory(folder string) ([]BrowseEntry, error) {
+	archivePath, archiveFolder, inArchive := SplitArchivePath(folder)
+	if inArchive {
+		return m.listArchive(archivePath, archiveFolder)
+	}
+	entries, err := os.ReadDir(folder)
+	if err != nil {
+		return nil, fmt.Errorf("read browser folder: %w", err)
+	}
+	results := make([]BrowseEntry, 0, len(entries))
+	for _, entry := range entries {
+		if m.cfg.Favorites.HideRootFiles && filepath.Clean(folder) == filepath.Clean(m.paths.SDRoot) {
+			if _, allowed := allowedRootEntries[strings.ToLower(entry.Name())]; !allowed {
+				continue
+			}
+		}
+		path := filepath.Join(folder, entry.Name())
+		if entry.IsDir() || isDirectorySymlink(path, entry) {
+			results = append(results, BrowseEntry{
+				Path: path, Name: entry.Name(), Label: entry.Name() + "/", IsDirectory: true,
+			})
+			continue
+		}
+
+		extension := strings.ToLower(filepath.Ext(entry.Name()))
+		if extension == ".zip" {
+			if system := m.matchMediaSystem(path); system != nil && system.Id == "NeoGeo" {
+				results = append(results, BrowseEntry{
+					System: system, Path: path, Name: entry.Name(),
+					Label: m.browserLabel(system, path), IsArchive: true,
+				})
+			} else if isZip(path) {
+				results = append(results, BrowseEntry{
+					Path: path, Name: entry.Name(), Label: entry.Name() + "/", IsDirectory: true, IsArchive: true,
+				})
+			}
+			continue
+		}
+
+		if extension == ".rbf" || extension == ".mra" || extension == ".mgl" {
+			results = append(results, BrowseEntry{Path: path, Name: entry.Name(), Label: entry.Name()})
+			continue
+		}
+		if system := m.matchMediaSystem(path); system != nil {
+			results = append(results, BrowseEntry{
+				System: system, Path: path, Name: entry.Name(), Label: m.browserLabel(system, path),
+			})
+		}
+	}
+	sortBrowseEntries(results)
+	return results, nil
+}
+
+func isDirectorySymlink(path string, entry os.DirEntry) bool {
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func sortBrowseEntries(entries []BrowseEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].IsDirectory != entries[j].IsDirectory {
+			return entries[i].IsDirectory
+		}
+		return strings.ToLower(entries[i].Label) < strings.ToLower(entries[j].Label)
+	})
+}
+
+func SplitArchivePath(path string) (archivePath, innerPath string, ok bool) {
+	lowerPath := strings.ToLower(filepath.ToSlash(path))
+	index := strings.Index(lowerPath, ".zip/")
+	if index < 0 {
+		return "", "", false
+	}
+	archiveEnd := index + len(".zip")
+	normalized := filepath.ToSlash(path)
+	return filepath.FromSlash(normalized[:archiveEnd]), strings.Trim(normalized[archiveEnd+1:], "/"), true
+}
+
+func isZip(path string) bool {
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		return false
+	}
+	_ = reader.Close()
+	return true
+}
+
+func (m *Manager) listArchive(archivePath, folder string) ([]BrowseEntry, error) {
+	cacheKey := filepath.Join(archivePath, filepath.FromSlash(folder))
+	if entries, found := m.archiveEntriesCache[cacheKey]; found {
+		return append([]BrowseEntry(nil), entries...), nil
+	}
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("open ZIP archive: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	prefix := strings.Trim(folder, "/")
+	if prefix != "" {
+		prefix += "/"
+	}
+	seen := make(map[string]struct{})
+	results := make([]BrowseEntry, 0)
+	for _, file := range reader.File {
+		name := strings.TrimPrefix(file.Name, "/")
+		if !strings.HasPrefix(name, prefix) || name == prefix {
+			continue
+		}
+		remainder := strings.TrimPrefix(name, prefix)
+		parts := strings.SplitN(remainder, "/", 2)
+		child := parts[0]
+		if child == "" {
+			continue
+		}
+		if _, found := seen[child]; found {
+			continue
+		}
+		seen[child] = struct{}{}
+		virtualPath := filepath.Join(archivePath, filepath.FromSlash(prefix), child)
+		if len(parts) == 2 || file.FileInfo().IsDir() {
+			results = append(results, BrowseEntry{
+				Path: virtualPath, Name: child, Label: child + "/", IsDirectory: true, IsArchive: true,
+			})
+			continue
+		}
+		system := m.matchMediaSystem(virtualPath)
+		if system == nil {
+			continue
+		}
+		results = append(results, BrowseEntry{
+			System: system, Path: virtualPath, Name: child, Label: m.browserLabel(system, virtualPath),
+			IsArchive: strings.EqualFold(filepath.Ext(child), ".zip"),
+		})
+	}
+	sortBrowseEntries(results)
+	m.archiveEntriesCache[cacheKey] = append([]BrowseEntry(nil), results...)
+	return results, nil
+}
+
+func (m *Manager) ParentFolder(path string) (string, error) {
+	archivePath, innerPath, inArchive := SplitArchivePath(path)
+	if !inArchive {
+		parent := filepath.Dir(path)
+		if filepath.Clean(path) == filepath.Clean(filepath.Dir(m.paths.SDRoot)) {
+			return path, errors.New("already at browser root")
+		}
+		return parent, nil
+	}
+	if innerPath == "" {
+		return filepath.Dir(archivePath), nil
+	}
+	parent := filepath.Dir(innerPath)
+	if parent == "." {
+		return archivePath + string(filepath.Separator), nil
+	}
+	return filepath.Join(archivePath, parent), nil
+}
+
+func (m *Manager) matchMediaSystem(path string) *games.System {
+	systems := games.FolderToSystems(m.cfg, path)
+	matches := make([]games.System, 0, len(systems))
+	for index := range systems {
+		if games.MatchSystemFile(&systems[index], path) {
+			matches = append(matches, systems[index])
+		}
+	}
+	for index := range matches {
+		if matches[index].SetName != "" {
+			return &matches[index]
+		}
+	}
+	if len(matches) > 0 {
+		return &matches[0]
+	}
+	if strings.EqualFold(filepath.Ext(path), ".zip") {
+		for index := range systems {
+			if systems[index].Id == "NeoGeo" {
+				return &systems[index]
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manager) browserLabel(system *games.System, path string) string {
+	if system != nil && system.Id == "NeoGeo" && strings.EqualFold(filepath.Ext(path), ".zip") {
+		if title := m.NeoGeoTitle(path); title != "" {
+			return title
+		}
+	}
+	return filepath.Base(path)
+}

--- a/pkg/favorites/config.go
+++ b/pkg/favorites/config.go
@@ -1,0 +1,123 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+const DefaultConfigFile = `[favorites]
+default_folder = _@Favorites
+folder_name_contains = fav
+create_default_folder = true
+manage_arcade_core_links = true
+hide_root_files = true
+external_folder = /media/usb0
+core_prefix =
+; Add custom game roots by repeating this key. Built-in MiSTer roots remain enabled.
+; games_folder = /media/network
+
+[cores]
+; Supported values: llapi, yc, or blank for standard cores.
+all =
+
+[tui]
+theme = default
+mouse = true
+crt_mode = true
+on_screen_keyboard = true
+`
+
+func DefaultUserConfig() *config.UserConfig {
+	return &config.UserConfig{
+		Favorites: config.FavoritesConfig{
+			DefaultFolder:         "_@Favorites",
+			ExternalFolder:        "/media/usb0",
+			FolderNameContains:    []string{"fav"},
+			CreateDefaultFolder:   true,
+			ManageArcadeCoreLinks: true,
+			HideRootFiles:         true,
+		},
+		TUI: config.TUIConfig{
+			Theme:            "default",
+			Mouse:            true,
+			CRTMode:          true,
+			OnScreenKeyboard: true,
+		},
+	}
+}
+
+func LoadConfig() (*config.UserConfig, error) {
+	cfg, err := config.LoadUserConfig("favorites", DefaultUserConfig())
+	return validateLoadedConfig(cfg, err)
+}
+
+func LoadConfigAt(iniPath, appPath string) (*config.UserConfig, error) {
+	cfg, err := config.LoadUserConfigAt(iniPath, appPath, DefaultUserConfig())
+	return validateLoadedConfig(cfg, err)
+}
+
+func validateLoadedConfig(cfg *config.UserConfig, err error) (*config.UserConfig, error) {
+	if err != nil {
+		return nil, fmt.Errorf("load user configuration: %w", err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	cfg.Systems.GamesFolder = append(cfg.Systems.GamesFolder, cfg.Favorites.GamesFolder...)
+	return cfg, nil
+}
+
+func EnsureConfigFile(cfg *config.UserConfig) error {
+	if cfg == nil {
+		return errors.New("no Favorites configuration supplied")
+	}
+	if err := config.EnsureUserConfig(cfg.IniPath, DefaultConfigFile); err != nil {
+		return fmt.Errorf("ensure Favorites configuration: %w", err)
+	}
+	return nil
+}
+
+func ValidateConfig(cfg *config.UserConfig) error {
+	if cfg == nil {
+		return errors.New("no Favorites configuration supplied")
+	}
+	if !strings.HasPrefix(cfg.Favorites.DefaultFolder, "_") {
+		return errors.New("favorites.default_folder must start with an underscore")
+	}
+	if len(cfg.Favorites.FolderNameContains) == 0 {
+		return errors.New("favorites.folder_name_contains must not be empty")
+	}
+	for _, fragment := range cfg.Favorites.FolderNameContains {
+		if strings.TrimSpace(fragment) == "" {
+			return errors.New("favorites.folder_name_contains contains an empty value")
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.FavoritesCores.All)) {
+	case "", "llapi", "yc":
+	default:
+		return fmt.Errorf("unsupported cores.all value: %s", cfg.FavoritesCores.All)
+	}
+	return nil
+}

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -1,0 +1,933 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in t.TempDir.
+package favorites
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+func newTestManager(t *testing.T) (*Manager, *config.UserConfig, string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "fat")
+	for _, folder := range []string{
+		root,
+		filepath.Join(root, "games"),
+		filepath.Join(root, "_Arcade", "cores"),
+		filepath.Join(root, "linux"),
+	} {
+		if err := os.MkdirAll(folder, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := DefaultUserConfig()
+	cfg.Systems.GamesFolder = []string{root}
+	cfg.Favorites.ExternalFolder = filepath.Join(filepath.Dir(root), "usb0")
+	paths := RuntimePaths{
+		SDRoot:            root,
+		StartupScript:     filepath.Join(root, "linux", "user-startup.sh"),
+		ArcadeCoresFolder: filepath.Join(root, "_Arcade", "cores"),
+	}
+	return NewManagerWithPaths(cfg, paths), cfg, root
+}
+
+func TestCleanupKeepsUserFolderAfterSettingsChange(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	userFolder := filepath.Join(root, "_Archive")
+	if err := os.Mkdir(userFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	created, err := manager.CreateDefaultFolder()
+	if err != nil || !created {
+		t.Fatalf("create default: %v, %v", created, err)
+	}
+	cfg.Favorites.DefaultFolder = "_Archive"
+	if cleanupErr := manager.CleanupCreatedDefault(created); cleanupErr != nil {
+		t.Fatal(cleanupErr)
+	}
+	if _, statErr := os.Stat(userFolder); statErr != nil {
+		t.Fatalf("user folder removed: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "_@Favorites")); !os.IsNotExist(statErr) {
+		t.Fatalf("original default not cleaned: %v", statErr)
+	}
+}
+
+func TestSymlinkedFavoriteRootWorkflows(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	target := t.TempDir()
+	nested := filepath.Join(target, "_Nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "_LinkedFavorites")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(nested, "_Cycle")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "game.mgl"), []byte("<mistergamedescription/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items, err := manager.List()
+	if err != nil || len(items) != 1 || items[0].Path != filepath.Join(link, "_Nested", "game.mgl") {
+		t.Fatalf("favorites: %#v, %v", items, err)
+	}
+	folders, err := manager.DestinationFolders(false, "")
+	if err != nil || !slices.Equal(folders, []string{link, filepath.Join(link, "_Nested")}) {
+		t.Fatalf("destinations: %v, %v", folders, err)
+	}
+	editable, err := manager.EditableItems()
+	if err != nil || len(editable) != 2 {
+		t.Fatalf("editable: %#v, %v", editable, err)
+	}
+	if setupErr := manager.SetupArcadeLinks(); setupErr != nil {
+		t.Fatal(setupErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(nested, "cores")); statErr != nil {
+		t.Fatal(statErr)
+	}
+	oldCore := filepath.Join(root, "Core_20260101.rbf")
+	newCore := filepath.Join(root, "Core_20260201.rbf")
+	if writeErr := os.WriteFile(newCore, nil, 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if linkErr := os.Symlink(oldCore, filepath.Join(nested, "Core_20260101.rbf")); linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	if refreshErr := manager.Refresh(); refreshErr != nil {
+		t.Fatal(refreshErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(nested, "Core_20260201.rbf")); statErr != nil {
+		t.Fatal(statErr)
+	}
+}
+
+func TestArchiveChildParentRemainsBrowsable(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	archive := filepath.Join(root, "games", "SNES", "games.zip")
+	if err := os.MkdirAll(filepath.Dir(archive), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Create(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	if _, createErr := writer.Create("sub/game.sfc"); createErr != nil {
+		t.Fatal(createErr)
+	}
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	parent, err := manager.ParentFolder(archive + "/sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := manager.ListDirectory(parent)
+	if err != nil || len(entries) != 1 || entries[0].Name != "sub" {
+		t.Fatalf("archive parent entries: %#v, %v", entries, err)
+	}
+}
+
+func TestSettingsRetainManagedRootComments(t *testing.T) {
+	for _, roots := range [][]string{{"/mnt/old"}, {"/mnt/new", "/mnt/second"}, nil} {
+		path := filepath.Join(t.TempDir(), "favorites.ini")
+		const initial = "[favorites]\n; root notes\ngames_folder = /mnt/old\n" +
+			"; second root notes\ngames_folder = /mnt/second\n"
+		if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		settings := SettingsFromConfig(DefaultUserConfig())
+		settings.GamesFolders = roots
+		if err := SaveSettings(path, &settings); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || !strings.Contains(string(data), "; root notes") ||
+			!strings.Contains(string(data), "; second root notes") {
+			t.Fatalf("lost notes: %s, %v", data, err)
+		}
+		loaded, err := LoadConfigAt(path, "favorites.sh")
+		if err != nil || !slices.Equal(loaded.Favorites.GamesFolder, roots) {
+			t.Fatalf("roots failed round trip: %v", err)
+		}
+	}
+}
+
+func TestNeoGeoNearestMappingIsAuthoritative(t *testing.T) {
+	for _, local := range []string{
+		`<romsets><romset name="other" altname="Other"/></romsets>`,
+		`<romsets/>`,
+		`<romsets><romset name="game" altname="Partial"/><broken`,
+	} {
+		manager, _, root := newTestManager(t)
+		base := filepath.Join(root, "games", "NeoGeo")
+		folder := filepath.Join(base, "sub")
+		if err := os.MkdirAll(folder, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		const parentXML = `<romsets><romset name="game" altname="Parent"/></romsets>`
+		if err := os.WriteFile(filepath.Join(base, "romsets.xml"), []byte(parentXML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(folder, "romsets.xml"), []byte(local), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if title := manager.NeoGeoTitle(filepath.Join(folder, "game.zip")); title != "" {
+			t.Fatalf("nearest XML not authoritative: %q", title)
+		}
+	}
+}
+
+func TestCustomDefaultFolderRemainsRecognized(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	cfg.Favorites.DefaultFolder = "_Collection"
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	created, err := manager.CreateDefaultFolder()
+	if err != nil || !created {
+		t.Fatalf("create custom default: %v, %v", created, err)
+	}
+	folders, err := manager.DestinationFolders(false, "")
+	if err != nil || !slices.Equal(folders, []string{filepath.Join(root, "_Collection")}) {
+		t.Fatalf("custom default destinations: %v, %v", folders, err)
+	}
+	if manager.IsFavoriteFolderName("_Other") || !manager.IsFavoriteFolderName("_Favorites") {
+		t.Fatal("custom default changed matching rules for other folders")
+	}
+	if _, createErr := manager.CreateFolder(folders[0], "_Nested"); createErr != nil {
+		t.Fatal(createErr)
+	}
+	restarted := NewManagerWithPaths(cfg, manager.paths)
+	folders, err = restarted.DestinationFolders(false, "")
+	if err != nil || len(folders) != 2 {
+		t.Fatalf("restarted destinations: %v, %v", folders, err)
+	}
+}
+
+func TestPlayerVariantsSelectCorrectCatalogCore(t *testing.T) {
+	for _, test := range []struct{ folder, extension, systemID string }{
+		{"GBA2P", ".gba", "GBA2P"},
+		{"GBA", ".gba", "GBA"},
+		{"GAMEBOY2P", ".gb", "Gameboy2P"},
+		{"GAMEBOY", ".gb", "Gameboy"},
+	} {
+		t.Run(test.folder, func(t *testing.T) {
+			manager, _, root := newTestManager(t)
+			folder := filepath.Join(root, "games", test.folder)
+			if err := os.MkdirAll(folder, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			media := filepath.Join(folder, "game"+test.extension)
+			if err := os.WriteFile(media, nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := games.GetSystem(test.systemID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := manager.generateMGL(expected, media)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index := range 20 {
+				entries, listErr := manager.ListDirectory(folder)
+				if listErr != nil || len(entries) != 1 || entries[0].System == nil ||
+					entries[0].System.Id != test.systemID {
+					t.Fatalf("wrong player variant: %#v, %v", entries, listErr)
+				}
+				path, createErr := manager.CreateGameFavorite(entries[0].System, media, root, strconv.Itoa(index))
+				if createErr != nil {
+					t.Fatal(createErr)
+				}
+				data, readErr := os.ReadFile(path)
+				if readErr != nil || string(data) != want {
+					t.Fatalf("wrong variant MGL: %s, %v", data, readErr)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigCreationPreservesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "favorites.ini")
+	t.Setenv(config.UserConfigEnv, path)
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ensureErr := EnsureConfigFile(cfg); ensureErr != nil {
+		t.Fatal(ensureErr)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[favorites]") || !strings.Contains(string(data), "[tui]") {
+		t.Fatalf("default config missing sections:\n%s", data)
+	}
+
+	const custom = "[cores]\nall = yc\n"
+	if writeErr := os.WriteFile(path, []byte(custom), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if ensureErr := EnsureConfigFile(cfg); ensureErr != nil {
+		t.Fatal(ensureErr)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != custom {
+		t.Fatalf("existing config changed: %q", data)
+	}
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.FavoritesCores.All != "yc" || loaded.Favorites.DefaultFolder != "_@Favorites" {
+		t.Fatalf("legacy config did not merge with defaults: %#v", loaded)
+	}
+}
+
+func TestSettingsSavePreservesUnknownINIContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "favorites.ini")
+	initial := "[cores]\nall =\n\n[custom]\n; keep this comment\nvalue = untouched\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultUserConfig()
+	cfg.IniPath = path
+	settings := SettingsFromConfig(cfg)
+	settings.DefaultFolder = "_My Favorites"
+	settings.FolderNameContains = []string{"fav", "collection"}
+	settings.GamesFolders = []string{"/media/network", "/media/usb9"}
+	settings.AlternateCore = "yc"
+	settings.Theme = "high_contrast"
+	settings.HideRootFiles = false
+	if err := SaveSettings(path, &settings); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, expected := range []string{"[custom]", "; keep this comment", "value = untouched"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("saved configuration lost %q:\n%s", expected, text)
+		}
+	}
+	t.Setenv(config.UserConfigEnv, path)
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Favorites.DefaultFolder != "_My Favorites" ||
+		!slices.Equal(loaded.Favorites.FolderNameContains, []string{"fav", "collection"}) ||
+		!slices.Equal(loaded.Favorites.GamesFolder, []string{"/media/network", "/media/usb9"}) ||
+		loaded.FavoritesCores.All != "yc" || loaded.TUI.Theme != "high_contrast" || loaded.Favorites.HideRootFiles {
+		t.Fatalf("loaded settings = %#v", SettingsFromConfig(loaded))
+	}
+}
+
+func TestSettingsRejectInvalidValues(t *testing.T) {
+	settings := SettingsFromConfig(DefaultUserConfig())
+	settings.DefaultFolder = "Favorites"
+	if err := settings.Validate(); err == nil {
+		t.Fatal("invalid default folder accepted")
+	}
+}
+
+func TestCoreFavoriteCreateRenameAndMove(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	sourceFolder := filepath.Join(root, "_Console")
+	for _, path := range []string{folder, sourceFolder} {
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := filepath.Join(sourceFolder, "NES_20260101.rbf")
+	if err := os.WriteFile(source, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	favorite, err := manager.CreateCoreFavorite(source, folder, "Nintendo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target, readErr := os.Readlink(favorite); readErr != nil || target != source {
+		t.Fatalf("core favorite target = %q, err = %v", target, readErr)
+	}
+	renamed, err := manager.Rename(favorite, "Nintendo Entertainment System.rbf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Ext(renamed) != ".rbf" || strings.HasSuffix(renamed, ".rbf.rbf") {
+		t.Fatalf("renamed favorite = %q", renamed)
+	}
+	moved, err := manager.Move(renamed, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(moved) != root {
+		t.Fatalf("moved favorite = %q", moved)
+	}
+}
+
+func TestFavoriteDiscoveryAndSafeFolderDeletion(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	nested := filepath.Join(folder, "_RPG")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	core := filepath.Join(root, "_Console", "NES_20260101.rbf")
+	if err := os.MkdirAll(filepath.Dir(core), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(core, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	favorite := filepath.Join(nested, filepath.Base(core))
+	if err := os.Symlink(core, favorite); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := manager.EditableItems()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 || items[0].Kind != FavoriteFolder && items[1].Kind != FavoriteFolder {
+		t.Fatalf("unexpected editable items: %#v", items)
+	}
+	if err := manager.Delete(nested); err == nil || err.Error() != "folder is not empty" {
+		t.Fatalf("delete non-empty folder error = %v", err)
+	}
+	if err := manager.Delete(favorite); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Delete(nested); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRefreshUpdatesVersionedCoreSymlink(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	coreFolder := filepath.Join(root, "_Console")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(coreFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldCore := filepath.Join(coreFolder, "SNES_20250101.rbf")
+	newCore := filepath.Join(coreFolder, "SNES_20260101.rbf")
+	if err := os.WriteFile(newCore, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldLink := filepath.Join(folder, filepath.Base(oldCore))
+	if err := os.Symlink(oldCore, oldLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Refresh(); err != nil {
+		t.Fatal(err)
+	}
+	newLink := filepath.Join(folder, filepath.Base(newCore))
+	target, err := os.Readlink(newLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != newCore {
+		t.Fatalf("new core target = %q, want %q", target, newCore)
+	}
+	if _, err := os.Lstat(oldLink); !os.IsNotExist(err) {
+		t.Fatalf("old link still exists: %v", err)
+	}
+}
+
+func TestRefreshUpdatesRelativeVersionedCoreSymlink(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	coreFolder := filepath.Join(root, "_Console")
+	for _, path := range []string{folder, coreFolder} {
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	newCore := filepath.Join(coreFolder, "NES_20260101.rbf")
+	if err := os.WriteFile(newCore, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldLink := filepath.Join(folder, "NES_20250101.rbf")
+	if err := os.Symlink(filepath.Join("..", "_Console", "NES_20250101.rbf"), oldLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Refresh(); err != nil {
+		t.Fatal(err)
+	}
+	newLink := filepath.Join(folder, filepath.Base(newCore))
+	target, err := os.Readlink(newLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != newCore {
+		t.Fatalf("new relative-core target = %q, want %q", target, newCore)
+	}
+}
+
+func TestCatalogBackedMGLGeneration(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	gameFolder := filepath.Join(root, "games", "Jaguar")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gameFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gamePath := filepath.Join(gameFolder, `Alien & Predator.j64`)
+	if err := os.WriteFile(gamePath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	system, err := games.GetSystem("Jaguar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	launcherPath, err := manager.CreateGameFavorite(system, gamePath, folder, "Alien vs Predator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launcher := string(data)
+	if !strings.Contains(launcher, "<rbf>_Console/Jaguar</rbf>") {
+		t.Fatalf("missing Jaguar RBF:\n%s", launcher)
+	}
+	if !strings.Contains(launcher, "Alien &amp; Predator.j64") {
+		t.Fatalf("media path was not XML-escaped:\n%s", launcher)
+	}
+	if !strings.Contains(launcher, `<reset delay="1" hold="1"/>`) {
+		t.Fatalf("missing canonical reset timing:\n%s", launcher)
+	}
+}
+
+func TestGeneratedMGLIsDiscoveredWithOriginalTarget(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	gameFolder := filepath.Join(root, "games", "SNES")
+	for _, path := range []string{folder, gameFolder} {
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gamePath := filepath.Join(gameFolder, "Chrono Trigger.sfc")
+	if err := os.WriteFile(gamePath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	system, err := games.GetSystem("SNES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	launcherPath, err := manager.CreateGameFavorite(system, gamePath, folder, "Chrono Trigger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := manager.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Path != launcherPath || items[0].Target != gamePath {
+		t.Fatalf("discovered Favorites = %#v", items)
+	}
+}
+
+func TestNeoGeoTitleAndRelativeLauncher(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	gameFolder := filepath.Join(root, "games", "NeoGeo")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gameFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	romsets := `<romsets><romset name="mslug,mslugx" altname="Metal Slug &amp; Friends"/></romsets>`
+	if err := os.WriteFile(filepath.Join(gameFolder, "romsets.xml"), []byte(romsets), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gamePath := filepath.Join(gameFolder, "mslug.zip")
+	if err := createZip(gamePath, map[string]string{"game.bin": "data"}); err != nil {
+		t.Fatal(err)
+	}
+	system, err := games.GetSystem("NeoGeo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.DefaultName(system, gamePath); got != "Metal Slug & Friends" {
+		t.Fatalf("NeoGeo title = %q", got)
+	}
+	launcherPath, err := manager.CreateGameFavorite(system, gamePath, folder, "Metal Slug")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `path="mslug.zip"`) {
+		t.Fatalf("NeoGeo path is not relative:\n%s", data)
+	}
+}
+
+func TestBrowseInsideZIPUsesCatalog(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	gameFolder := filepath.Join(root, "games", "SNES")
+	if err := os.MkdirAll(gameFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(gameFolder, "collection.zip")
+	if err := createZip(archive, map[string]string{
+		"RPG/Chrono Trigger.sfc": "data",
+		"notes.txt":              "ignore",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := manager.ListDirectory(archive + string(filepath.Separator))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || !entries[0].IsDirectory || entries[0].Name != "RPG" {
+		t.Fatalf("archive root entries = %#v", entries)
+	}
+	entries, err = manager.ListDirectory(filepath.Join(archive, "RPG"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].System == nil || entries[0].System.Id != "SNES" {
+		t.Fatalf("archive game entries = %#v", entries)
+	}
+}
+
+func TestBrowseFollowsDirectorySymlinksAndMarksNeoGeoZIP(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	externalGames := filepath.Join(root, "external-games")
+	if err := os.MkdirAll(filepath.Join(externalGames, "SNES"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	gamesLink := filepath.Join(root, "games")
+	if err := os.Remove(gamesLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalGames, gamesLink); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := manager.ListDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundGamesLink := false
+	for _, entry := range entries {
+		if entry.Path == gamesLink && entry.IsDirectory {
+			foundGamesLink = true
+		}
+	}
+	if !foundGamesLink {
+		t.Fatalf("symlinked games folder entries = %#v", entries)
+	}
+
+	neoGeoTarget := filepath.Join(externalGames, "NeoGeo")
+	if mkdirErr := os.MkdirAll(neoGeoTarget, 0o750); mkdirErr != nil {
+		t.Fatal(mkdirErr)
+	}
+	neoGeoFolder := filepath.Join(gamesLink, "NeoGeo")
+	archive := filepath.Join(neoGeoFolder, "mslug.zip")
+	if createErr := createZip(archive, map[string]string{"nested/game.neo": "data"}); createErr != nil {
+		t.Fatal(createErr)
+	}
+	entries, err = manager.ListDirectory(neoGeoFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].System == nil || !entries[0].IsArchive || entries[0].IsDirectory {
+		t.Fatalf("NeoGeo ZIP entry = %#v", entries)
+	}
+	inside, err := manager.ListDirectory(archive + string(filepath.Separator))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inside) != 1 || !inside[0].IsDirectory {
+		t.Fatalf("NeoGeo ZIP contents = %#v", inside)
+	}
+}
+
+func TestCanonicalCatalogRecognizesEveryLegacyGamesFolder(t *testing.T) {
+	_, cfg, root := newTestManager(t)
+	legacyFolders := []string{
+		"Amiga", "Arcadia", "AVision", "Astrocade", "ATARI2600", "ATARI5200", "ATARI7800", "AtariLynx",
+		"C64", "ChannelF", "Coleco", "CreatiVision", "GAMEBOY2P", "GAMEBOY", "GBC", "Gamate",
+		"GameNWatch", "GameGear", "GBA2P", "GBA", "MegaDrive", "Genesis", "Intellivision", "MegaCD",
+		"N64", "NeoGeo-CD", "NeoGeo", "NES", "ODYSSEY2", "PSX", "PocketChallengeV2", "PokemonMini",
+		"Saturn", "S32X", "SG1000", "SGB", "SMS", "SNES", "SuperVision", "TGFX16-CD", "TGFX16",
+		"VC4000", "VECTREX", "WonderSwan", "WonderSwanColor",
+	}
+	for _, folder := range legacyFolders {
+		t.Run(folder, func(t *testing.T) {
+			path := filepath.Join(root, "games", folder) + string(filepath.Separator)
+			if systems := games.FolderToSystems(cfg, path); len(systems) == 0 {
+				t.Fatalf("legacy games folder is not in canonical catalog: %s", folder)
+			}
+		})
+	}
+}
+
+func TestCanonicalCatalogCoversLegacyAndNewSystems(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	if err := os.MkdirAll(folder, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		id       string
+		filename string
+		wantRBF  string
+		wantFile string
+	}{
+		{id: "Genesis", filename: "Sonic.md", wantRBF: "_Console/MegaDrive", wantFile: `type="f" index="1"`},
+		{id: "CDI", filename: "Hotel Mario.chd", wantRBF: "_Console/CDi", wantFile: `type="s" index="1"`},
+		{id: "CoCo2", filename: "Mega-Bug.ccc", wantRBF: "_Computer/CoCo2", wantFile: `type="f" index="1"`},
+	}
+	for _, test := range tests {
+		t.Run(test.id, func(t *testing.T) {
+			system, err := games.GetSystem(test.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mediaPath := filepath.Join(root, "games", system.Folder[0], test.filename)
+			if mkdirErr := os.MkdirAll(filepath.Dir(mediaPath), 0o750); mkdirErr != nil {
+				t.Fatal(mkdirErr)
+			}
+			if writeErr := os.WriteFile(mediaPath, nil, 0o600); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+			launcherPath, err := manager.CreateGameFavorite(system, mediaPath, folder, test.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(launcherPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			launcher := string(data)
+			if !strings.Contains(launcher, "<rbf>"+test.wantRBF+"</rbf>") ||
+				!strings.Contains(launcher, test.wantFile) {
+				t.Fatalf("unexpected %s launcher:\n%s", test.id, launcher)
+			}
+		})
+	}
+}
+
+func TestAlternateCoreAndCorePrefix(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	gameFolder := filepath.Join(root, "games", "Genesis")
+	llapiFolder := filepath.Join(root, "_LLAPI")
+	for _, path := range []string{folder, gameFolder, llapiFolder} {
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mediaPath := filepath.Join(gameFolder, "Sonic.md")
+	if err := os.WriteFile(mediaPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(llapiFolder, "Genesis_LLAPI_20260101.rbf"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(llapiFolder, "GenesisYC_20260101.rbf"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	system, err := games.GetSystem("Genesis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.FavoritesCores.All = "llapi"
+	launcherPath, err := manager.CreateGameFavorite(system, mediaPath, folder, "LLAPI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "<rbf>_LLAPI/Genesis_LLAPI</rbf>") {
+		t.Fatalf("alternate core not selected:\n%s", data)
+	}
+
+	cfg.FavoritesCores.All = "yc"
+	launcherPath, err = manager.CreateGameFavorite(system, mediaPath, folder, "YC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "<rbf>_LLAPI/GenesisYC</rbf>") {
+		t.Fatalf("YC core not selected:\n%s", data)
+	}
+
+	cfg.FavoritesCores.All = ""
+	cfg.Favorites.CorePrefix = "_Alt/"
+	launcherPath, err = manager.CreateGameFavorite(system, mediaPath, folder, "Prefixed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "<rbf>_Alt/_Console/MegaDrive</rbf>") {
+		t.Fatalf("core prefix not applied:\n%s", data)
+	}
+}
+
+func TestArcadeLinksDoNotReplaceExistingContent(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	nested := filepath.Join(folder, "_Arcade Picks")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	rootCores := filepath.Join(root, "cores")
+	if err := os.WriteFile(rootCores, []byte("user content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetupArcadeLinks(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(rootCores)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "user content" {
+		t.Fatalf("root cores content changed: %q", data)
+	}
+	for _, path := range []string{filepath.Join(folder, "cores"), filepath.Join(nested, "cores")} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("arcade cores path is not a symlink: %s", path)
+		}
+	}
+}
+
+func TestStartupEntryUsesConfiguredApplicationPath(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	cfg.AppPath = filepath.Join(root, "Custom Scripts", "favorites.sh")
+	startup := filepath.Join(root, "linux", "user-startup.sh")
+	if err := os.MkdirAll(filepath.Dir(startup), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(startup, []byte("#!/bin/bash\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.TryAddToStartup(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quotedPath := `"` + cfg.AppPath + `"`
+	if !strings.Contains(string(data), "[[ -e "+quotedPath+" ]] && "+quotedPath+" refresh") {
+		t.Fatalf("startup entry = %q", data)
+	}
+}
+
+func TestStartupEntryIsIdempotent(t *testing.T) {
+	manager, _, _ := newTestManager(t)
+	if err := os.WriteFile(manager.paths.StartupScript, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.TryAddToStartup(); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.TryAddToStartup(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(manager.paths.StartupScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(data), startupMarker) != 1 {
+		t.Fatalf("startup marker count = %d", strings.Count(string(data), startupMarker))
+	}
+}
+
+func createZip(path string, files map[string]string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create ZIP fixture: %w", err)
+	}
+	writer := zip.NewWriter(file)
+	for name, content := range files {
+		entry, createErr := writer.Create(name)
+		if createErr != nil {
+			_ = writer.Close()
+			_ = file.Close()
+			return fmt.Errorf("create ZIP entry: %w", createErr)
+		}
+		if _, writeErr := entry.Write([]byte(content)); writeErr != nil {
+			_ = writer.Close()
+			_ = file.Close()
+			return fmt.Errorf("write ZIP entry: %w", writeErr)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("close ZIP writer: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close ZIP fixture: %w", err)
+	}
+	return nil
+}

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -456,9 +456,12 @@ func TestRefreshUpdatesVersionedCoreSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 	oldCore := filepath.Join(coreFolder, "SNES_20250101.rbf")
+	staleCore := filepath.Join(coreFolder, "SNES_20250601.rbf")
 	newCore := filepath.Join(coreFolder, "SNES_20260101.rbf")
-	if err := os.WriteFile(newCore, nil, 0o644); err != nil {
-		t.Fatal(err)
+	for _, core := range []string{staleCore, newCore} {
+		if err := os.WriteFile(core, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	oldLink := filepath.Join(folder, filepath.Base(oldCore))
 	if err := os.Symlink(oldCore, oldLink); err != nil {
@@ -477,6 +480,9 @@ func TestRefreshUpdatesVersionedCoreSymlink(t *testing.T) {
 	}
 	if _, err := os.Lstat(oldLink); !os.IsNotExist(err) {
 		t.Fatalf("old link still exists: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(folder, filepath.Base(staleCore))); !os.IsNotExist(err) {
+		t.Fatalf("stale core was linked instead of newest: %v", err)
 	}
 }
 

--- a/pkg/favorites/launcher.go
+++ b/pkg/favorites/launcher.go
@@ -1,0 +1,260 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/mister/catalog"
+	mglgen "github.com/ZaparooProject/zaparoo-core/mister/mgl"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+)
+
+const BadCharacters = `<>:"/\|?*`
+
+var alternateCores = map[string]map[string]string{
+	"llapi": {
+		"Atari7800": "Atari7800_LLAPI", "Gameboy": "Gameboy_LLAPI", "GBA2P": "GBA2P_LLAPI",
+		"GBA": "GBA_LLAPI", "Genesis": "Genesis_LLAPI", "MegaCD": "MegaCD_LLAPI",
+		"NeoGeo": "NeoGeo_LLAPI", "NES": "NES_LLAPI", "Sega32X": "S32X_LLAPI",
+		"SuperGameboy": "SGB_LLAPI", "MasterSystem": "SMS_LLAPI", "SNES": "SNES_LLAPI",
+		"TurboGrafx16CD": "TurboGrafx16_LLAPI", "TurboGrafx16": "TurboGrafx16_LLAPI",
+	},
+	"yc": {
+		"Atari2600": "Atari7800YC", "Atari7800": "Atari7800YC", "C64": "C64YC",
+		"ColecoVision": "ColecoVisionYC", "Gameboy": "GameboyYC", "Genesis": "GenesisYC",
+		"MegaCD": "MegaCDYC", "NeoGeo": "NeoGeoYC", "NES": "NESYC", "PSX": "PSXYC",
+		"Sega32X": "S32XYC", "SuperGameboy": "SGBYC", "MasterSystem": "SMSYC", "SNES": "SNESYC",
+		"TurboGrafx16CD": "TurboGrafx16YC", "TurboGrafx16": "TurboGrafx16YC",
+	},
+}
+
+func HasBadChars(value string) bool {
+	return strings.ContainsAny(value, BadCharacters)
+}
+
+func ValidateDisplayName(name string) error {
+	switch {
+	case strings.TrimSpace(name) == "":
+		return errors.New("display name cannot be empty")
+	case HasBadChars(name):
+		return fmt.Errorf("display name cannot contain any of these characters: %s", BadCharacters)
+	default:
+		return nil
+	}
+}
+
+func (m *Manager) DefaultName(system *games.System, path string) string {
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if system != nil && system.Id == "NeoGeo" && strings.EqualFold(filepath.Ext(path), ".zip") {
+		if title := m.NeoGeoTitle(path); title != "" {
+			cleaned := strings.Map(func(value rune) rune {
+				if strings.ContainsRune(BadCharacters, value) {
+					return ' '
+				}
+				return value
+			}, title)
+			if safeName := strings.Trim(strings.Join(strings.Fields(cleaned), " "), "."); safeName != "" {
+				return safeName
+			}
+		}
+	}
+	return name
+}
+
+func (m *Manager) CreateCoreFavorite(source, destination, name string) (string, error) {
+	if err := m.validateDestination(destination, true); err != nil {
+		return "", err
+	}
+	if err := ValidateDisplayName(name); err != nil {
+		return "", err
+	}
+	extension := strings.ToLower(filepath.Ext(source))
+	if extension != ".rbf" && extension != ".mra" && extension != ".mgl" {
+		return "", fmt.Errorf("unsupported favorite file: %s", source)
+	}
+	if strings.EqualFold(filepath.Ext(name), extension) {
+		name = strings.TrimSuffix(name, filepath.Ext(name))
+	}
+	path := filepath.Join(destination, name+extension)
+	if _, err := os.Lstat(path); err == nil {
+		return "", fmt.Errorf("favorite already exists: %s", filepath.Base(path))
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect favorite destination: %w", err)
+	}
+	if err := os.Symlink(source, path); err != nil {
+		return "", fmt.Errorf("create core favorite: %w", err)
+	}
+	return path, nil
+}
+
+func (m *Manager) CreateGameFavorite(
+	system *games.System,
+	mediaPath, destination, name string,
+) (string, error) {
+	if system == nil {
+		return "", errors.New("no system selected")
+	}
+	if err := m.validateDestination(destination, true); err != nil {
+		return "", err
+	}
+	if err := ValidateDisplayName(name); err != nil {
+		return "", err
+	}
+	launcherPath := filepath.Join(destination, name+".mgl")
+	if _, err := os.Lstat(launcherPath); err == nil {
+		return "", fmt.Errorf("favorite already exists: %s", filepath.Base(launcherPath))
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect game favorite destination: %w", err)
+	}
+
+	resolvedSystem := *system
+	resolvedSystem.Rbf = m.resolveCore(&resolvedSystem)
+	launcher, err := m.generateMGL(&resolvedSystem, mediaPath)
+	if err != nil {
+		return "", err
+	}
+	// #nosec G306,G703 -- MiSTer menu launchers must remain world-readable.
+	if err := os.WriteFile(launcherPath, []byte(launcher), 0o644); err != nil {
+		return "", fmt.Errorf("write game favorite: %w", err)
+	}
+	return launcherPath, nil
+}
+
+func (m *Manager) generateMGL(system *games.System, mediaPath string) (string, error) {
+	if system.Id != "NeoGeo" {
+		launcher, err := mister.GenerateMgl(m.cfg, system, mediaPath, "")
+		if err != nil {
+			return "", fmt.Errorf("generate favorite MGL: %w", err)
+		}
+		return launcher, nil
+	}
+
+	base := m.neoGeoBase(mediaPath)
+	if base == "" {
+		launcher, err := mister.GenerateMgl(m.cfg, system, mediaPath, "")
+		if err != nil {
+			return "", fmt.Errorf("generate NeoGeo favorite MGL: %w", err)
+		}
+		return launcher, nil
+	}
+	relativePath, err := filepath.Rel(base, resolveExistingPath(mediaPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve NeoGeo favorite path: %w", err)
+	}
+	core := games.CatalogCore(system)
+	params, err := catalog.PathToMGLDef(&core, mediaPath)
+	if err != nil {
+		if !strings.EqualFold(filepath.Ext(mediaPath), ".zip") {
+			return "", fmt.Errorf("resolve NeoGeo MGL parameters: %w", err)
+		}
+		// NeoGeo ZIP sets are supported by Favorites but are not yet present in
+		// the published standalone catalog module.
+		params = &catalog.MGLParams{Delay: 1, Method: "f", Index: 1}
+	}
+	//nolint:gocritic // Explicit XML quoting is required after attribute escaping.
+	override := fmt.Sprintf(
+		"\t<file delay=\"%d\" type=%q index=\"%d\" path=\"%s\"/>\n",
+		params.Delay,
+		params.Method,
+		params.Index,
+		escapeAttribute(filepath.ToSlash(relativePath)),
+	)
+	if params.ResetDelay > 0 {
+		override += fmt.Sprintf("\t<reset delay=\"%d\" hold=\"%d\"/>\n", params.ResetDelay, params.ResetHold)
+	}
+	launcher, err := mglgen.Generate(&core, core.RBF, mediaPath, override)
+	if err != nil {
+		return "", fmt.Errorf("generate relative NeoGeo favorite MGL: %w", err)
+	}
+	return launcher, nil
+}
+
+func escapeAttribute(value string) string {
+	return strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	).Replace(value)
+}
+
+func (m *Manager) resolveCore(system *games.System) string {
+	defaultRBF := m.cfg.Favorites.CorePrefix + system.Rbf
+	mode := strings.ToLower(strings.TrimSpace(m.cfg.FavoritesCores.All))
+	if mode == "" {
+		return defaultRBF
+	}
+	coreName := alternateCores[mode][system.Id]
+	if coreName == "" {
+		return defaultRBF
+	}
+	for _, core := range m.shallowRBFs() {
+		if strings.HasPrefix(filepath.Base(core.Path), coreName) {
+			return core.MGLName
+		}
+	}
+	return defaultRBF
+}
+
+func (m *Manager) shallowRBFs() []games.RBFInfo {
+	entries, err := os.ReadDir(m.paths.SDRoot)
+	if err != nil {
+		return nil
+	}
+	paths := make([]string, 0)
+	for _, entry := range entries {
+		path := filepath.Join(m.paths.SDRoot, entry.Name())
+		if !entry.IsDir() && !isDirectorySymlink(path, entry) {
+			if strings.EqualFold(filepath.Ext(entry.Name()), ".rbf") {
+				paths = append(paths, path)
+			}
+			continue
+		}
+		if _, allowed := allowedRootEntries[strings.ToLower(entry.Name())]; !allowed {
+			continue
+		}
+		subEntries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			continue
+		}
+		for _, subEntry := range subEntries {
+			if !subEntry.IsDir() && strings.EqualFold(filepath.Ext(subEntry.Name()), ".rbf") {
+				paths = append(paths, filepath.Join(path, subEntry.Name()))
+			}
+		}
+	}
+	sort.Strings(paths)
+	cores := make([]games.RBFInfo, 0, len(paths))
+	for _, path := range paths {
+		core := games.ParseRBF(path)
+		if relativeDir, relativeErr := filepath.Rel(m.paths.SDRoot, filepath.Dir(path)); relativeErr == nil {
+			core.MGLName = filepath.Join(relativeDir, core.ShortName)
+		}
+		cores = append(cores, core)
+	}
+	return cores
+}

--- a/pkg/favorites/manager.go
+++ b/pkg/favorites/manager.go
@@ -583,7 +583,7 @@ func refreshVersionedCore(linkPath, oldTarget string) error {
 		return nil
 	}
 	sort.Strings(matches)
-	newTarget := matches[0]
+	newTarget := matches[len(matches)-1]
 	underscore := strings.LastIndex(newTarget, "_")
 	if underscore < 0 {
 		return nil

--- a/pkg/favorites/manager.go
+++ b/pkg/favorites/manager.go
@@ -1,0 +1,668 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+)
+
+const startupMarker = "# Startup favorites"
+
+var versionedCorePattern = regexp.MustCompile(`_\d{8}\.`)
+
+type RuntimePaths struct {
+	SDRoot            string
+	StartupScript     string
+	ArcadeCoresFolder string
+}
+
+type FavoriteKind string
+
+const (
+	FavoriteGame       FavoriteKind = "Game"
+	FavoriteCore       FavoriteKind = "Core"
+	FavoriteArcadeCore FavoriteKind = "Arcade Core"
+	FavoriteFolder     FavoriteKind = "Folder"
+)
+
+type Favorite struct {
+	Path    string
+	Target  string
+	System  string
+	SetName string
+	Kind    FavoriteKind
+}
+
+//nolint:govet // Field order keeps configuration, paths, and caches grouped.
+type Manager struct {
+	cfg                 *config.UserConfig
+	paths               RuntimePaths
+	archiveEntriesCache map[string][]BrowseEntry
+	neoGeoNamesCache    map[string]map[string]string
+	createdDefaultPath  string
+	createdDefaultInfo  os.FileInfo
+}
+
+func DefaultRuntimePaths() RuntimePaths {
+	return RuntimePaths{
+		SDRoot:            config.SdFolder,
+		StartupScript:     config.StartupFile,
+		ArcadeCoresFolder: config.ArcadeCoresFolder,
+	}
+}
+
+func NewManager(cfg *config.UserConfig) *Manager {
+	return NewManagerWithPaths(cfg, DefaultRuntimePaths())
+}
+
+func NewManagerWithPaths(cfg *config.UserConfig, paths RuntimePaths) *Manager {
+	return &Manager{
+		cfg:                 cfg,
+		paths:               paths,
+		archiveEntriesCache: make(map[string][]BrowseEntry),
+		neoGeoNamesCache:    make(map[string]map[string]string),
+	}
+}
+
+func (m *Manager) Root() string {
+	return m.paths.SDRoot
+}
+
+func (m *Manager) RelativePath(path string) string {
+	relative, err := filepath.Rel(m.paths.SDRoot, path)
+	if err != nil || strings.HasPrefix(relative, "..") {
+		return path
+	}
+	return relative
+}
+
+func (m *Manager) IsFavoriteFolderName(name string) bool {
+	lowerName := strings.ToLower(name)
+	if !strings.HasPrefix(name, "_") {
+		return false
+	}
+	if strings.EqualFold(name, m.cfg.Favorites.DefaultFolder) {
+		return true
+	}
+	for _, fragment := range m.cfg.Favorites.FolderNameContains {
+		if strings.Contains(lowerName, strings.ToLower(fragment)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) FavoriteFolders() ([]string, error) {
+	entries, err := os.ReadDir(m.paths.SDRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read MiSTer root: %w", err)
+	}
+	folders := make([]string, 0)
+	for _, entry := range entries {
+		path := filepath.Join(m.paths.SDRoot, entry.Name())
+		if (entry.IsDir() || isDirectorySymlink(path, entry)) && m.IsFavoriteFolderName(entry.Name()) {
+			folders = append(folders, path)
+		}
+	}
+	sort.Slice(folders, func(i, j int) bool {
+		return strings.ToLower(folders[i]) < strings.ToLower(folders[j])
+	})
+	return folders, nil
+}
+
+func (m *Manager) DestinationFolders(includeRoot bool, ignorePath string) ([]string, error) {
+	favoritesFolders, err := m.FavoriteFolders()
+	if err != nil {
+		return nil, err
+	}
+	folders := make([]string, 0, len(favoritesFolders)+1)
+	if includeRoot {
+		folders = append(folders, m.paths.SDRoot)
+	}
+	for _, root := range favoritesFolders {
+		folders = append(folders, root)
+		walkErr := walkFavoriteRoot(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path == root || !entry.IsDir() {
+				return nil
+			}
+			if path == ignorePath {
+				return filepath.SkipDir
+			}
+			if strings.HasPrefix(entry.Name(), "_") {
+				folders = append(folders, path)
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("scan Favorites folders: %w", walkErr)
+		}
+	}
+	sort.Slice(folders, func(i, j int) bool {
+		return strings.ToLower(folders[i]) < strings.ToLower(folders[j])
+	})
+	return folders, nil
+}
+
+// Follow only the selected root symlink, not nested directory symlinks.
+// Callbacks retain logical menu paths rather than exposing the target location.
+func walkFavoriteRoot(root string, visit fs.WalkDirFunc) error {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolve Favorites root: %w", err)
+	}
+	err = filepath.WalkDir(resolved, func(path string, entry fs.DirEntry, walkErr error) error {
+		relative, relErr := filepath.Rel(resolved, path)
+		if relErr != nil {
+			return fmt.Errorf("resolve logical Favorites path: %w", relErr)
+		}
+		return visit(filepath.Join(root, relative), entry, walkErr)
+	})
+	if err != nil {
+		return fmt.Errorf("walk Favorites root: %w", err)
+	}
+	return nil
+}
+
+func IsFavoriteFile(path string) bool {
+	extension := strings.ToLower(filepath.Ext(path))
+	if extension == ".mgl" {
+		return true
+	}
+	if extension != ".rbf" && extension != ".mra" {
+		return false
+	}
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}
+
+func (m *Manager) List() ([]Favorite, error) {
+	favorites := make([]Favorite, 0)
+	rootEntries, err := os.ReadDir(m.paths.SDRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read MiSTer root: %w", err)
+	}
+	for _, entry := range rootEntries {
+		path := filepath.Join(m.paths.SDRoot, entry.Name())
+		if IsFavoriteFile(path) {
+			favorites = append(favorites, inspectFavorite(path))
+		}
+	}
+
+	folders, err := m.FavoriteFolders()
+	if err != nil {
+		return nil, err
+	}
+	for _, folder := range folders {
+		walkErr := walkFavoriteRoot(folder, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !entry.IsDir() && IsFavoriteFile(path) {
+				favorites = append(favorites, inspectFavorite(path))
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("scan Favorites: %w", walkErr)
+		}
+	}
+	sort.Slice(favorites, func(i, j int) bool {
+		return strings.ToLower(favorites[i].Path) < strings.ToLower(favorites[j].Path)
+	})
+	return favorites, nil
+}
+
+func (m *Manager) EditableItems() ([]Favorite, error) {
+	items, err := m.List()
+	if err != nil {
+		return nil, err
+	}
+	folders, err := m.FavoriteFolders()
+	if err != nil {
+		return nil, err
+	}
+	for _, root := range folders {
+		walkErr := walkFavoriteRoot(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path != root && entry.IsDir() && strings.HasPrefix(entry.Name(), "_") {
+				items = append(items, Favorite{Path: path, Kind: FavoriteFolder})
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("scan editable Favorites folders: %w", walkErr)
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return strings.ToLower(items[i].Path) < strings.ToLower(items[j].Path)
+	})
+	return items, nil
+}
+
+func inspectFavorite(path string) Favorite {
+	favorite := Favorite{Path: path, Target: favoriteTarget(path)}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".rbf":
+		favorite.Kind = FavoriteCore
+	case ".mra":
+		favorite.Kind = FavoriteArcadeCore
+	case ".mgl":
+		favorite.Kind = FavoriteGame
+		if launcher, err := mister.ReadMGL(path); err == nil {
+			favorite.System = filepath.Base(launcher.Rbf)
+			favorite.SetName = launcher.SetName
+		}
+	}
+	return favorite
+}
+
+func favoriteTarget(path string) string {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return ""
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, readErr := os.Readlink(path)
+		if readErr == nil {
+			return target
+		}
+		return ""
+	}
+	if !strings.EqualFold(filepath.Ext(path), ".mgl") {
+		return ""
+	}
+	launcher, err := mister.ReadMGL(path)
+	if err != nil {
+		return ""
+	}
+	const generatedPrefix = "../../../../../"
+	if strings.HasPrefix(launcher.File.Path, generatedPrefix) {
+		return string(filepath.Separator) + strings.TrimPrefix(launcher.File.Path, generatedPrefix)
+	}
+	return launcher.File.Path
+}
+
+func (m *Manager) CreateDefaultFolder() (bool, error) {
+	folders, err := m.FavoriteFolders()
+	if err != nil {
+		return false, err
+	}
+	path := filepath.Join(m.paths.SDRoot, m.cfg.Favorites.DefaultFolder)
+	if len(folders) > 0 {
+		return false, nil
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		return false, nil
+	} else if !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("inspect default Favorites folder: %w", statErr)
+	}
+	// #nosec G301 -- MiSTer menu folders must be readable by the menu process.
+	if mkdirErr := os.Mkdir(path, 0o755); mkdirErr != nil {
+		return false, fmt.Errorf("create default Favorites folder: %w", mkdirErr)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false, fmt.Errorf("inspect created Favorites folder: %w", err)
+	}
+	m.createdDefaultPath = path
+	m.createdDefaultInfo = info
+	return true, nil
+}
+
+func (m *Manager) CleanupCreatedDefault(created bool) error {
+	if !created || m.createdDefaultInfo == nil {
+		return nil
+	}
+	path := m.createdDefaultPath
+	info, statErr := os.Lstat(path)
+	if os.IsNotExist(statErr) {
+		return nil
+	}
+	if statErr != nil {
+		return fmt.Errorf("inspect created Favorites folder: %w", statErr)
+	}
+	if !os.SameFile(info, m.createdDefaultInfo) {
+		return nil
+	}
+	entries, err := os.ReadDir(path)
+	if os.IsNotExist(err) {
+		return nil //nolint:nilerr // Missing app-created folder is already clean.
+	}
+	if err != nil {
+		return fmt.Errorf("read default Favorites folder: %w", err)
+	}
+	if len(entries) == 1 && entries[0].Name() == "cores" {
+		coresPath := filepath.Join(path, "cores")
+		info, statErr := os.Lstat(coresPath)
+		if os.IsNotExist(statErr) {
+			return nil //nolint:nilerr // Concurrent removal already completed cleanup.
+		}
+		if statErr != nil {
+			return fmt.Errorf("inspect default arcade cores link: %w", statErr)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return nil
+		}
+		if err := os.Remove(coresPath); err != nil {
+			return fmt.Errorf("remove default arcade cores link: %w", err)
+		}
+		entries = nil
+	}
+	if len(entries) == 0 {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove unused default Favorites folder: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) CreateFolder(parent, name string) (string, error) {
+	if err := ValidateFolderName(name); err != nil {
+		return "", err
+	}
+	if err := m.validateDestination(parent, false); err != nil {
+		return "", err
+	}
+	path := filepath.Join(parent, name)
+	if _, err := os.Lstat(path); err == nil {
+		return "", fmt.Errorf("folder already exists: %s", name)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect destination folder: %w", err)
+	}
+	// #nosec G301 -- MiSTer menu folders must be readable by the menu process.
+	if err := os.Mkdir(path, 0o755); err != nil {
+		return "", fmt.Errorf("create Favorites folder: %w", err)
+	}
+	if m.cfg.Favorites.ManageArcadeCoreLinks {
+		if err := m.ensureArcadeLink(path); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}
+
+func ValidateFolderName(name string) error {
+	switch {
+	case !strings.HasPrefix(name, "_"):
+		return errors.New("folder name must start with an underscore")
+	case name == "_":
+		return errors.New("folder name cannot be empty")
+	case HasBadChars(name):
+		return fmt.Errorf("folder name cannot contain any of these characters: %s", BadCharacters)
+	default:
+		return nil
+	}
+}
+
+func (*Manager) Rename(path, name string) (string, error) {
+	if info, err := os.Lstat(path); err != nil {
+		return "", fmt.Errorf("inspect favorite: %w", err)
+	} else if info.IsDir() {
+		if err := ValidateFolderName(name); err != nil {
+			return "", err
+		}
+	} else if err := ValidateDisplayName(name); err != nil {
+		return "", err
+	}
+	newPath := filepath.Join(filepath.Dir(path), name)
+	if !isDirectory(path) && !strings.EqualFold(filepath.Ext(name), filepath.Ext(path)) {
+		newPath += filepath.Ext(path)
+	}
+	if _, err := os.Lstat(newPath); err == nil {
+		return "", fmt.Errorf("favorite already exists: %s", filepath.Base(newPath))
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect renamed favorite: %w", err)
+	}
+	if err := os.Rename(path, newPath); err != nil {
+		return "", fmt.Errorf("rename favorite: %w", err)
+	}
+	return newPath, nil
+}
+
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func (m *Manager) Move(path, destination string) (string, error) {
+	if err := m.validateDestination(destination, !isDirectory(path)); err != nil {
+		return "", err
+	}
+	newPath := filepath.Join(destination, filepath.Base(path))
+	if _, err := os.Lstat(newPath); err == nil {
+		return "", fmt.Errorf("favorite already exists in destination: %s", filepath.Base(path))
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect move destination: %w", err)
+	}
+	if err := os.Rename(path, newPath); err != nil {
+		return "", fmt.Errorf("move favorite: %w", err)
+	}
+	return newPath, nil
+}
+
+func (*Manager) Delete(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect favorite for deletion: %w", err)
+	}
+	if !info.IsDir() {
+		if !IsFavoriteFile(path) {
+			return fmt.Errorf("not a managed favorite: %s", path)
+		}
+		if removeErr := os.Remove(path); removeErr != nil {
+			return fmt.Errorf("delete favorite: %w", removeErr)
+		}
+		return nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("read Favorites folder: %w", err)
+	}
+	for _, entry := range entries {
+		entryPath := filepath.Join(path, entry.Name())
+		entryInfo, statErr := os.Lstat(entryPath)
+		if entry.Name() != "cores" || statErr != nil || entryInfo.Mode()&os.ModeSymlink == 0 {
+			return errors.New("folder is not empty")
+		}
+	}
+	for _, entry := range entries {
+		if err := os.Remove(filepath.Join(path, entry.Name())); err != nil {
+			return fmt.Errorf("remove arcade cores link: %w", err)
+		}
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("delete Favorites folder: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) validateDestination(path string, allowRoot bool) error {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == filepath.Clean(m.paths.SDRoot) {
+		if allowRoot {
+			return nil
+		}
+		return errors.New("top-level destination is not allowed")
+	}
+	folders, err := m.DestinationFolders(false, "")
+	if err != nil {
+		return err
+	}
+	for _, folder := range folders {
+		if cleanPath == filepath.Clean(folder) {
+			return nil
+		}
+	}
+	return fmt.Errorf("not a Favorites folder: %s", path)
+}
+
+func (m *Manager) Refresh() error {
+	favorites, err := m.List()
+	if err != nil {
+		return err
+	}
+	for _, favorite := range favorites {
+		info, statErr := os.Lstat(favorite.Path)
+		if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		target := favorite.Target
+		resolvedTarget := target
+		if !filepath.IsAbs(target) {
+			resolvedTarget = filepath.Join(filepath.Dir(favorite.Path), target)
+		}
+		if _, statErr := os.Stat(resolvedTarget); statErr == nil {
+			continue
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("inspect favorite target: %w", statErr)
+		}
+		if err := os.Remove(favorite.Path); err != nil {
+			return fmt.Errorf("remove broken favorite: %w", err)
+		}
+		if !versionedCorePattern.MatchString(favorite.Path) {
+			continue
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(favorite.Path), target)
+		}
+		if err := refreshVersionedCore(favorite.Path, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func refreshVersionedCore(linkPath, oldTarget string) error {
+	linkPrefix := strings.TrimSuffix(linkPath, filepath.Ext(linkPath))
+	if underscore := strings.LastIndex(linkPrefix, "_"); underscore >= 0 {
+		linkPrefix = linkPrefix[:underscore]
+	}
+	targetPrefix := oldTarget
+	if underscore := strings.LastIndex(targetPrefix, "_"); underscore >= 0 {
+		targetPrefix = targetPrefix[:underscore]
+	}
+	matches, err := filepath.Glob(targetPrefix + "_*")
+	if err != nil {
+		return fmt.Errorf("find updated core: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Strings(matches)
+	newTarget := matches[0]
+	underscore := strings.LastIndex(newTarget, "_")
+	if underscore < 0 {
+		return nil
+	}
+	newLink := linkPrefix + newTarget[underscore:]
+	if err := os.Symlink(newTarget, newLink); err != nil {
+		return fmt.Errorf("link updated core: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) TryAddToStartup() error {
+	data, err := os.ReadFile(m.paths.StartupScript)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read startup script: %w", err)
+	}
+	if strings.Contains(string(data), startupMarker) {
+		return nil
+	}
+	file, err := os.OpenFile(m.paths.StartupScript, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open startup script: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	appPath := m.cfg.AppPath
+	if appPath == "" {
+		appPath = "/media/fat/Scripts/favorites.sh"
+	}
+	commandPath := appPath
+	if strings.ContainsAny(appPath, " \t") {
+		commandPath = strconv.Quote(appPath)
+	}
+	entry := fmt.Sprintf("\n# Startup favorites\n[[ -e %s ]] && %s refresh\n", commandPath, commandPath)
+	if _, err := file.WriteString(entry); err != nil {
+		return fmt.Errorf("append Favorites startup entry: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) SetupArcadeLinks() error {
+	if !m.cfg.Favorites.ManageArcadeCoreLinks {
+		return nil
+	}
+	if err := m.ensureArcadeLink(m.paths.SDRoot); err != nil {
+		return err
+	}
+	folders, err := m.FavoriteFolders()
+	if err != nil {
+		return err
+	}
+	for _, root := range folders {
+		walkErr := walkFavoriteRoot(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				return m.ensureArcadeLink(path)
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return fmt.Errorf("set up arcade links: %w", walkErr)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) ensureArcadeLink(folder string) error {
+	linkPath := filepath.Join(folder, "cores")
+	if _, err := os.Lstat(linkPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect arcade cores link: %w", err)
+	}
+	if err := os.Symlink(m.paths.ArcadeCoresFolder, linkPath); err != nil {
+		return fmt.Errorf("create arcade cores link: %w", err)
+	}
+	return nil
+}

--- a/pkg/favorites/neogeo.go
+++ b/pkg/favorites/neogeo.go
@@ -1,0 +1,145 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+func (m *Manager) NeoGeoTitle(path string) string {
+	if !strings.EqualFold(filepath.Ext(path), ".zip") {
+		return ""
+	}
+	base := m.neoGeoBase(path)
+	if base == "" {
+		return ""
+	}
+	folder := filepath.Dir(path)
+	for {
+		xmlPath := filepath.Join(folder, "romsets.xml")
+		if info, err := os.Stat(xmlPath); err == nil && !info.IsDir() {
+			names := m.loadNeoGeoNames(xmlPath)
+			return names[strings.ToLower(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))]
+		}
+		if samePath(folder, base) {
+			return ""
+		}
+		parent := filepath.Dir(folder)
+		if parent == folder {
+			return ""
+		}
+		folder = parent
+	}
+}
+
+func (m *Manager) neoGeoBase(path string) string {
+	resolvedPath := resolveExistingPath(path)
+	neoGeo, err := games.GetSystem("NeoGeo")
+	if err != nil {
+		return ""
+	}
+	best := ""
+	folderNames := append(append([]string(nil), neoGeo.Folder...), "NeoGeo", "NEOGEO")
+	for _, root := range games.GetGamesFolders(m.cfg) {
+		for _, folder := range folderNames {
+			candidate := filepath.Join(root, folder)
+			if matched, matchErr := games.FindFile(candidate); matchErr == nil {
+				candidate = matched
+			}
+			resolvedCandidate := resolveExistingPath(candidate)
+			relative, relErr := filepath.Rel(resolvedCandidate, resolvedPath)
+			if relErr != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+				continue
+			}
+			if len(resolvedCandidate) > len(best) {
+				best = resolvedCandidate
+			}
+		}
+	}
+	return best
+}
+
+func resolveExistingPath(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
+}
+
+func samePath(first, second string) bool {
+	return filepath.Clean(resolveExistingPath(first)) == filepath.Clean(resolveExistingPath(second))
+}
+
+func (m *Manager) loadNeoGeoNames(path string) map[string]string {
+	path = resolveExistingPath(path)
+	if names, found := m.neoGeoNamesCache[path]; found {
+		return names
+	}
+	names := make(map[string]string)
+	defer func() { m.neoGeoNamesCache[path] = names }()
+	// #nosec G304 -- path is a discovered romsets.xml file under a selected NeoGeo folder.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return names
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	for {
+		token, tokenErr := decoder.Token()
+		if errors.Is(tokenErr, io.EOF) {
+			break
+		}
+		if tokenErr != nil {
+			clear(names)
+			return names
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Local != "romset" {
+			continue
+		}
+		var rawNames, title string
+		for _, attribute := range start.Attr {
+			switch attribute.Name.Local {
+			case "name":
+				rawNames = attribute.Value
+			case "altname":
+				title = strings.TrimSpace(attribute.Value)
+			}
+		}
+		if rawNames == "" || title == "" {
+			continue
+		}
+		for _, rawName := range strings.Split(rawNames, ",") {
+			name := strings.ToLower(strings.TrimSpace(rawName))
+			if name != "" {
+				names[name] = title
+			}
+		}
+	}
+	return names
+}

--- a/pkg/favorites/settings.go
+++ b/pkg/favorites/settings.go
@@ -1,0 +1,268 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"gopkg.in/ini.v1"
+)
+
+//nolint:govet // Field order groups settings by their INI sections.
+type Settings struct {
+	DefaultFolder         string
+	ExternalFolder        string
+	CorePrefix            string
+	FolderNameContains    []string
+	GamesFolders          []string
+	AlternateCore         string
+	Theme                 string
+	CreateDefaultFolder   bool
+	ManageArcadeCoreLinks bool
+	HideRootFiles         bool
+	Mouse                 bool
+	CRTMode               bool
+	OnScreenKeyboard      bool
+}
+
+func SettingsFromConfig(cfg *config.UserConfig) Settings {
+	return Settings{
+		DefaultFolder:         cfg.Favorites.DefaultFolder,
+		ExternalFolder:        cfg.Favorites.ExternalFolder,
+		CorePrefix:            cfg.Favorites.CorePrefix,
+		FolderNameContains:    slices.Clone(cfg.Favorites.FolderNameContains),
+		GamesFolders:          slices.Clone(cfg.Favorites.GamesFolder),
+		AlternateCore:         strings.ToLower(strings.TrimSpace(cfg.FavoritesCores.All)),
+		Theme:                 cfg.TUI.Theme,
+		CreateDefaultFolder:   cfg.Favorites.CreateDefaultFolder,
+		ManageArcadeCoreLinks: cfg.Favorites.ManageArcadeCoreLinks,
+		HideRootFiles:         cfg.Favorites.HideRootFiles,
+		Mouse:                 cfg.TUI.Mouse,
+		CRTMode:               cfg.TUI.CRTMode,
+		OnScreenKeyboard:      cfg.TUI.OnScreenKeyboard,
+	}
+}
+
+func (s *Settings) ApplyTo(cfg *config.UserConfig) {
+	cfg.Favorites.DefaultFolder = s.DefaultFolder
+	cfg.Favorites.ExternalFolder = s.ExternalFolder
+	cfg.Favorites.CorePrefix = s.CorePrefix
+	cfg.Favorites.FolderNameContains = slices.Clone(s.FolderNameContains)
+	cfg.Favorites.GamesFolder = slices.Clone(s.GamesFolders)
+	cfg.FavoritesCores.All = s.AlternateCore
+	cfg.TUI.Theme = s.Theme
+	cfg.Favorites.CreateDefaultFolder = s.CreateDefaultFolder
+	cfg.Favorites.ManageArcadeCoreLinks = s.ManageArcadeCoreLinks
+	cfg.Favorites.HideRootFiles = s.HideRootFiles
+	cfg.TUI.Mouse = s.Mouse
+	cfg.TUI.CRTMode = s.CRTMode
+	cfg.TUI.OnScreenKeyboard = s.OnScreenKeyboard
+}
+
+func (s *Settings) Validate() error {
+	cfg := DefaultUserConfig()
+	s.ApplyTo(cfg)
+	return ValidateConfig(cfg)
+}
+
+func (s *Settings) Equal(other *Settings) bool {
+	return s.DefaultFolder == other.DefaultFolder &&
+		s.ExternalFolder == other.ExternalFolder &&
+		s.CorePrefix == other.CorePrefix &&
+		slices.Equal(s.FolderNameContains, other.FolderNameContains) &&
+		slices.Equal(s.GamesFolders, other.GamesFolders) &&
+		s.AlternateCore == other.AlternateCore &&
+		s.Theme == other.Theme &&
+		s.CreateDefaultFolder == other.CreateDefaultFolder &&
+		s.ManageArcadeCoreLinks == other.ManageArcadeCoreLinks &&
+		s.HideRootFiles == other.HideRootFiles &&
+		s.Mouse == other.Mouse &&
+		s.CRTMode == other.CRTMode &&
+		s.OnScreenKeyboard == other.OnScreenKeyboard
+}
+
+func SaveSettings(path string, settings *Settings) error {
+	if err := settings.Validate(); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("read Favorites configuration for update: %w", err)
+	}
+	file, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true}, data)
+	if err != nil {
+		return fmt.Errorf("load Favorites configuration for update: %w", err)
+	}
+	favoritesSection, err := getOrCreateSection(file, "favorites")
+	if err != nil {
+		return err
+	}
+	setKey(favoritesSection, "default_folder", settings.DefaultFolder)
+	setKey(favoritesSection, "folder_name_contains", strings.Join(settings.FolderNameContains, ","))
+	setKey(favoritesSection, "create_default_folder", formatBool(settings.CreateDefaultFolder))
+	setKey(favoritesSection, "manage_arcade_core_links", formatBool(settings.ManageArcadeCoreLinks))
+	setKey(favoritesSection, "hide_root_files", formatBool(settings.HideRootFiles))
+	setKey(favoritesSection, "external_folder", settings.ExternalFolder)
+	setKey(favoritesSection, "core_prefix", settings.CorePrefix)
+	if shadowErr := setShadowKeys(favoritesSection, "games_folder", settings.GamesFolders); shadowErr != nil {
+		return shadowErr
+	}
+
+	coresSection, err := getOrCreateSection(file, "cores")
+	if err != nil {
+		return err
+	}
+	setKey(coresSection, "all", settings.AlternateCore)
+
+	tuiSection, err := getOrCreateSection(file, "tui")
+	if err != nil {
+		return err
+	}
+	setKey(tuiSection, "theme", settings.Theme)
+	setKey(tuiSection, "mouse", formatBool(settings.Mouse))
+	setKey(tuiSection, "crt_mode", formatBool(settings.CRTMode))
+	setKey(tuiSection, "on_screen_keyboard", formatBool(settings.OnScreenKeyboard))
+
+	if err := retainINIComments(data, file); err != nil {
+		return err
+	}
+	return writeINIAtomically(path, file)
+}
+
+// The INI parser replaces attached comments when loading shadow keys. Keep
+// otherwise lost full-line notes as file comments, even when a key is removed.
+func retainINIComments(original []byte, file *ini.File) error {
+	var rendered strings.Builder
+	if _, err := file.WriteTo(&rendered); err != nil {
+		return fmt.Errorf("render Favorites configuration comments: %w", err)
+	}
+	present := make(map[string]bool)
+	for _, line := range strings.Split(rendered.String(), "\n") {
+		present[strings.TrimSpace(line)] = true
+	}
+	for _, line := range strings.Split(string(original), "\n") {
+		line = strings.TrimSpace(line)
+		if (strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")) && !present[line] {
+			section := file.Section(ini.DefaultSection)
+			section.Comment = strings.TrimSpace(section.Comment + "\n" + line)
+			present[line] = true
+		}
+	}
+	return nil
+}
+
+func getOrCreateSection(file *ini.File, name string) (*ini.Section, error) {
+	section, err := file.GetSection(name)
+	if err == nil {
+		return section, nil
+	}
+	section, err = file.NewSection(name)
+	if err != nil {
+		return nil, fmt.Errorf("create %s configuration section: %w", name, err)
+	}
+	return section, nil
+}
+
+func setKey(section *ini.Section, name, value string) {
+	section.Key(name).SetValue(value)
+}
+
+func setShadowKeys(section *ini.Section, name string, values []string) error {
+	comment := ""
+	if existing, err := section.GetKey(name); err == nil {
+		comment = existing.Comment
+	}
+	section.DeleteKey(name)
+	if len(values) == 0 {
+		// Keep notes on cleared roots without leaving an active empty key.
+		if comment != "" {
+			section.Comment = strings.TrimSpace(section.Comment + "\n" + comment)
+		}
+		return nil
+	}
+	key, err := section.NewKey(name, values[0])
+	if err != nil {
+		return fmt.Errorf("create %s setting: %w", name, err)
+	}
+	key.Comment = comment
+	for _, value := range values[1:] {
+		if err := key.AddShadow(value); err != nil {
+			return fmt.Errorf("add %s setting: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func formatBool(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func writeINIAtomically(path string, file *ini.File) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".favorites-*.ini")
+	if err != nil {
+		return fmt.Errorf("create temporary Favorites configuration: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := file.WriteTo(temporary); err != nil {
+		return fmt.Errorf("write temporary Favorites configuration: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary Favorites configuration: %w", err)
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("set Favorites configuration permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary Favorites configuration: %w", err)
+	}
+	// #nosec G703 -- destination is the explicit Favorites configuration path.
+	if err := os.Rename(temporaryPath, filepath.Clean(path)); err != nil {
+		return fmt.Errorf("replace Favorites configuration: %w", err)
+	}
+	removeTemporary = false
+	return nil
+}
+
+func ParseListSetting(value string) []string {
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}

--- a/pkg/games/paths.go
+++ b/pkg/games/paths.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -75,10 +76,9 @@ func FolderToSystems(cfg *config.UserConfig, path string) []System {
 	gamesFolder := ""
 
 	for _, folder := range GetGamesFolders(cfg) {
-		if strings.HasPrefix(path, strings.ToLower(folder)) {
+		if withinFolder(path, strings.ToLower(folder)) && len(folder) > len(gamesFolder) {
 			validGamesFolder = true
 			gamesFolder = folder
-			break
 		}
 	}
 
@@ -91,13 +91,14 @@ func FolderToSystems(cfg *config.UserConfig, path string) []System {
 		system := Systems[id]
 		for _, folder := range system.Folder {
 			systemPath := strings.ToLower(filepath.Join(gamesFolder, folder))
-			if strings.HasPrefix(path, systemPath) {
+			if withinFolder(path, systemPath) {
 				validSystems = append(validSystems, system)
 				break
 			}
 		}
 	}
 
+	sort.Slice(validSystems, func(i, j int) bool { return validSystems[i].Id < validSystems[j].Id })
 	if strings.HasSuffix(path, "/") {
 		return validSystems
 	}
@@ -115,6 +116,11 @@ func FolderToSystems(cfg *config.UserConfig, path string) []System {
 	}
 
 	return matchedExtensions
+}
+
+func withinFolder(path, folder string) bool {
+	folder = strings.TrimRight(filepath.Clean(folder), string(filepath.Separator))
+	return path == folder || strings.HasPrefix(path, folder+string(filepath.Separator))
 }
 
 func BestSystemMatch(cfg *config.UserConfig, path string) (System, error) {

--- a/pkg/games/systems_test.go
+++ b/pkg/games/systems_test.go
@@ -21,12 +21,30 @@ package games
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/mister/catalog"
+	"github.com/wizzomafizzo/mrext/pkg/config"
 )
+
+func TestFolderMatchingUsesComponentBoundaries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	cfg := &config.UserConfig{Systems: config.SystemsConfig{GamesFolder: []string{root}}}
+	if found := FolderToSystems(cfg, filepath.Join(root+"backup", "GBA", "game.gba")); len(found) != 0 {
+		t.Fatalf("matched sibling root: %#v", found)
+	}
+	if found := FolderToSystems(cfg, filepath.Join(root, "GBAunknown", "game.gba")); len(found) != 0 {
+		t.Fatalf("matched partial system folder: %#v", found)
+	}
+	cfg.Systems.GamesFolder = append(cfg.Systems.GamesFolder, filepath.Join(root, "nested"))
+	found := FolderToSystems(cfg, filepath.Join(root, "nested", "GBA", "game.gba"))
+	if len(found) != 1 || found[0].Id != "GBA" {
+		t.Fatalf("nested root shadowed by parent: %#v", found)
+	}
+}
 
 func TestSystemsUseCatalogOperationalData(t *testing.T) {
 	t.Parallel()

--- a/pkg/tui/button_bar.go
+++ b/pkg/tui/button_bar.go
@@ -1,0 +1,255 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type ButtonBar struct {
+	*tview.Box
+	app             *tview.Application
+	onEscape        func()
+	onUp            func()
+	onDown          func()
+	onWrap          func()
+	onLeft          func()
+	onRight         func()
+	helpCallback    func(string)
+	buttons         []*tview.Button
+	helpTexts       []string
+	focusedIndex    int
+	persistentFocus bool
+}
+
+func NewButtonBar(app *tview.Application) *ButtonBar {
+	return &ButtonBar{Box: tview.NewBox(), app: app}
+}
+
+func (bb *ButtonBar) AddButton(label string, action func()) *ButtonBar {
+	return bb.AddButtonWithHelp(label, "", action)
+}
+
+func (bb *ButtonBar) AddButtonWithHelp(label, helpText string, action func()) *ButtonBar {
+	theme := CurrentTheme()
+	button := tview.NewButton(label).
+		SetStyle(tcell.StyleDefault.
+			Foreground(theme.PrimaryTextColor).
+			Background(theme.ContrastBackgroundColor)).
+		SetActivatedStyle(tcell.StyleDefault.
+			Foreground(tcell.ColorBlack).
+			Background(theme.BorderColor)).
+		SetSelectedFunc(action)
+	bb.buttons = append(bb.buttons, button)
+	bb.helpTexts = append(bb.helpTexts, helpText)
+	return bb
+}
+
+func (bb *ButtonBar) SetHelpCallback(callback func(string)) *ButtonBar {
+	bb.helpCallback = callback
+	return bb
+}
+
+func (bb *ButtonBar) SetPersistentFocus(enabled bool) *ButtonBar {
+	bb.persistentFocus = enabled
+	return bb
+}
+
+func (bb *ButtonBar) SetupNavigation(onEscape func()) *ButtonBar {
+	bb.onEscape = onEscape
+	return bb
+}
+
+func (bb *ButtonBar) SetOnUp(callback func()) *ButtonBar {
+	bb.onUp = callback
+	return bb
+}
+
+func (bb *ButtonBar) SetOnDown(callback func()) *ButtonBar {
+	bb.onDown = callback
+	return bb
+}
+
+func (bb *ButtonBar) SetOnWrap(callback func()) *ButtonBar {
+	bb.onWrap = callback
+	return bb
+}
+
+func (bb *ButtonBar) SetOnLeft(callback func()) *ButtonBar {
+	bb.onLeft = callback
+	return bb
+}
+
+func (bb *ButtonBar) SetOnRight(callback func()) *ButtonBar {
+	bb.onRight = callback
+	return bb
+}
+
+func (bb *ButtonBar) triggerHelp() {
+	if bb.helpCallback != nil && bb.focusedIndex < len(bb.helpTexts) {
+		bb.helpCallback(bb.helpTexts[bb.focusedIndex])
+	}
+}
+
+func (bb *ButtonBar) Draw(screen tcell.Screen) {
+	bb.DrawForSubclass(screen, bb)
+	x, y, width, _ := bb.GetInnerRect()
+	if len(bb.buttons) == 0 || width <= 0 {
+		return
+	}
+
+	spacing := 2
+	buttonWidth := max((width-spacing*(len(bb.buttons)-1))/len(bb.buttons), 6)
+	focused := bb.HasFocus() || bb.persistentFocus
+	currentX := x
+	for index, button := range bb.buttons {
+		widthRemaining := x + width - currentX
+		if widthRemaining <= 0 {
+			break
+		}
+		itemWidth := min(buttonWidth, widthRemaining)
+		button.SetRect(currentX, y, itemWidth, 1)
+		if focused && index == bb.focusedIndex {
+			button.Focus(func(tview.Primitive) {})
+		} else {
+			button.Blur()
+		}
+		button.Draw(screen)
+		currentX += itemWidth + spacing
+	}
+}
+
+func (bb *ButtonBar) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return bb.WrapInputHandler(func(event *tcell.EventKey, setFocus func(tview.Primitive)) {
+		if len(bb.buttons) == 0 {
+			return
+		}
+		switch event.Key() {
+		case tcell.KeyLeft:
+			if bb.focusedIndex == 0 && bb.onLeft != nil {
+				bb.onLeft()
+			} else {
+				bb.focusedIndex = (bb.focusedIndex - 1 + len(bb.buttons)) % len(bb.buttons)
+				bb.triggerHelp()
+			}
+		case tcell.KeyBacktab:
+			if bb.focusedIndex == 0 && bb.onWrap != nil {
+				bb.onWrap()
+			} else {
+				bb.focusedIndex = (bb.focusedIndex - 1 + len(bb.buttons)) % len(bb.buttons)
+				bb.triggerHelp()
+			}
+		case tcell.KeyRight:
+			if bb.focusedIndex == len(bb.buttons)-1 && bb.onRight != nil {
+				bb.onRight()
+			} else {
+				bb.focusedIndex = (bb.focusedIndex + 1) % len(bb.buttons)
+				bb.triggerHelp()
+			}
+		case tcell.KeyTab:
+			if bb.focusedIndex == len(bb.buttons)-1 && bb.onWrap != nil {
+				bb.onWrap()
+			} else {
+				bb.focusedIndex = (bb.focusedIndex + 1) % len(bb.buttons)
+				bb.triggerHelp()
+			}
+		case tcell.KeyUp:
+			if bb.onUp != nil {
+				bb.onUp()
+			}
+		case tcell.KeyDown:
+			if bb.onDown != nil {
+				bb.onDown()
+			} else if bb.onUp != nil {
+				bb.onUp()
+			}
+		case tcell.KeyEnter:
+			if handler := bb.buttons[bb.focusedIndex].InputHandler(); handler != nil {
+				handler(event, setFocus)
+			}
+		case tcell.KeyEscape:
+			if bb.onEscape != nil {
+				bb.onEscape()
+			}
+		default:
+		}
+	})
+}
+
+func (bb *ButtonBar) MouseHandler() func(
+	tview.MouseAction,
+	*tcell.EventMouse,
+	func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return bb.WrapMouseHandler(func(
+		action tview.MouseAction,
+		event *tcell.EventMouse,
+		setFocus func(tview.Primitive),
+	) (bool, tview.Primitive) {
+		for index, button := range bb.buttons {
+			if !button.InRect(event.Position()) {
+				continue
+			}
+			bb.focusedIndex = index
+			bb.triggerHelp()
+			if !bb.persistentFocus {
+				setFocus(bb)
+			}
+			if action == tview.MouseLeftClick {
+				if handler := button.MouseHandler(); handler != nil {
+					buttonFocus := setFocus
+					if bb.persistentFocus {
+						buttonFocus = func(tview.Primitive) {}
+					}
+					return handler(action, event, buttonFocus)
+				}
+			}
+			return action == tview.MouseLeftDown, nil
+		}
+		return false, nil
+	})
+}
+
+func (bb *ButtonBar) Focus(delegate func(tview.Primitive)) {
+	if len(bb.buttons) > 0 {
+		bb.Box.Focus(delegate)
+		bb.triggerHelp()
+	}
+}
+
+func (bb *ButtonBar) HasFocus() bool {
+	return bb.Box.HasFocus()
+}
+
+func (bb *ButtonBar) GetFirstButton() *tview.Button {
+	if len(bb.buttons) == 0 {
+		return nil
+	}
+	return bb.buttons[0]
+}
+
+func (bb *ButtonBar) UpdateButtonLabel(index int, label string) {
+	if index >= 0 && index < len(bb.buttons) {
+		bb.buttons[index].SetLabel(label)
+	}
+}

--- a/pkg/tui/choice.go
+++ b/pkg/tui/choice.go
@@ -1,0 +1,79 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import "github.com/rivo/tview"
+
+type Choice struct {
+	Label string
+	Help  string
+}
+
+// ShowChoiceModal selects a value without applying changes on cancellation.
+func ShowChoiceModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	title string,
+	choices []Choice,
+	selected int,
+	onSelect func(int),
+	onCancel func(),
+) {
+	const page = "tui_choice_modal"
+	list := NewMenuList()
+	for _, choice := range choices {
+		list.AddRow(choice.Label, MenuRowItem)
+	}
+	list.SetCurrentItem(selected)
+	cancel := func() {
+		pages.RemovePage(page)
+		if onCancel != nil {
+			onCancel()
+		}
+	}
+	selectChoice := func() {
+		index := list.GetCurrentItem()
+		if index < 0 || index >= len(choices) {
+			return
+		}
+		pages.RemovePage(page)
+		onSelect(index)
+	}
+	bar := NewButtonBar(app).
+		AddButton("Select", selectChoice).
+		AddButton("Cancel", cancel).
+		SetupNavigation(cancel)
+	frame := NewPageFrame(app).
+		SetTitle(title).
+		SetContent(list).
+		SetButtonBar(bar).
+		SetOnEscape(cancel)
+	help := func(index int) {
+		if index >= 0 && index < len(choices) {
+			frame.SetHelpText(choices[index].Help)
+		}
+	}
+	list.SetRowChangedFunc(help)
+	help(list.GetCurrentItem())
+	list.SetSelectedFunc(func(int, string, string, rune) { selectChoice() })
+	frame.SetupContentToButtonNavigation()
+	pages.AddPage(page, Centered(69, min(len(choices)+4, 13), frame), true, true)
+	app.SetFocus(list)
+}

--- a/pkg/tui/components.go
+++ b/pkg/tui/components.go
@@ -49,7 +49,7 @@ func Centered(width, height int, primitive tview.Primitive) tview.Primitive {
 		AddItem(nil, 0, 1, false)
 }
 
-func ButtonBar(buttons []string, selected int) string {
+func ButtonLabels(buttons []string, selected int) string {
 	parts := make([]string, len(buttons))
 	for i, button := range buttons {
 		label := "< " + tview.Escape(button) + " >"
@@ -81,7 +81,7 @@ func ListPicker(opts *ListPickerOpts, items []string) (button, item int, err err
 
 		footer := tview.NewTextView().SetDynamicColors(true).SetTextAlign(tview.AlignCenter)
 		drawFooter := func() {
-			text := ButtonBar(opts.Buttons, selectedButton)
+			text := ButtonLabels(opts.Buttons, selectedButton)
 			if opts.ShowTotal && len(items) > 0 {
 				text = fmt.Sprintf("%d/%d    %s", list.GetCurrentItem()+1, len(items), text)
 			}

--- a/pkg/tui/dialog.go
+++ b/pkg/tui/dialog.go
@@ -1,0 +1,210 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	dialogChromeWidth = 4
+	dialogMargin      = 2
+)
+
+type Dialog struct {
+	*tview.Box
+	frame    *tview.Box
+	textView *tview.TextView
+	form     *tview.Form
+	done     func(int)
+	text     string
+	buttons  []string
+}
+
+func NewDialog() *Dialog {
+	theme := CurrentTheme()
+	dialog := &Dialog{
+		Box: tview.NewBox(),
+		frame: tview.NewBox().
+			SetBackgroundColor(tview.Styles.ContrastBackgroundColor),
+		textView: tview.NewTextView().
+			SetDynamicColors(true).
+			SetWrap(true).
+			SetWordWrap(true).
+			SetTextAlign(tview.AlignCenter),
+		form: tview.NewForm().
+			SetButtonsAlign(tview.AlignCenter).
+			SetButtonBackgroundColor(tview.Styles.PrimitiveBackgroundColor).
+			SetButtonTextColor(tview.Styles.PrimaryTextColor),
+	}
+	dialog.frame.SetBorder(true).
+		SetBorderColor(theme.BorderColor).
+		SetTitleColor(theme.BorderColor).
+		SetTitleAlign(tview.AlignCenter)
+	dialog.textView.SetBackgroundColor(tview.Styles.ContrastBackgroundColor)
+	dialog.textView.SetTextColor(theme.PrimaryTextColor)
+	dialog.form.SetBackgroundColor(tview.Styles.ContrastBackgroundColor)
+	dialog.form.SetBorderPadding(0, 0, 0, 0)
+	dialog.form.SetCancelFunc(func() {
+		if dialog.done != nil {
+			dialog.done(-1)
+		}
+	})
+	return dialog
+}
+
+func (d *Dialog) SetText(text string) *Dialog {
+	d.text = text
+	d.textView.SetText(text)
+	return d
+}
+
+func (d *Dialog) SetTextAlign(align int) *Dialog {
+	d.textView.SetTextAlign(align)
+	return d
+}
+
+func (d *Dialog) SetTitle(title string) *Dialog {
+	d.frame.SetTitle(" " + title + " ")
+	return d
+}
+
+func (d *Dialog) SetAccentColor(color tcell.Color) *Dialog {
+	d.frame.SetBorderColor(color).SetTitleColor(color)
+	return d
+}
+
+func (d *Dialog) AddButtons(labels []string) *Dialog {
+	for index, label := range labels {
+		buttonIndex := index
+		d.buttons = append(d.buttons, label)
+		d.form.AddButton(label, func() {
+			if d.done != nil {
+				d.done(buttonIndex)
+			}
+		})
+		button := d.form.GetButton(d.form.GetButtonCount() - 1)
+		button.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyDown, tcell.KeyRight:
+				return tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+			case tcell.KeyUp, tcell.KeyLeft:
+				return tcell.NewEventKey(tcell.KeyBacktab, 0, tcell.ModNone)
+			default:
+				return event
+			}
+		})
+	}
+	return d
+}
+
+func (d *Dialog) SetDoneFunc(handler func(int)) *Dialog {
+	d.done = handler
+	return d
+}
+
+func (d *Dialog) contentWidth() int {
+	width := 0
+	for _, label := range d.buttons {
+		width += tview.TaggedStringWidth(label) + 6
+	}
+	if width > 0 {
+		width -= 2
+	}
+	for _, line := range strings.Split(d.text, "\n") {
+		width = max(width, tview.TaggedStringWidth(line))
+	}
+	return max(width, tview.TaggedStringWidth(d.frame.GetTitle()))
+}
+
+func (d *Dialog) Draw(screen tcell.Screen) {
+	x, y, width, height := d.GetInnerRect()
+	if width < 1 || height < 1 {
+		return
+	}
+
+	dialogWidth := min(d.contentWidth()+dialogChromeWidth, width-dialogMargin)
+	textWidth := max(dialogWidth-dialogChromeWidth, 1)
+	dialogWidth = textWidth + dialogChromeWidth
+	buttonRows := 0
+	if len(d.buttons) > 0 {
+		buttonRows = 2
+	}
+	dialogHeight := min(len(tview.WordWrap(d.text, textWidth))+buttonRows+2, height)
+
+	d.frame.SetRect(x+(width-dialogWidth)/2, y+(height-dialogHeight)/2, dialogWidth, dialogHeight)
+	d.frame.Draw(screen)
+
+	innerX, innerY, innerWidth, innerHeight := d.frame.GetInnerRect()
+	if textHeight := innerHeight - buttonRows; textHeight > 0 {
+		d.textView.SetRect(innerX+1, innerY, max(innerWidth-2, 1), textHeight)
+		d.textView.Draw(screen)
+	}
+	if buttonRows > 0 && innerHeight > 0 {
+		d.form.SetRect(innerX, innerY+innerHeight-1, innerWidth, 1)
+		d.form.Draw(screen)
+	}
+}
+
+func (d *Dialog) Focus(delegate func(tview.Primitive)) {
+	if len(d.buttons) > 0 {
+		delegate(d.form)
+		return
+	}
+	d.Box.Focus(delegate)
+}
+
+func (d *Dialog) HasFocus() bool {
+	return d.form.HasFocus() || d.Box.HasFocus()
+}
+
+func (d *Dialog) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(tview.Primitive)) {
+		if d.form.HasFocus() {
+			if handler := d.form.InputHandler(); handler != nil {
+				handler(event, setFocus)
+			}
+		}
+	})
+}
+
+func (d *Dialog) MouseHandler() func(
+	tview.MouseAction,
+	*tcell.EventMouse,
+	func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return d.WrapMouseHandler(func(
+		action tview.MouseAction,
+		event *tcell.EventMouse,
+		setFocus func(tview.Primitive),
+	) (bool, tview.Primitive) {
+		consumed, capture := d.form.MouseHandler()(action, event, setFocus)
+		if !consumed && action == tview.MouseLeftDown && d.InRect(event.Position()) {
+			setFocus(d)
+			consumed = true
+		}
+		return consumed, capture
+	})
+}

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -1,0 +1,282 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestKeyboardModalMatchesCompactZaparooLayout(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	ShowInputModal(pages, app, InputOptions{
+		Title: "Name", Prompt: "Floating prompt must not appear", OnScreenKeyboard: true,
+	}, func(string) {}, func() {})
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	pages.SetRect(0, 0, 75, 15)
+	pages.Draw(screen)
+	keyboard, ok := app.GetFocus().(*VirtualKeyboard)
+	if !ok {
+		t.Fatal("keyboard not focused")
+	}
+	_, _, width, height := keyboard.GetRect()
+	if width != 41 || height != 8 {
+		t.Fatalf("keyboard size = %dx%d", width, height)
+	}
+	var text strings.Builder
+	for y := range 15 {
+		for x := range 75 {
+			value, _, _ := screen.Get(x, y)
+			_, _ = text.WriteString(value)
+		}
+	}
+	if strings.Contains(text.String(), "Floating prompt") || !strings.Contains(text.String(), "SPC") {
+		t.Fatalf("unexpected keyboard rendering: %s", text.String())
+	}
+}
+
+func TestChoiceModalPreservesSelectionOnCancel(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	selected, cancelled := -1, false
+	ShowChoiceModal(pages, app, "Core", []Choice{{Label: "Standard"}, {Label: "LLAPI"}, {Label: "YC"}},
+		1, func(index int) { selected = index }, func() { cancelled = true })
+	list, ok := app.GetFocus().(*MenuList)
+	if !ok || list.GetCurrentItem() != 1 {
+		t.Fatal("picker did not preselect current value")
+	}
+	list.InputHandler()(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), nil)
+	list.InputHandler()(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone), nil)
+	if selected != -1 || !cancelled || pages.HasPage("tui_choice_modal") {
+		t.Fatal("cancel committed choice or left modal open")
+	}
+}
+
+func TestSelectedRowsRenderPlainBlackAcrossThemes(t *testing.T) {
+	t.Cleanup(func() { SetCurrentTheme("default") })
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	for _, name := range ThemeNames {
+		SetCurrentTheme(name)
+		menu := NewMenuList().AddRow("Selected", MenuRowItem)
+		menu.SetRect(0, 0, 75, 1)
+		menu.Draw(screen)
+		_, style, _ := screen.Get(2, 0)
+		foreground, _, attributes := style.Decompose()
+		if foreground != tcell.ColorBlack || attributes&tcell.AttrBold != 0 {
+			t.Fatalf("theme %s selected style = %v", name, style)
+		}
+	}
+}
+
+func TestMenuListPagingSkipsHeaders(t *testing.T) {
+	for _, height := range []int{2, 11, 30} {
+		menu := NewMenuList().AddHeader("Start")
+		for index := range 24 {
+			if index%4 == 0 {
+				menu.AddHeader("Section")
+			} else {
+				menu.AddRow(strconv.Itoa(index), MenuRowItem)
+			}
+		}
+		menu.AddHeader("End")
+		menu.SetRect(0, 0, 75, height)
+		handle := menu.InputHandler()
+		for _, key := range []tcell.Key{tcell.KeyPgDn, tcell.KeyPgUp} {
+			for range 30 {
+				handle(tcell.NewEventKey(key, 0, tcell.ModNone), nil)
+				index := menu.GetCurrentItem()
+				if !menu.selectable(index) || menu.selected != index {
+					t.Fatalf("height=%d key=%v row=%d highlight=%d", height, key, index, menu.selected)
+				}
+			}
+		}
+	}
+}
+
+func TestMenuListBuildAllocationGrowthIsLinear(t *testing.T) {
+	allocations := func(count int) float64 {
+		return testing.AllocsPerRun(2, func() {
+			menu := NewMenuList()
+			for range count {
+				menu.AddRow("Game (USA)", MenuRowItem)
+			}
+		})
+	}
+	small, large := allocations(200), allocations(800)
+	if large > small*5 {
+		t.Fatalf("superlinear menu allocation growth: 200=%f 800=%f", small, large)
+	}
+}
+
+func BenchmarkMenuListBuild(b *testing.B) {
+	for _, count := range []int{1000, 3000, 6000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				menu := NewMenuList()
+				for range count {
+					menu.AddRow("Super Mario World (USA) [Rev 1].sfc", MenuRowItem)
+				}
+			}
+		})
+	}
+}
+
+func TestNewApplicationAppliesTheme(t *testing.T) {
+	app, err := NewApplication(ApplicationOptions{Theme: "nord", Mouse: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app == nil || CurrentTheme().Name != "nord" {
+		t.Fatalf("application=%v theme=%q", app, CurrentTheme().Name)
+	}
+	if _, err := NewApplication(ApplicationOptions{Theme: "missing"}); err == nil {
+		t.Fatal("unknown theme accepted")
+	}
+	if !SetCurrentTheme("default") {
+		t.Fatal("failed to restore default theme")
+	}
+}
+
+func TestVirtualKeyboardSupportsModesAndInput(t *testing.T) {
+	submitted := ""
+	cancelled := false
+	keyboard := NewVirtualKeyboard("fav", func(text string) {
+		submitted = text
+	}, func() {
+		cancelled = true
+	})
+	handle := keyboard.InputHandler()
+	handle(tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone), nil)
+	if keyboard.layout()[keyboard.cursorRow][keyboard.cursorCol] != keyboardSubmit {
+		t.Fatal("keyboard must start on OK")
+	}
+	handle(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), nil)
+	if submitted != "favs" {
+		t.Fatalf("submitted text = %q", submitted)
+	}
+	handle(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone), nil)
+	if !cancelled {
+		t.Fatal("escape did not cancel")
+	}
+}
+
+func TestMenuListStylesAndSkipsHeaders(t *testing.T) {
+	if !SetCurrentTheme("default") {
+		t.Fatal("failed to select default theme")
+	}
+	menu := NewMenuList().
+		AddRow("Add favorite", MenuRowAdd).
+		AddHeader("Existing favorites").
+		AddRow("_@Favorites/SNES/Zelda", MenuRowItem)
+	if menu.GetCurrentItem() != 0 {
+		t.Fatalf("initial row = %d", menu.GetCurrentItem())
+	}
+	handle := menu.InputHandler()
+	handle(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), func(tview.Primitive) {})
+	if menu.GetCurrentItem() != 2 {
+		t.Fatalf("down selected header: row=%d", menu.GetCurrentItem())
+	}
+	handle(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone), func(tview.Primitive) {})
+	if menu.GetCurrentItem() != 0 {
+		t.Fatalf("up selected header: row=%d", menu.GetCurrentItem())
+	}
+	selected, _ := menu.GetItemText(0)
+	header, _ := menu.GetItemText(1)
+	if !strings.Contains(selected, "[black:yellow:-]") || !strings.Contains(header, "[gray:darkblue:b]") {
+		t.Fatalf("safe palette formatting missing: selected=%q header=%q", selected, header)
+	}
+}
+
+func TestListAndButtonBarUseIndependentAxes(t *testing.T) {
+	app, err := NewApplication(ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := ""
+	list := tview.NewList().ShowSecondaryText(false).
+		AddItem("First row", "", 0, nil).
+		AddItem("Second row", "", 0, nil)
+	bar := NewButtonBar(app).
+		AddButton("Select", func() { selected = "select" }).
+		AddButton("Cancel", func() { selected = "cancel" })
+	frame := NewPageFrame(app).
+		SetContent(list).
+		SetButtonBar(bar)
+	frame.SetupContentToButtonNavigation()
+	app.SetFocus(list)
+	handle := frame.InputHandler()
+	setFocus := func(primitive tview.Primitive) { app.SetFocus(primitive) }
+
+	handle(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone), setFocus)
+	if list.GetCurrentItem() != 1 || !list.HasFocus() {
+		t.Fatalf("down changed focus or failed to select row: row=%d focus=%v", list.GetCurrentItem(), list.HasFocus())
+	}
+	handle(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone), setFocus)
+	if list.GetCurrentItem() != 1 || !list.HasFocus() || bar.focusedIndex != 1 {
+		t.Fatalf(
+			"right changed row or focus: row=%d focus=%v button=%d",
+			list.GetCurrentItem(),
+			list.HasFocus(),
+			bar.focusedIndex,
+		)
+	}
+	handle(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), setFocus)
+	if selected != "cancel" {
+		t.Fatalf("selected button = %q", selected)
+	}
+	if !bar.persistentFocus {
+		t.Fatal("button bar is not persistently highlighted")
+	}
+}
+
+func TestButtonBarNavigationAndActivation(t *testing.T) {
+	app, err := NewApplication(ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := ""
+	bar := NewButtonBar(app).
+		AddButton("First", func() { selected = "first" }).
+		AddButton("Second", func() { selected = "second" })
+	bar.Focus(func(tview.Primitive) {})
+	handle := bar.InputHandler()
+	setFocus := func(primitive tview.Primitive) { app.SetFocus(primitive) }
+	handle(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone), setFocus)
+	handle(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), setFocus)
+	if selected != "second" {
+		t.Fatalf("selected = %q", selected)
+	}
+}

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -280,3 +280,78 @@ func TestButtonBarNavigationAndActivation(t *testing.T) {
 		t.Fatalf("selected = %q", selected)
 	}
 }
+
+func TestModalDismissalRestoresPageFocus(t *testing.T) {
+	type harness struct {
+		app   *tview.Application
+		pages *tview.Pages
+		root  tview.Primitive
+		list  *MenuList
+	}
+	newHarness := func(t *testing.T) harness {
+		t.Helper()
+		app := tview.NewApplication()
+		pages := tview.NewPages()
+		list := NewMenuList().AddRow("Item", MenuRowItem)
+		frame := NewPageFrame(app).SetTitle("Main").SetContent(list).SetFocusTarget(list)
+		pages.AddAndSwitchToPage("main", frame, true)
+		root := WrapRoot(ApplicationOptions{}, pages)
+		app.SetRoot(root, true)
+		if app.GetFocus() != list {
+			t.Fatalf("initial focus = %T", app.GetFocus())
+		}
+		return harness{app: app, pages: pages, root: root, list: list}
+	}
+	press := func(h harness, keys ...tcell.Key) {
+		setFocus := func(p tview.Primitive) { h.app.SetFocus(p) }
+		for _, key := range keys {
+			h.root.InputHandler()(tcell.NewEventKey(key, 0, tcell.ModNone), setFocus)
+		}
+	}
+	cases := []struct {
+		show func(h harness, done *bool)
+		name string
+		page string
+		keys []tcell.Key
+	}{
+		{func(h harness, done *bool) {
+			ShowInfoModal(h.pages, h.app, "Title", "Message", func() { *done = true })
+		}, "info", infoModalPage, []tcell.Key{tcell.KeyEnter}},
+		{func(h harness, done *bool) {
+			ShowErrorModal(h.pages, h.app, "Message", func() { *done = true })
+		}, "error", errorModalPage, []tcell.Key{tcell.KeyEnter}},
+		{func(h harness, done *bool) {
+			ShowConfirmModal(h.pages, h.app, "Title", "Message", func() { *done = true }, nil)
+		}, "confirm yes", confirmModalPage, []tcell.Key{tcell.KeyEnter}},
+		{func(h harness, done *bool) {
+			ShowConfirmModal(h.pages, h.app, "Title", "Message", nil, func() { *done = true })
+		}, "confirm escape", confirmModalPage, []tcell.Key{tcell.KeyEscape}},
+		{func(h harness, done *bool) {
+			ShowInputModal(h.pages, h.app, InputOptions{Title: "Name"}, func(string) { *done = true }, nil)
+		}, "input submit", inputModalPage, []tcell.Key{tcell.KeyEnter, tcell.KeyEnter}},
+		{func(h harness, done *bool) {
+			ShowInputModal(h.pages, h.app, InputOptions{Title: "Name"}, nil, func() { *done = true })
+		}, "input escape", inputModalPage, []tcell.Key{tcell.KeyEscape}},
+		{func(h harness, done *bool) {
+			options := InputOptions{Title: "Name", OnScreenKeyboard: true}
+			ShowInputModal(h.pages, h.app, options, nil, func() { *done = true })
+		}, "keyboard escape", inputModalPage, []tcell.Key{tcell.KeyEscape}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			done := false
+			tc.show(h, &done)
+			if !h.pages.HasPage(tc.page) || h.app.GetFocus() == h.list {
+				t.Fatal("modal did not open or take focus")
+			}
+			press(h, tc.keys...)
+			if !done || h.pages.HasPage(tc.page) {
+				t.Fatal("modal did not dismiss")
+			}
+			if !h.root.HasFocus() || h.app.GetFocus() != h.list {
+				t.Fatalf("focus after dismissal = %T", h.app.GetFocus())
+			}
+		})
+	}
+}

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -1,0 +1,103 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	DefaultMaxWidth  = 100
+	DefaultMaxHeight = 30
+	CRTWidth         = 75
+	CRTHeight        = 15
+)
+
+type ApplicationOptions struct {
+	Theme            string
+	Mouse            bool
+	CRTMode          bool
+	OnScreenKeyboard bool
+}
+
+func NewApplication(options ApplicationOptions) (*tview.Application, error) {
+	if !SetCurrentTheme(options.Theme) {
+		return nil, fmt.Errorf("unknown TUI theme: %s", options.Theme)
+	}
+	app := tview.NewApplication()
+	app.EnableMouse(options.Mouse)
+	return app, nil
+}
+
+func WrapRoot(options ApplicationOptions, primitive tview.Primitive) tview.Primitive {
+	if options.CRTMode {
+		return Centered(CRTWidth, CRTHeight, primitive)
+	}
+	return ResponsiveMaxWidget(DefaultMaxWidth, DefaultMaxHeight, primitive)
+}
+
+type responsiveWrapper struct {
+	*tview.Box
+	child     tview.Primitive
+	maxWidth  int
+	maxHeight int
+}
+
+func ResponsiveMaxWidget(maxWidth, maxHeight int, primitive tview.Primitive) tview.Primitive {
+	return &responsiveWrapper{
+		Box:       tview.NewBox(),
+		child:     primitive,
+		maxWidth:  maxWidth,
+		maxHeight: maxHeight,
+	}
+}
+
+func (r *responsiveWrapper) Draw(screen tcell.Screen) {
+	x, y, width, height := r.GetInnerRect()
+	actualWidth := min(width, r.maxWidth)
+	actualHeight := min(height, r.maxHeight)
+	r.child.SetRect(x+(width-actualWidth)/2, y+(height-actualHeight)/2, actualWidth, actualHeight)
+	r.child.Draw(screen)
+}
+
+func (r *responsiveWrapper) Focus(delegate func(tview.Primitive)) {
+	delegate(r.child)
+}
+
+func (r *responsiveWrapper) HasFocus() bool {
+	return r.child.HasFocus()
+}
+
+func (r *responsiveWrapper) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return r.child.InputHandler()
+}
+
+func (r *responsiveWrapper) MouseHandler() func(
+	tview.MouseAction,
+	*tcell.EventMouse,
+	func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return r.child.MouseHandler()
+}

--- a/pkg/tui/menu_list.go
+++ b/pkg/tui/menu_list.go
@@ -1,0 +1,237 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type MenuRowKind int
+
+const (
+	MenuRowItem MenuRowKind = iota
+	MenuRowFolder
+	MenuRowAction
+	MenuRowAdd
+	MenuRowHeader
+)
+
+type menuRow struct {
+	label string
+	kind  MenuRowKind
+}
+
+type MenuList struct {
+	*tview.List
+	onRowChanged func(int)
+	rows         []menuRow
+	selected     int
+}
+
+func NewMenuList() *MenuList {
+	list := tview.NewList().ShowSecondaryText(false)
+	list.SetWrapAround(false)
+	list.SetHighlightFullLine(false)
+	list.SetSelectedStyle(tcell.StyleDefault)
+	list.SetMainTextStyle(tcell.StyleDefault)
+	list.SetMainTextColor(CurrentTheme().PrimaryTextColor)
+	menu := &MenuList{List: list, selected: -1}
+	list.SetChangedFunc(func(index int, _, _ string, _ rune) {
+		if menu.selectable(index) {
+			previous := menu.selected
+			menu.selected = index
+			menu.refreshRow(previous)
+			menu.refreshRow(index)
+			if menu.onRowChanged != nil {
+				menu.onRowChanged(index)
+			}
+		}
+	})
+	list.SetInputCapture(menu.captureInput)
+	return menu
+}
+
+func (m *MenuList) AddRow(label string, kind MenuRowKind) *MenuList {
+	row := menuRow{label: label, kind: kind}
+	m.rows = append(m.rows, row)
+	m.AddItem(formatMenuRow(row, false), "", 0, nil)
+	if m.selected < 0 && kind != MenuRowHeader {
+		m.List.SetCurrentItem(len(m.rows) - 1)
+	}
+	return m
+}
+
+func (m *MenuList) AddHeader(label string) *MenuList {
+	return m.AddRow(label, MenuRowHeader)
+}
+
+// SetRowChangedFunc adds a notification without replacing selection styling.
+func (m *MenuList) SetRowChangedFunc(callback func(int)) *MenuList {
+	m.onRowChanged = callback
+	return m
+}
+
+func (m *MenuList) NavigationList() *tview.List {
+	return m.List
+}
+
+func (m *MenuList) SetCurrentItem(index int) *MenuList {
+	if !m.selectable(index) {
+		if target := m.scanSelectable(index, 1); target >= 0 {
+			index = target
+		} else if target := m.scanSelectable(index, -1); target >= 0 {
+			index = target
+		} else {
+			return m
+		}
+	}
+	m.List.SetCurrentItem(index)
+	return m
+}
+
+func (m *MenuList) MouseHandler() func(
+	tview.MouseAction,
+	*tcell.EventMouse,
+	func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return m.WrapMouseHandler(func(
+		action tview.MouseAction,
+		event *tcell.EventMouse,
+		setFocus func(tview.Primitive),
+	) (bool, tview.Primitive) {
+		if action == tview.MouseLeftDown || action == tview.MouseLeftClick {
+			_, top, _, height := m.GetInnerRect()
+			_, mouseY := event.Position()
+			if mouseY >= top && mouseY < top+height {
+				itemOffset, _ := m.GetOffset()
+				if !m.selectable(itemOffset + mouseY - top) {
+					return true, nil
+				}
+			}
+		}
+		return m.List.MouseHandler()(action, event, setFocus)
+	})
+}
+
+func (m *MenuList) selectable(index int) bool {
+	return index >= 0 && index < len(m.rows) && m.rows[index].kind != MenuRowHeader
+}
+
+func (m *MenuList) scanSelectable(start, direction int) int {
+	for index := start; index >= 0 && index < len(m.rows); index += direction {
+		if m.selectable(index) {
+			return index
+		}
+	}
+	return -1
+}
+
+func (m *MenuList) captureInput(event *tcell.EventKey) *tcell.EventKey {
+	switch event.Key() {
+	case tcell.KeyUp:
+		if target := m.scanSelectable(m.GetCurrentItem()-1, -1); target >= 0 {
+			m.List.SetCurrentItem(target)
+		}
+		return nil
+	case tcell.KeyDown:
+		if target := m.scanSelectable(m.GetCurrentItem()+1, 1); target >= 0 {
+			m.List.SetCurrentItem(target)
+		}
+		return nil
+	case tcell.KeyPgUp, tcell.KeyPgDn:
+		_, _, _, height := m.GetInnerRect()
+		direction := 1
+		if event.Key() == tcell.KeyPgUp {
+			direction = -1
+		}
+		start := max(0, min(m.GetCurrentItem()+direction*max(height, 1), len(m.rows)-1))
+		target := m.scanSelectable(start, direction)
+		if target < 0 {
+			target = m.scanSelectable(start, -direction)
+		}
+		if target >= 0 {
+			m.List.SetCurrentItem(target)
+		}
+		return nil
+	case tcell.KeyHome:
+		if target := m.scanSelectable(0, 1); target >= 0 {
+			m.List.SetCurrentItem(target)
+		}
+		return nil
+	case tcell.KeyEnd:
+		if target := m.scanSelectable(len(m.rows)-1, -1); target >= 0 {
+			m.List.SetCurrentItem(target)
+		}
+		return nil
+	default:
+		return event
+	}
+}
+
+func (m *MenuList) refreshRow(index int) {
+	if index >= 0 && index < len(m.rows) {
+		m.SetItemText(index, formatMenuRow(m.rows[index], index == m.selected), "")
+	}
+}
+
+func formatMenuRow(row menuRow, selected bool) string {
+	theme := CurrentTheme()
+	label := tview.Escape(row.label)
+	if row.kind == MenuRowHeader {
+		return fmt.Sprintf("[%s:%s:b]-- %s --[-:-:-]", theme.SecondaryName, theme.BackgroundName, label)
+	}
+
+	prefix := "  "
+	switch row.kind {
+	case MenuRowFolder, MenuRowAction:
+		prefix = "> "
+	case MenuRowAdd:
+		prefix = "+ "
+	case MenuRowItem, MenuRowHeader:
+	}
+	if selected {
+		return fmt.Sprintf(
+			"[%s:%s:b]%s[%s:%s:-]%s[-:-:-]",
+			theme.AccentName,
+			theme.BackgroundName,
+			prefix,
+			theme.HighlightForegroundName,
+			theme.HighlightBackgroundName,
+			label,
+		)
+	}
+	attributes := ""
+	if row.kind == MenuRowAction || row.kind == MenuRowAdd {
+		attributes = "b"
+	}
+	return fmt.Sprintf(
+		"[%s:%s:%s]%s[%s:%s]%s[-:-:-]",
+		theme.AccentName,
+		theme.BackgroundName,
+		attributes,
+		prefix,
+		theme.TextName,
+		theme.BackgroundName,
+		label,
+	)
+}

--- a/pkg/tui/modals.go
+++ b/pkg/tui/modals.go
@@ -1,0 +1,173 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	infoModalPage    = "tui_info_modal"
+	errorModalPage   = "tui_error_modal"
+	confirmModalPage = "tui_confirm_modal"
+	inputModalPage   = "tui_input_modal"
+)
+
+func ShowInfoModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	title, message string,
+	onDismiss func(),
+) {
+	showMessageModal(pages, app, infoModalPage, title, message, CurrentTheme().BorderColor, onDismiss)
+}
+
+func ShowErrorModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	message string,
+	onDismiss func(),
+) {
+	showMessageModal(pages, app, errorModalPage, "Error", message, CurrentTheme().ErrorColor, onDismiss)
+}
+
+func showMessageModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	page, title, message string,
+	accent tcell.Color,
+	onDismiss func(),
+) {
+	dialog := NewDialog().
+		SetTitle(title).
+		SetAccentColor(accent).
+		SetText(message).
+		AddButtons([]string{"OK"}).
+		SetDoneFunc(func(int) {
+			pages.RemovePage(page)
+			if onDismiss != nil {
+				onDismiss()
+			}
+		})
+	pages.AddPage(page, dialog, true, true)
+	app.SetFocus(dialog)
+}
+
+func ShowConfirmModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	title, message string,
+	onYes, onNo func(),
+) {
+	dialog := NewDialog().
+		SetTitle(title).
+		SetText(message).
+		AddButtons([]string{"Yes", "No"}).
+		SetDoneFunc(func(button int) {
+			pages.RemovePage(confirmModalPage)
+			if button == 0 {
+				if onYes != nil {
+					onYes()
+				}
+				return
+			}
+			if onNo != nil {
+				onNo()
+			}
+		})
+	pages.AddPage(confirmModalPage, dialog, true, true)
+	app.SetFocus(dialog)
+}
+
+//nolint:govet // Field order keeps textual options readable at call sites.
+type InputOptions struct {
+	Title            string
+	Prompt           string
+	InitialValue     string
+	OnScreenKeyboard bool
+	Validate         func(string) error
+}
+
+func ShowInputModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	options InputOptions,
+	onSubmit func(string),
+	onCancel func(),
+) {
+	cleanup := func() {
+		pages.RemovePage(inputModalPage)
+	}
+	submit := func(value string) {
+		if options.Validate != nil {
+			if err := options.Validate(value); err != nil {
+				options.InitialValue = value
+				ShowErrorModal(pages, app, err.Error(), func() {
+					ShowInputModal(pages, app, options, onSubmit, onCancel)
+				})
+				return
+			}
+		}
+		cleanup()
+		if onSubmit != nil {
+			onSubmit(value)
+		}
+	}
+	cancel := func() {
+		cleanup()
+		if onCancel != nil {
+			onCancel()
+		}
+	}
+
+	if options.OnScreenKeyboard {
+		keyboard := NewVirtualKeyboard(options.InitialValue, submit, cancel)
+		keyboard.SetTitle(" " + options.Title + " ")
+		pages.AddPage(inputModalPage, Centered(41, 8, keyboard), true, true)
+		app.SetFocus(keyboard)
+		return
+	}
+
+	input := tview.NewInputField().
+		SetText(options.InitialValue).
+		SetFieldBackgroundColor(CurrentTheme().FieldFocusedBackground)
+	form := tview.NewForm().
+		AddFormItem(input).
+		AddButton("Save", func() { submit(input.GetText()) }).
+		AddButton("Cancel", cancel)
+	form.SetBorder(true).SetTitle(" " + options.Title + " ")
+	form.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEscape {
+			cancel()
+			return nil
+		}
+		return event
+	})
+	content := tview.NewFlex().SetDirection(tview.FlexRow)
+	if options.Prompt != "" {
+		content.AddItem(tview.NewTextView().SetText(options.Prompt).SetWordWrap(true), 2, 0, false)
+	}
+	content.AddItem(form, 4, 0, true)
+	pages.AddPage(inputModalPage, Centered(61, 7, content), true, true)
+	app.SetFocus(input)
+}

--- a/pkg/tui/page_frame.go
+++ b/pkg/tui/page_frame.go
@@ -1,0 +1,233 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type PageFrame struct {
+	*tview.Box
+	app       *tview.Application
+	content   tview.Primitive
+	focus     tview.Primitive
+	helpText  *tview.TextView
+	buttonBar *ButtonBar
+	onEscape  func()
+}
+
+func NewPageFrame(app *tview.Application) *PageFrame {
+	theme := CurrentTheme()
+	frame := &PageFrame{
+		Box: tview.NewBox(),
+		app: app,
+		helpText: tview.NewTextView().
+			SetDynamicColors(true).
+			SetTextAlign(tview.AlignCenter).
+			SetTextColor(theme.SecondaryTextColor),
+	}
+	frame.SetBorder(true).
+		SetBorderColor(theme.BorderColor).
+		SetTitleColor(theme.BorderColor).
+		SetTitleAlign(tview.AlignCenter)
+	return frame
+}
+
+func (pf *PageFrame) SetTitle(path ...string) *PageFrame {
+	pf.Box.SetTitle(" " + strings.Join(path, " > ") + " ")
+	return pf
+}
+
+func (pf *PageFrame) SetContent(content tview.Primitive) *PageFrame {
+	pf.content = content
+	pf.focus = content
+	return pf
+}
+
+func (pf *PageFrame) SetFocusTarget(focus tview.Primitive) *PageFrame {
+	pf.focus = focus
+	return pf
+}
+
+func (pf *PageFrame) SetHelpText(text string) *PageFrame {
+	pf.helpText.SetText(text)
+	return pf
+}
+
+func (pf *PageFrame) SetButtonBar(bar *ButtonBar) *PageFrame {
+	pf.buttonBar = bar
+	return pf
+}
+
+func (pf *PageFrame) SetOnEscape(callback func()) *PageFrame {
+	pf.onEscape = callback
+	return pf
+}
+
+func (pf *PageFrame) Draw(screen tcell.Screen) {
+	pf.DrawForSubclass(screen, pf)
+	x, y, width, height := pf.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	buttonHeight := 0
+	if pf.buttonBar != nil {
+		buttonHeight = 1
+	}
+	contentHeight := max(height-1-buttonHeight, 1)
+	if pf.content != nil {
+		pf.content.SetRect(x, y, width, contentHeight)
+		pf.content.Draw(screen)
+	}
+	pf.helpText.SetRect(x, y+contentHeight, width, 1)
+	pf.helpText.Draw(screen)
+	if pf.buttonBar != nil {
+		pf.buttonBar.SetRect(x, y+contentHeight+1, width, buttonHeight)
+		pf.buttonBar.Draw(screen)
+	}
+	pf.drawHints(screen)
+}
+
+func (pf *PageFrame) drawHints(screen tcell.Screen) {
+	x, y, width, height := pf.GetRect()
+	if width <= 4 || height <= 2 {
+		return
+	}
+	hints := []rune("↑↓: Rows │ ←→: Actions │ Enter: Confirm │ ESC: Back")
+	if len(hints) > width-4 {
+		hints = hints[:width-4]
+	}
+	start := x + (width-len(hints))/2
+	style := tcell.StyleDefault.
+		Foreground(CurrentTheme().BorderColor).
+		Background(CurrentTheme().PrimitiveBackgroundColor)
+	for column := start - 1; column < start+len(hints)+1; column++ {
+		screen.SetContent(column, y+height-1, ' ', nil, style)
+	}
+	for index, value := range hints {
+		screen.SetContent(start+index, y+height-1, value, nil, style)
+	}
+}
+
+func (pf *PageFrame) Focus(delegate func(tview.Primitive)) {
+	if pf.focus != nil {
+		delegate(pf.focus)
+	} else if pf.buttonBar != nil {
+		delegate(pf.buttonBar)
+	}
+}
+
+func (pf *PageFrame) HasFocus() bool {
+	return pf.focus != nil && pf.focus.HasFocus() || pf.buttonBar != nil && pf.buttonBar.HasFocus()
+}
+
+func (pf *PageFrame) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return pf.WrapInputHandler(func(event *tcell.EventKey, setFocus func(tview.Primitive)) {
+		if event.Key() == tcell.KeyEscape && pf.onEscape != nil {
+			pf.onEscape()
+			return
+		}
+		if pf.focus != nil && pf.focus.HasFocus() {
+			if handler := pf.focus.InputHandler(); handler != nil {
+				handler(event, setFocus)
+			}
+			return
+		}
+		if pf.buttonBar != nil && pf.buttonBar.HasFocus() {
+			if handler := pf.buttonBar.InputHandler(); handler != nil {
+				handler(event, setFocus)
+			}
+		}
+	})
+}
+
+func (pf *PageFrame) MouseHandler() func(
+	tview.MouseAction,
+	*tcell.EventMouse,
+	func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return pf.WrapMouseHandler(func(
+		action tview.MouseAction,
+		event *tcell.EventMouse,
+		setFocus func(tview.Primitive),
+	) (bool, tview.Primitive) {
+		if pf.buttonBar != nil && pf.buttonBar.InRect(event.Position()) {
+			return pf.buttonBar.MouseHandler()(action, event, setFocus)
+		}
+		if pf.content != nil {
+			if handler := pf.content.MouseHandler(); handler != nil {
+				return handler(action, event, setFocus)
+			}
+		}
+		return false, nil
+	})
+}
+
+func (pf *PageFrame) FocusContent() {
+	if pf.focus != nil {
+		pf.app.SetFocus(pf.focus)
+	}
+}
+
+func (pf *PageFrame) FocusButtonBar() {
+	if pf.buttonBar != nil {
+		pf.app.SetFocus(pf.buttonBar)
+	}
+}
+
+func (pf *PageFrame) SetupContentToButtonNavigation() {
+	var list *tview.List
+	switch focus := pf.focus.(type) {
+	case *tview.List:
+		list = focus
+	case interface{ NavigationList() *tview.List }:
+		list = focus.NavigationList()
+	}
+	if list == nil || pf.buttonBar == nil {
+		return
+	}
+	pf.buttonBar.SetPersistentFocus(true)
+	capture := list.GetInputCapture()
+	list.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyLeft, tcell.KeyRight, tcell.KeyTab, tcell.KeyBacktab, tcell.KeyEnter:
+			if handler := pf.buttonBar.InputHandler(); handler != nil {
+				handler(event, func(tview.Primitive) {})
+			}
+			return nil
+		case tcell.KeyEscape:
+			if pf.onEscape != nil {
+				pf.onEscape()
+				return nil
+			}
+		default:
+		}
+		if capture != nil {
+			return capture(event)
+		}
+		return event
+	})
+}

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -1,0 +1,275 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type Theme struct {
+	Name                     string
+	DisplayName              string
+	BackgroundName           string
+	AccentName               string
+	TextName                 string
+	HighlightBackgroundName  string
+	HighlightForegroundName  string
+	SecondaryName            string
+	ErrorName                string
+	WarningName              string
+	SuccessName              string
+	LabelName                string
+	PrimitiveBackgroundColor tcell.Color
+	ContrastBackgroundColor  tcell.Color
+	BorderColor              tcell.Color
+	PrimaryTextColor         tcell.Color
+	SecondaryTextColor       tcell.Color
+	InverseTextColor         tcell.Color
+	FieldFocusedBackground   tcell.Color
+	FieldUnfocusedBackground tcell.Color
+	ProgressFillColor        tcell.Color
+	ProgressEmptyColor       tcell.Color
+	ErrorColor               tcell.Color
+	WarningColor             tcell.Color
+	SuccessColor             tcell.Color
+	LabelColor               tcell.Color
+}
+
+var ThemeDefault = Theme{
+	Name:                     "default",
+	DisplayName:              "Default (Dark Blue)",
+	BackgroundName:           "darkblue",
+	AccentName:               "yellow",
+	TextName:                 "white",
+	HighlightBackgroundName:  "yellow",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "gray",
+	ErrorName:                "red",
+	WarningName:              "yellow",
+	SuccessName:              "green",
+	LabelName:                "gray",
+	PrimitiveBackgroundColor: tcell.ColorDarkBlue,
+	ContrastBackgroundColor:  tcell.ColorBlue,
+	BorderColor:              tcell.ColorLightYellow,
+	PrimaryTextColor:         tcell.ColorWhite,
+	SecondaryTextColor:       tcell.ColorGray,
+	InverseTextColor:         tcell.ColorDarkBlue,
+	FieldFocusedBackground:   tcell.ColorBlue,
+	FieldUnfocusedBackground: tcell.ColorDarkBlue,
+	ProgressFillColor:        tcell.ColorGreen,
+	ProgressEmptyColor:       tcell.ColorGray,
+	ErrorColor:               tcell.ColorRed,
+	WarningColor:             tcell.ColorYellow,
+	SuccessColor:             tcell.ColorGreen,
+	LabelColor:               tcell.ColorGray,
+}
+
+var ThemeHighContrast = Theme{
+	Name:                     "high_contrast",
+	DisplayName:              "High Contrast",
+	BackgroundName:           "#000000",
+	AccentName:               "yellow",
+	TextName:                 "white",
+	HighlightBackgroundName:  "yellow",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "white",
+	ErrorName:                "red",
+	WarningName:              "yellow",
+	SuccessName:              "lime",
+	LabelName:                "white",
+	PrimitiveBackgroundColor: tcell.NewHexColor(0x000000),
+	ContrastBackgroundColor:  tcell.NewHexColor(0x000000),
+	BorderColor:              tcell.ColorYellow,
+	PrimaryTextColor:         tcell.ColorWhite,
+	SecondaryTextColor:       tcell.ColorWhite,
+	InverseTextColor:         tcell.NewHexColor(0x000000),
+	FieldFocusedBackground:   tcell.ColorYellow,
+	FieldUnfocusedBackground: tcell.NewHexColor(0x000000),
+	ProgressFillColor:        tcell.ColorYellow,
+	ProgressEmptyColor:       tcell.ColorWhite,
+	ErrorColor:               tcell.ColorRed,
+	WarningColor:             tcell.ColorYellow,
+	SuccessColor:             tcell.ColorLime,
+	LabelColor:               tcell.ColorWhite,
+}
+
+var ThemeDracula = Theme{
+	Name:                     "dracula",
+	DisplayName:              "Dracula",
+	BackgroundName:           "#282a36",
+	AccentName:               "#bd93f9",
+	TextName:                 "#f8f8f2",
+	HighlightBackgroundName:  "#bd93f9",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "#6272a4",
+	ErrorName:                "#ff5555",
+	WarningName:              "#f1fa8c",
+	SuccessName:              "#50fa7b",
+	LabelName:                "#6272a4",
+	PrimitiveBackgroundColor: tcell.NewHexColor(0x282A36),
+	ContrastBackgroundColor:  tcell.NewHexColor(0x44475A),
+	BorderColor:              tcell.NewHexColor(0xBD93F9),
+	PrimaryTextColor:         tcell.NewHexColor(0xF8F8F2),
+	SecondaryTextColor:       tcell.NewHexColor(0x6272A4),
+	InverseTextColor:         tcell.NewHexColor(0x282A36),
+	FieldFocusedBackground:   tcell.NewHexColor(0x44475A),
+	FieldUnfocusedBackground: tcell.NewHexColor(0x282A36),
+	ProgressFillColor:        tcell.NewHexColor(0x50FA7B),
+	ProgressEmptyColor:       tcell.NewHexColor(0x44475A),
+	ErrorColor:               tcell.NewHexColor(0xFF5555),
+	WarningColor:             tcell.NewHexColor(0xF1FA8C),
+	SuccessColor:             tcell.NewHexColor(0x50FA7B),
+	LabelColor:               tcell.NewHexColor(0x6272A4),
+}
+
+var ThemeNord = Theme{
+	Name:                     "nord",
+	DisplayName:              "Nord",
+	BackgroundName:           "#2e3440",
+	AccentName:               "#88c0d0",
+	TextName:                 "#eceff4",
+	HighlightBackgroundName:  "#88c0d0",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "#d8dee9",
+	ErrorName:                "#bf616a",
+	WarningName:              "#ebcb8b",
+	SuccessName:              "#a3be8c",
+	LabelName:                "#4c566a",
+	PrimitiveBackgroundColor: tcell.NewHexColor(0x2E3440),
+	ContrastBackgroundColor:  tcell.NewHexColor(0x3B4252),
+	BorderColor:              tcell.NewHexColor(0x88C0D0),
+	PrimaryTextColor:         tcell.NewHexColor(0xECEFF4),
+	SecondaryTextColor:       tcell.NewHexColor(0xD8DEE9),
+	InverseTextColor:         tcell.NewHexColor(0x2E3440),
+	FieldFocusedBackground:   tcell.NewHexColor(0x3B4252),
+	FieldUnfocusedBackground: tcell.NewHexColor(0x2E3440),
+	ProgressFillColor:        tcell.NewHexColor(0xA3BE8C),
+	ProgressEmptyColor:       tcell.NewHexColor(0x4C566A),
+	ErrorColor:               tcell.NewHexColor(0xBF616A),
+	WarningColor:             tcell.NewHexColor(0xEBCB8B),
+	SuccessColor:             tcell.NewHexColor(0xA3BE8C),
+	LabelColor:               tcell.NewHexColor(0x4C566A),
+}
+
+var ThemeGruvbox = Theme{
+	Name:                     "gruvbox",
+	DisplayName:              "Gruvbox",
+	BackgroundName:           "#282828",
+	AccentName:               "#fabd2f",
+	TextName:                 "#ebdbb2",
+	HighlightBackgroundName:  "#fabd2f",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "#a89984",
+	ErrorName:                "#fb4934",
+	WarningName:              "#fabd2f",
+	SuccessName:              "#b8bb26",
+	LabelName:                "#a89984",
+	PrimitiveBackgroundColor: tcell.NewHexColor(0x282828),
+	ContrastBackgroundColor:  tcell.NewHexColor(0x3C3836),
+	BorderColor:              tcell.NewHexColor(0xFABD2F),
+	PrimaryTextColor:         tcell.NewHexColor(0xEBDBB2),
+	SecondaryTextColor:       tcell.NewHexColor(0xA89984),
+	InverseTextColor:         tcell.NewHexColor(0x282828),
+	FieldFocusedBackground:   tcell.NewHexColor(0x504945),
+	FieldUnfocusedBackground: tcell.NewHexColor(0x282828),
+	ProgressFillColor:        tcell.NewHexColor(0xB8BB26),
+	ProgressEmptyColor:       tcell.NewHexColor(0x504945),
+	ErrorColor:               tcell.NewHexColor(0xFB4934),
+	WarningColor:             tcell.NewHexColor(0xFABD2F),
+	SuccessColor:             tcell.NewHexColor(0xB8BB26),
+	LabelColor:               tcell.NewHexColor(0xA89984),
+}
+
+var ThemeMonoGreen = Theme{
+	Name:                     "monogreen",
+	DisplayName:              "Mono Green (Retro)",
+	BackgroundName:           "black",
+	AccentName:               "green",
+	TextName:                 "green",
+	HighlightBackgroundName:  "green",
+	HighlightForegroundName:  "black",
+	SecondaryName:            "darkgreen",
+	ErrorName:                "red",
+	WarningName:              "yellow",
+	SuccessName:              "lime",
+	LabelName:                "darkgreen",
+	PrimitiveBackgroundColor: tcell.ColorBlack,
+	ContrastBackgroundColor:  tcell.NewHexColor(0x0A1A0A),
+	BorderColor:              tcell.ColorGreen,
+	PrimaryTextColor:         tcell.ColorGreen,
+	SecondaryTextColor:       tcell.ColorDarkGreen,
+	InverseTextColor:         tcell.ColorBlack,
+	FieldFocusedBackground:   tcell.ColorDarkGreen,
+	FieldUnfocusedBackground: tcell.ColorBlack,
+	ProgressFillColor:        tcell.ColorLime,
+	ProgressEmptyColor:       tcell.ColorDarkGreen,
+	ErrorColor:               tcell.ColorRed,
+	WarningColor:             tcell.ColorYellow,
+	SuccessColor:             tcell.ColorLime,
+	LabelColor:               tcell.ColorDarkGreen,
+}
+
+var AvailableThemes = map[string]*Theme{
+	"default":       &ThemeDefault,
+	"high_contrast": &ThemeHighContrast,
+	"dracula":       &ThemeDracula,
+	"nord":          &ThemeNord,
+	"gruvbox":       &ThemeGruvbox,
+	"monogreen":     &ThemeMonoGreen,
+}
+
+var ThemeNames = []string{"default", "high_contrast", "dracula", "nord", "gruvbox", "monogreen"}
+
+var (
+	currentTheme = &ThemeDefault
+	themeMu      sync.RWMutex
+)
+
+func CurrentTheme() *Theme {
+	themeMu.RLock()
+	defer themeMu.RUnlock()
+	return currentTheme
+}
+
+func SetCurrentTheme(name string) bool {
+	theme, ok := AvailableThemes[name]
+	if !ok {
+		return false
+	}
+	themeMu.Lock()
+	currentTheme = theme
+	themeMu.Unlock()
+	ApplyTheme(theme)
+	return true
+}
+
+func ApplyTheme(theme *Theme) {
+	tview.Styles.PrimitiveBackgroundColor = theme.PrimitiveBackgroundColor
+	tview.Styles.ContrastBackgroundColor = theme.ContrastBackgroundColor
+	tview.Styles.BorderColor = theme.BorderColor
+	tview.Styles.PrimaryTextColor = theme.PrimaryTextColor
+	tview.Styles.SecondaryTextColor = theme.SecondaryTextColor
+	tview.Styles.InverseTextColor = theme.InverseTextColor
+}

--- a/pkg/tui/virtual_keyboard.go
+++ b/pkg/tui/virtual_keyboard.go
@@ -1,0 +1,289 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Portions adapted from Zaparoo Core, Copyright (c) 2026 The Zaparoo Project Contributors.
+
+package tui
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	keyboardDelete  = "DEL"
+	keyboardSubmit  = "OK"
+	keyboardShift   = "SHFT"
+	keyboardSymbols = "SYM"
+	keyboardSpace   = "SPC"
+	keyboardCancel  = "CANC"
+)
+
+var (
+	keyboardLower = [][]string{
+		{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+		{"q", "w", "e", "r", "t", "y", "u", "i", "o", "p"},
+		{"a", "s", "d", "f", "g", "h", "j", "k", "l"},
+		{"z", "x", "c", "v", "b", "n", "m", ",", "."},
+		{keyboardShift, keyboardSymbols, keyboardSpace, keyboardDelete, keyboardSubmit, keyboardCancel},
+	}
+	keyboardUpper = [][]string{
+		{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+		{"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"},
+		{"A", "S", "D", "F", "G", "H", "J", "K", "L"},
+		{"Z", "X", "C", "V", "B", "N", "M", ",", "."},
+		{keyboardShift, keyboardSymbols, keyboardSpace, keyboardDelete, keyboardSubmit, keyboardCancel},
+	}
+	keyboardSymbolKeys = [][]string{
+		{"!", "@", "#", "$", "%", "^", "&", "*", "(", ")"},
+		{"-", "_", "=", "+", "[", "]", "{", "}", "\\", "|"},
+		{";", ":", "'", "\"", "`", "~", "/", "?", "<", ">"},
+		{},
+		{"ABC", keyboardSpace, keyboardDelete, keyboardSubmit, keyboardCancel},
+	}
+)
+
+type VirtualKeyboard struct {
+	*tview.Box
+	onSubmit  func(string)
+	onCancel  func()
+	text      []rune
+	cursorRow int
+	cursorCol int
+	shift     bool
+	symbols   bool
+}
+
+func NewVirtualKeyboard(initialText string, onSubmit func(string), onCancel func()) *VirtualKeyboard {
+	keyboard := &VirtualKeyboard{
+		Box:       tview.NewBox(),
+		onSubmit:  onSubmit,
+		onCancel:  onCancel,
+		text:      []rune(initialText),
+		cursorRow: len(keyboardLower) - 1,
+		cursorCol: 4,
+	}
+	keyboard.SetBorder(true).SetTitle(" Keyboard ")
+	return keyboard
+}
+
+func (k *VirtualKeyboard) Text() string {
+	return string(k.text)
+}
+
+func (k *VirtualKeyboard) layout() [][]string {
+	switch {
+	case k.symbols:
+		return keyboardSymbolKeys
+	case k.shift:
+		return keyboardUpper
+	default:
+		return keyboardLower
+	}
+}
+
+func (k *VirtualKeyboard) Draw(screen tcell.Screen) {
+	k.DrawForSubclass(screen, k)
+	x, y, width, height := k.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+	theme := CurrentTheme()
+	inputStyle := tcell.StyleDefault.
+		Foreground(theme.PrimaryTextColor).
+		Background(theme.FieldFocusedBackground)
+	for column := x; column < x+width; column++ {
+		screen.SetContent(column, y, ' ', nil, inputStyle)
+	}
+	display := k.text
+	if len(display) > width-2 {
+		display = display[len(display)-(width-2):]
+	}
+	for index, value := range display {
+		screen.SetContent(x+1+index, y, value, nil, inputStyle)
+	}
+	cursor := x + 1 + len(display)
+	if cursor < x+width-1 {
+		screen.SetContent(cursor, y, '_', nil, inputStyle.Blink(true))
+	}
+
+	for row, keys := range k.layout() {
+		if y+1+row >= y+height || len(keys) == 0 {
+			continue
+		}
+		k.drawRow(screen, x, y+1+row, row, keys, theme)
+	}
+}
+
+func (k *VirtualKeyboard) drawRow(
+	screen tcell.Screen,
+	x, y, row int,
+	keys []string,
+	theme *Theme,
+) {
+	if row == len(k.layout())-1 {
+		leftCount := len(keys) - 4
+		rightStart := 39 - 3*5
+		for column, key := range keys {
+			keyX, keyWidth := x+column*5, 4
+			switch {
+			case column == leftCount:
+				keyWidth = rightStart - leftCount*5 - 1
+			case column > leftCount:
+				keyX = x + rightStart + (column-leftCount-1)*5
+			}
+			k.drawKey(screen, keyX, y, key, keyWidth, row, column, theme)
+		}
+		return
+	}
+	for column, key := range keys {
+		k.drawKey(screen, x+column*4, y, key, 3, row, column, theme)
+	}
+}
+
+func (k *VirtualKeyboard) drawKey(
+	screen tcell.Screen,
+	x, y int,
+	label string,
+	width, row, column int,
+	theme *Theme,
+) {
+	style := tcell.StyleDefault.
+		Foreground(theme.PrimaryTextColor).
+		Background(theme.PrimitiveBackgroundColor)
+	if row == k.cursorRow && column == k.cursorCol {
+		style = tcell.StyleDefault.
+			Foreground(tcell.GetColor(theme.HighlightForegroundName)).
+			Background(tcell.GetColor(theme.HighlightBackgroundName))
+	} else if isKeyboardAction(label) {
+		style = style.Foreground(theme.LabelColor)
+	}
+	padding := max((width-len(label))/2, 0)
+	for index := range width {
+		value := ' '
+		labelIndex := index - padding
+		if labelIndex >= 0 && labelIndex < len(label) {
+			value = rune(label[labelIndex])
+		}
+		screen.SetContent(x+index, y, value, nil, style)
+	}
+}
+
+func isKeyboardAction(key string) bool {
+	switch key {
+	case keyboardDelete, keyboardSubmit, keyboardShift, keyboardSymbols,
+		keyboardSpace, keyboardCancel, "ABC":
+		return true
+	default:
+		return false
+	}
+}
+
+func (k *VirtualKeyboard) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return k.WrapInputHandler(func(event *tcell.EventKey, _ func(tview.Primitive)) {
+		layout := k.layout()
+		switch event.Key() {
+		case tcell.KeyUp:
+			k.moveVertical(layout, -1)
+		case tcell.KeyDown:
+			k.moveVertical(layout, 1)
+		case tcell.KeyLeft:
+			k.cursorCol = (k.cursorCol - 1 + len(layout[k.cursorRow])) % len(layout[k.cursorRow])
+		case tcell.KeyRight:
+			k.cursorCol = (k.cursorCol + 1) % len(layout[k.cursorRow])
+		case tcell.KeyEnter:
+			k.activate()
+		case tcell.KeyEscape:
+			if k.onCancel != nil {
+				k.onCancel()
+			}
+		case tcell.KeyBackspace, tcell.KeyBackspace2, tcell.KeyDelete:
+			k.deleteLast()
+		case tcell.KeyRune:
+			k.text = append(k.text, event.Rune())
+		default:
+		}
+	})
+}
+
+func (k *VirtualKeyboard) moveVertical(layout [][]string, direction int) {
+	column := k.cursorCol
+	for {
+		k.cursorRow = (k.cursorRow + direction + len(layout)) % len(layout)
+		if len(layout[k.cursorRow]) > 0 {
+			k.cursorCol = min(column, len(layout[k.cursorRow])-1)
+			return
+		}
+	}
+}
+
+func (k *VirtualKeyboard) deleteLast() {
+	if len(k.text) > 0 {
+		k.text = k.text[:len(k.text)-1]
+	}
+}
+
+func (k *VirtualKeyboard) activate() {
+	layout := k.layout()
+	if k.cursorRow >= len(layout) || k.cursorCol >= len(layout[k.cursorRow]) {
+		return
+	}
+	key := layout[k.cursorRow][k.cursorCol]
+	switch key {
+	case keyboardDelete:
+		k.deleteLast()
+	case keyboardSubmit:
+		if k.onSubmit != nil {
+			k.onSubmit(string(k.text))
+		}
+	case keyboardShift:
+		k.shift = !k.shift
+		k.symbols = false
+	case keyboardSymbols:
+		k.symbols = true
+		k.shift = false
+		k.cursorCol = 0
+	case "ABC":
+		k.symbols = false
+		k.cursorCol = 1
+	case keyboardSpace:
+		k.text = append(k.text, ' ')
+	case keyboardCancel:
+		if k.onCancel != nil {
+			k.onCancel()
+		}
+	default:
+		if strings.TrimSpace(key) != "" {
+			k.text = append(k.text, []rune(key)...)
+			if k.shift && !k.symbols {
+				k.shift = false
+			}
+		}
+	}
+}
+
+func (k *VirtualKeyboard) Focus(delegate func(tview.Primitive)) {
+	k.Box.Focus(delegate)
+}
+
+func (k *VirtualKeyboard) HasFocus() bool {
+	return k.Box.HasFocus()
+}

--- a/scripts/generate_repo.py
+++ b/scripts/generate_repo.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from zipfile import ZipFile
 from typing import TypedDict, Union, Optional, List
 
-APPS = ["lastplayed", "launchsync", "playlog", "random", "remote", "search"]
+APPS = ["favorites", "lastplayed", "launchsync", "playlog", "random", "remote", "search"]
 FILES = {
+    "favorites": ["favorites.sh"],
     "lastplayed": ["lastplayed.sh"],
     "launchsync": ["launchsync.sh"],
     "playlog": ["playlog.sh"],
@@ -21,7 +22,6 @@ FILES = {
 REBOOT = ["remote"]
 SCRIPT_FILES = [
     "scripts/bgm.sh",
-    "scripts/favorites.sh",
     "scripts/gamesmenu.sh",
 ]
 
@@ -160,6 +160,7 @@ def main():
 
     for app in APPS:
         repo_db = create_app_db(app, tag)
+        os.makedirs("{}/{}".format(RELEASES_FOLDER, app), exist_ok=True)
         with open("{}/{}/{}.json".format(RELEASES_FOLDER, app, app), "w") as f:
             f.write(generate_json(repo_db))
 


### PR DESCRIPTION
## Summary
- Replace Python Favorites delivery with a standalone native ARMv7 `favorites.sh`, using the shared MiSTer catalog/MGL generator while retaining the unchanged Python source for comparison.
- Preserve stock-MiSTer workflows: folder management, SD/USB/ZIP browsing, NeoGeo naming, alternate cores, arcade links, and startup refresh.
- Add reusable themed TUI components, dual-axis controller navigation, compact keyboard, and staged INI settings with per-row help, list editors, and option pickers.
- Fix parity and release-review regressions, including symlinked roots, ZIP navigation, safe cleanup, deterministic core matching, and large-list performance; wire native release assets into Downloader and document configuration.

## Validation
- 136 tests passed across 32 packages; go vet, strict golangci-lint, actionlint, and diff checks passed.
- Static ARMv7 build passed; all ten verified review findings resolved with regression coverage.
- Final on-device acceptance, UPX-compressed asset testing, and Downloader upgrade testing remain outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a full Favorites Manager for creating, organizing, renaming, moving, and deleting game, core, arcade, and folder shortcuts.
  - Added local-folder and ZIP-archive browsing, alternate cores, NeoGeo titles, automatic link refresh, and configurable settings.
  - Added themes, improved terminal navigation and dialogs, contextual help, on-screen keyboard support, and non-interactive refresh.
  - Added release-based installation as a compiled application.

- **Documentation**
  - Added comprehensive Favorites documentation and updated installation links.

- **Bug Fixes**
  - Improved game-folder matching and versioned-core refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->