### PR TITLE
feat(bgm): rewrite BGM in Go with the shared TUI

### DIFF
--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DL_URL=https://github.com/wizzomafizzo/mrext/releases/download/${{ steps.mrextreleaseinfo.outputs.tag_name }}
           mkdir -p _bin/releases
-          for file in favorites.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
+          for file in bgm.sh favorites.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
             curl -fsSL "$DL_URL/$file" -o "_bin/releases/$file"
           done
       - name: Create databases

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Control MiSTer from any device on your network. Remote provides a web interface 
 
 Play music in MiSTer menu. BGM supports common audio formats and internet radio streams, and can pause automatically while a core is running.
 
-<a href="https://github.com/wizzomafizzo/mrext/raw/main/scripts/bgm.sh"><img src="docs/images/download.svg" alt="Download BGM" title="Download BGM" width="140"></a>
-<a href="https://github.com/wizzomafizzo/mrext#bgm"><img src="docs/images/readme.svg" alt="Readme BGM" title="Readme BGM" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/releases/latest/download/bgm.sh"><img src="docs/images/download.svg" alt="Download BGM" title="Download BGM" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/blob/main/docs/bgm.md"><img src="docs/images/readme.svg" alt="Readme BGM" title="Readme BGM" width="140"></a>
 
 ## Favorites
 

--- a/cmd/bgm/main.go
+++ b/cmd/bgm/main.go
@@ -1,0 +1,251 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/bgm"
+)
+
+const (
+	commandExec    = "exec"
+	commandStart   = "start"
+	commandStop    = "stop"
+	commandRestart = "restart"
+	usage          = "usage: bgm.sh [--root PATH] [exec|start|stop|restart]"
+)
+
+// serviceTimeout bounds how long the CLI waits for the service socket to
+// appear or disappear; tests shorten it.
+var serviceTimeout = 5 * time.Second
+
+type cliOptions struct {
+	root    string
+	command string
+}
+
+func parseCLI(args []string) (cliOptions, error) {
+	flags := flag.NewFlagSet("bgm", flag.ContinueOnError)
+	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	if err := flags.Parse(args); err != nil {
+		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
+	}
+	positionals := flags.Args()
+	if len(positionals) > 1 {
+		return cliOptions{}, errors.New(usage)
+	}
+	options := cliOptions{root: *root}
+	if len(positionals) == 1 {
+		switch positionals[0] {
+		case commandExec, commandStart, commandStop, commandRestart:
+			options.command = positionals[0]
+		default:
+			return cliOptions{}, errors.New(usage)
+		}
+	}
+	return options, nil
+}
+
+func loadRuntime(root string) (bgm.Paths, error) {
+	if root == "" {
+		return bgm.DefaultPaths(), nil
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return bgm.Paths{}, fmt.Errorf("resolve local MiSTer root: %w", err)
+	}
+	paths := bgm.RootedPaths(absoluteRoot)
+	folders := []string{
+		absoluteRoot, paths.TempFolder, filepath.Dir(paths.CmdInterface), filepath.Dir(paths.StartupScript),
+	}
+	for _, folder := range folders {
+		// #nosec G301 -- local fixture mirrors MiSTer's shared filesystem permissions.
+		if mkdirErr := os.MkdirAll(folder, 0o755); mkdirErr != nil {
+			return bgm.Paths{}, fmt.Errorf("create local MiSTer root: %w", mkdirErr)
+		}
+	}
+	return paths, nil
+}
+
+// app wires the CLI commands together. spawn and runTUI are replaced by tests.
+type app struct {
+	logger *bgm.Logger
+	spawn  func() error
+	runTUI func(cfg *bgm.Config) error
+	paths  bgm.Paths
+	root   string
+}
+
+func newApp(options cliOptions, stdout io.Writer) (*app, error) {
+	paths, err := loadRuntime(options.root)
+	if err != nil {
+		return nil, err
+	}
+	application := &app{
+		logger: bgm.NewLoggerTo(&paths, stdout),
+		paths:  paths,
+		root:   options.root,
+	}
+	application.spawn = func() error { return bgm.SpawnService(&application.paths, application.root) }
+	application.runTUI = func(cfg *bgm.Config) error {
+		return newUI(&application.paths, cfg, application.logger).Run()
+	}
+	return application, nil
+}
+
+func run(args []string, stdout io.Writer) error {
+	options, err := parseCLI(args)
+	if err != nil {
+		return err
+	}
+	application, err := newApp(options, stdout)
+	if err != nil {
+		return err
+	}
+	return application.dispatch(options.command)
+}
+
+// dispatch mirrors the Python __main__ block.
+func (a *app) dispatch(command string) error {
+	cfg, _ := bgm.LoadConfig(&a.paths)
+	switch command {
+	case commandExec:
+		return a.runExec()
+	case commandStart:
+		return a.start(&cfg)
+	case commandStop:
+		return stopService(&a.paths, a.logger)
+	case commandRestart:
+		if err := stopService(&a.paths, a.logger); err != nil {
+			return err
+		}
+		if bgm.SocketExists(&a.paths) && !bgm.WaitForSocketGone(&a.paths, serviceTimeout) {
+			return errors.New("BGM service did not stop")
+		}
+		restarted, _ := bgm.LoadConfig(&a.paths)
+		return a.start(&restarted)
+	default:
+		return a.interactive()
+	}
+}
+
+func (a *app) start(cfg *bgm.Config) error {
+	if !cfg.Startup {
+		a.logger.Print("Auto-start is disabled in configuration")
+		return nil
+	}
+	return a.spawn()
+}
+
+func (a *app) interactive() error {
+	created, err := bgm.EnsureMusicFolder(&a.paths)
+	if err != nil {
+		return fmt.Errorf("prepare music folder: %w", err)
+	}
+	if created {
+		a.logger.Print("Created music folder.")
+	}
+	if err := bgm.TryAddToStartup(&a.paths, a.logger); err != nil {
+		return fmt.Errorf("configure startup: %w", err)
+	}
+	cfg, _ := bgm.LoadConfig(&a.paths)
+	player := bgm.NewPlayer(&a.paths, a.logger, &cfg)
+	if player.TotalTracks(player.Playlist(), true) == 0 {
+		a.logger.Print(fmt.Sprintf("Add music files to %s and re-run this script to start.", a.paths.MusicFolder))
+		return nil
+	}
+	if bgm.SocketStale(&a.paths) {
+		// A crashed service left its socket behind; the Python script could
+		// only be recovered from this with a reboot.
+		_ = os.Remove(a.paths.SocketFile)
+	}
+	if !bgm.SocketExists(&a.paths) {
+		a.logger.Print("Starting BGM service...")
+		if err := a.spawn(); err != nil {
+			return err
+		}
+		if !bgm.WaitForSocket(&a.paths, serviceTimeout) {
+			return nil
+		}
+	}
+	return a.runTUI(&cfg)
+}
+
+func (a *app) runExec() error {
+	if bgm.SocketExists(&a.paths) {
+		if !bgm.SocketStale(&a.paths) {
+			a.logger.Print("BGM service is already running, exiting...")
+			return nil
+		}
+		_ = os.Remove(a.paths.SocketFile)
+	}
+	service := bgm.NewService(&a.paths, a.logger)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		received := <-signals
+		a.logger.Log(fmt.Sprintf("Stopping service (%d)", signalNumber(received)))
+		a.shutdown(service)
+		os.Exit(0)
+	}()
+	err := service.Run(context.Background())
+	a.logger.Log("Stopping service (0)")
+	a.shutdown(service)
+	if err != nil {
+		return fmt.Errorf("run BGM service: %w", err)
+	}
+	return nil
+}
+
+func stopService(paths *bgm.Paths, logger *bgm.Logger) error {
+	if err := bgm.StopService(paths, logger); err != nil {
+		return fmt.Errorf("stop BGM service: %w", err)
+	}
+	return nil
+}
+
+func (a *app) shutdown(service *bgm.Service) {
+	service.Cleanup()
+	bgm.RemoveServiceBinary(&a.paths)
+}
+
+func signalNumber(received os.Signal) int {
+	if number, ok := received.(syscall.Signal); ok {
+		return int(number)
+	}
+	return 0
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/bgm/main_test.go
+++ b/cmd/bgm/main_test.go
@@ -1,0 +1,268 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/bgm"
+)
+
+type syncBuffer struct {
+	buf strings.Builder
+	mu  sync.Mutex
+}
+
+func (b *syncBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(data) //nolint:wrapcheck // test helper
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// newTestApp builds an app on a temporary root with recording spawn/TUI
+// hooks and a short socket path.
+func newTestApp(t *testing.T) (*app, *syncBuffer) {
+	t.Helper()
+	out := &syncBuffer{}
+	application, err := newApp(cliOptions{root: t.TempDir()}, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	socketDir, err := os.MkdirTemp("", "bgm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	application.paths.SocketFile = filepath.Join(socketDir, bgm.SocketFilename)
+	application.logger = bgm.NewLoggerTo(&application.paths, out)
+	application.spawn = func() error { return nil }
+	application.runTUI = func(*bgm.Config) error { return nil }
+	return application, out
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// startFakeService listens on the app socket with a stopped player so the
+// CLI and TUI see a running service without spawning audio players.
+func startFakeService(t *testing.T, application *app) *bgm.Player {
+	t.Helper()
+	cfg, _ := bgm.LoadConfig(&application.paths)
+	player := bgm.NewPlayer(&application.paths, application.logger, &cfg)
+	player.StopPlaylist()
+	remote, err := bgm.StartRemote(&application.paths, application.logger, player)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		remote.Close()
+		player.StopPlaylist()
+		_ = os.Remove(application.paths.SocketFile)
+	})
+	return player
+}
+
+func TestParseCLI(t *testing.T) {
+	for _, command := range []string{"exec", "start", "stop", "restart"} {
+		options, err := parseCLI([]string{"--root", "/tmp/x", command})
+		if err != nil || options.command != command || options.root != "/tmp/x" {
+			t.Fatalf("parseCLI(%s) = %+v %v", command, options, err)
+		}
+	}
+	options, err := parseCLI(nil)
+	if err != nil || options.command != "" {
+		t.Fatalf("no arguments should select the interactive path: %+v %v", options, err)
+	}
+	for _, args := range [][]string{{"status"}, {"start", "now"}, {"--bogus"}} {
+		if _, err := parseCLI(args); err == nil {
+			t.Fatalf("expected an error for %v", args)
+		}
+	}
+}
+
+func TestStartHonoursStartupFlag(t *testing.T) {
+	application, out := newTestApp(t)
+	spawned := 0
+	application.spawn = func() error { spawned++; return nil }
+	writeTestFile(t, application.paths.IniFile, "[bgm]\nstartup = no\n")
+	if err := application.dispatch(commandStart); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 0 || out.String() != "Auto-start is disabled in configuration\n" {
+		t.Fatalf("spawned=%d output %q", spawned, out.String())
+	}
+	writeTestFile(t, application.paths.IniFile, bgm.DefaultINI)
+	if err := application.dispatch(commandStart); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 {
+		t.Fatalf("spawned=%d", spawned)
+	}
+}
+
+func TestStopAndRestartWithoutService(t *testing.T) {
+	application, out := newTestApp(t)
+	spawned := 0
+	application.spawn = func() error { spawned++; return nil }
+	writeTestFile(t, application.paths.IniFile, bgm.DefaultINI)
+	if err := application.dispatch(commandStop); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "BGM service is not running\n" {
+		t.Fatalf("output %q", out.String())
+	}
+	if err := application.dispatch(commandRestart); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 {
+		t.Fatalf("restart should start the service, spawned=%d", spawned)
+	}
+}
+
+func TestInteractiveFirstRunPreparesFilesAndAsksForMusic(t *testing.T) {
+	application, out := newTestApp(t)
+	application.paths.AppPath = "/media/fat/Scripts/bgm.sh"
+	spawned := false
+	application.spawn = func() error { spawned = true; return nil }
+	if err := application.dispatch(""); err != nil {
+		t.Fatal(err)
+	}
+	want := "Created music folder.\nAdded service to startup script.\n" +
+		"Add music files to " + application.paths.MusicFolder + " and re-run this script to start.\n"
+	if out.String() != want {
+		t.Fatalf("output %q", out.String())
+	}
+	if spawned {
+		t.Fatal("service must not start without music")
+	}
+	data, err := os.ReadFile(application.paths.IniFile)
+	if err != nil || string(data) != bgm.DefaultINI {
+		t.Fatalf("default ini not created: %q %v", data, err)
+	}
+	startup, err := os.ReadFile(application.paths.StartupScript)
+	hook := "[[ -e /media/fat/Scripts/bgm.sh ]] && /media/fat/Scripts/bgm.sh $1"
+	if err != nil || !strings.Contains(string(startup), hook) {
+		t.Fatalf("startup script %q %v", startup, err)
+	}
+}
+
+func TestInteractiveStartsServiceThenOpensTUI(t *testing.T) {
+	application, out := newTestApp(t)
+	writeTestFile(t, filepath.Join(application.paths.MusicFolder, "song.mp3"), "")
+	opened := 0
+	application.runTUI = func(*bgm.Config) error { opened++; return nil }
+	spawned := 0
+	application.spawn = func() error {
+		spawned++
+		startFakeService(t, application)
+		return nil
+	}
+	if err := application.dispatch(""); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 || opened != 1 {
+		t.Fatalf("spawned=%d opened=%d", spawned, opened)
+	}
+	if !strings.Contains(out.String(), "Starting BGM service...\n") {
+		t.Fatalf("output %q", out.String())
+	}
+	// With the service already running the TUI opens directly.
+	if err := application.dispatch(""); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 || opened != 2 {
+		t.Fatalf("spawned=%d opened=%d", spawned, opened)
+	}
+}
+
+func TestInteractiveReplacesStaleSocket(t *testing.T) {
+	application, out := newTestApp(t)
+	writeTestFile(t, filepath.Join(application.paths.MusicFolder, "song.mp3"), "")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", application.paths.SocketFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		unixListener.SetUnlinkOnClose(false)
+	}
+	_ = listener.Close()
+	spawned, opened := 0, 0
+	application.spawn = func() error {
+		spawned++
+		startFakeService(t, application)
+		return nil
+	}
+	application.runTUI = func(*bgm.Config) error { opened++; return nil }
+	if err := application.dispatch(""); err != nil {
+		t.Fatal(err)
+	}
+	if spawned != 1 || opened != 1 || !strings.Contains(out.String(), "Starting BGM service...\n") {
+		t.Fatalf("spawned=%d opened=%d output %q", spawned, opened, out.String())
+	}
+}
+
+func TestInteractiveGivesUpWhenServiceNeverAppears(t *testing.T) {
+	application, out := newTestApp(t)
+	previous := serviceTimeout
+	serviceTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { serviceTimeout = previous })
+	writeTestFile(t, filepath.Join(application.paths.MusicFolder, "song.mp3"), "")
+	opened := false
+	application.runTUI = func(*bgm.Config) error { opened = true; return nil }
+	if err := application.dispatch(""); err != nil {
+		t.Fatal(err)
+	}
+	if opened || !strings.HasSuffix(out.String(), "Starting BGM service...\n") {
+		t.Fatalf("opened=%v output %q", opened, out.String())
+	}
+}
+
+func TestExecRefusesWhenServiceRunning(t *testing.T) {
+	application, out := newTestApp(t)
+	writeTestFile(t, application.paths.IniFile, bgm.DefaultINI)
+	startFakeService(t, application)
+	if err := application.dispatch(commandExec); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "BGM service is already running, exiting...\n" {
+		t.Fatalf("output %q", out.String())
+	}
+}

--- a/cmd/bgm/settings.go
+++ b/cmd/bgm/settings.go
@@ -1,0 +1,258 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/wizzomafizzo/mrext/pkg/bgm"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const pageSettings = "bgm_settings"
+
+const (
+	menuVolumeHelp = "Automatically change MiSTer's volume in the menu when it is open, to adjust music " +
+		"volume. The \"default volume\" setting must also be enabled for this feature to work."
+	defaultVolumeHelp = "Automatically revert MiSTer's volume when the menu is closed, to set volume back " +
+		"to normal. The \"menu volume\" setting must also be enabled for this feature to work."
+)
+
+//nolint:govet // Field order groups staged values and page runtime state.
+type settingsPage struct {
+	staged   bgm.Settings
+	original bgm.Settings
+	actions  map[int]func()
+	help     map[int]string
+	list     *tui.MenuList
+	ui       *ui
+}
+
+func (u *ui) startSettings() {
+	page := &settingsPage{
+		staged:   bgm.SettingsFromConfig(&u.cfg),
+		original: bgm.SettingsFromConfig(&u.cfg),
+		ui:       u,
+	}
+	page.show(0)
+}
+
+func (s *settingsPage) show(selection int) {
+	s.actions = make(map[int]func())
+	s.help = make(map[int]string)
+	s.list = tui.NewMenuList()
+	s.list.AddHeader("Playback")
+	s.addToggle("Start on boot", &s.staged.Startup)
+	s.addToggle("Play music in cores", &s.staged.PlayInCore)
+	s.addText("Core boot delay", bgm.FormatDelay(s.staged.CoreBootDelay), func(value string) error {
+		if _, err := bgm.ParseDelay(value); err != nil {
+			return fmt.Errorf("invalid core boot delay: %w", err)
+		}
+		return nil
+	}, func(value string) {
+		if parsed, err := bgm.ParseDelay(value); err == nil {
+			s.staged.CoreBootDelay = parsed
+		}
+	})
+
+	s.list.AddHeader("Volume")
+	s.addVolume("Menu volume", menuVolumeHelp, &s.staged.MenuVolume, true)
+	s.addVolume("Default volume", defaultVolumeHelp, &s.staged.DefaultVolume, false)
+
+	s.list.AddHeader("Logging")
+	s.addToggle("Debug logging", &s.staged.Debug)
+
+	s.list.AddHeader("Interface")
+	themes := make([]tui.Choice, 0, len(tui.ThemeNames))
+	for _, name := range tui.ThemeNames {
+		themes = append(themes, tui.Choice{Label: themeLabel(name), Help: "Applied after saving settings."})
+	}
+	themeIndex := slices.Index(tui.ThemeNames, s.staged.Theme)
+	s.addChoice("Theme", themeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
+		s.staged.Theme = tui.ThemeNames[index]
+	})
+	s.addToggle("Mouse", &s.staged.Mouse)
+	s.addToggle("CRT mode", &s.staged.CRTMode)
+	s.addToggle("On-screen keyboard", &s.staged.OnScreenKeyboard)
+
+	s.list.SetCurrentItem(selection)
+	change := func() {
+		if action := s.actions[s.list.GetCurrentItem()]; action != nil {
+			action()
+		}
+	}
+	s.list.SetSelectedFunc(func(int, string, string, rune) { change() })
+	back := func() { s.back() }
+	bar := tui.NewButtonBar(s.ui.app).
+		AddButtonWithHelp("Change", "Change selected setting", change).
+		AddButtonWithHelp("Save", "Save settings and return", s.save).
+		AddButtonWithHelp("Cancel", "Discard changes and return", back).
+		SetupNavigation(back)
+	frame := tui.NewPageFrame(s.ui.app).
+		SetTitle(appTitle, "Settings").
+		SetContent(s.list).
+		SetHelpText("Change settings, then save or cancel.").
+		SetButtonBar(bar).
+		SetOnEscape(back)
+	showHelp := func(index int) { frame.SetHelpText(s.help[index]) }
+	s.list.SetRowChangedFunc(showHelp)
+	showHelp(s.list.GetCurrentItem())
+	frame.SetupContentToButtonNavigation()
+	s.ui.pages.AddAndSwitchToPage(pageSettings, frame, true)
+	s.ui.app.SetFocus(s.list)
+}
+
+func (s *settingsPage) addRow(label, value string, action func()) {
+	index := s.list.GetItemCount()
+	s.list.AddRow(label+": "+value, tui.MenuRowAction)
+	s.actions[index] = action
+	s.help[index] = settingsHelp[label]
+}
+
+func (s *settingsPage) addToggle(label string, value *bool) {
+	display := "Off"
+	if *value {
+		display = "On"
+	}
+	s.addRow(label, display, func() {
+		*value = !*value
+		s.show(s.list.GetCurrentItem())
+	})
+}
+
+func (s *settingsPage) addChoice(label, value string, choices []tui.Choice, selected int, apply func(int)) {
+	s.addRow(label, value, func() {
+		selection := s.list.GetCurrentItem()
+		tui.ShowChoiceModal(s.ui.pages, s.ui.app, label, choices, max(selected, 0), func(index int) {
+			apply(index)
+			s.show(selection)
+		}, func() { s.show(selection) })
+	})
+}
+
+func (s *settingsPage) addText(label, value string, validate func(string) error, apply func(string)) {
+	s.addRow(label, value, func() {
+		selection := s.list.GetCurrentItem()
+		options := tui.InputOptions{
+			Title:            "Edit " + label,
+			Prompt:           "Enter the number of seconds to wait, such as 0 or 1.5.",
+			InitialValue:     value,
+			OnScreenKeyboard: s.ui.options.OnScreenKeyboard,
+			Validate:         validate,
+		}
+		tui.ShowInputModal(s.ui.pages, s.ui.app, options, func(updated string) {
+			apply(updated)
+			s.show(selection)
+		}, func() { s.show(selection) })
+	})
+}
+
+// addVolume offers the same nine levels as the Python dialog. The menu
+// volume is applied live when chosen, exactly as before.
+func (s *settingsPage) addVolume(label, help string, value *int, live bool) {
+	choices := make([]tui.Choice, 0, 9)
+	choices = append(choices,
+		tui.Choice{Label: "Disabled (make no changes to volume)", Help: help},
+		tui.Choice{Label: "Mute", Help: help},
+	)
+	for level := 1; level <= 7; level++ {
+		choice := tui.Choice{Label: "Level " + strconv.Itoa(level), Help: help}
+		if level == 7 {
+			choice.Label += " (max)"
+		}
+		choices = append(choices, choice)
+	}
+	s.addChoice(label, volumeLabel(*value), choices, *value+1, func(index int) {
+		*value = index - 1
+		if live && *value >= 0 {
+			bgm.VolumeSet(&s.ui.paths, s.ui.logger, *value)
+		}
+	})
+}
+
+func volumeLabel(volume int) string {
+	switch {
+	case volume < 0:
+		return "Disabled"
+	case volume == 0:
+		return "Mute"
+	default:
+		return "Level " + strconv.Itoa(volume)
+	}
+}
+
+func (s *settingsPage) back() {
+	if s.staged.Equal(&s.original) {
+		s.ui.mustShowMain()
+		return
+	}
+	tui.ShowConfirmModal(
+		s.ui.pages,
+		s.ui.app,
+		"Discard Settings",
+		"Discard unsaved settings?",
+		s.ui.mustShowMain,
+		func() { s.show(s.list.GetCurrentItem()) },
+	)
+}
+
+func (s *settingsPage) save() {
+	if _, exists := tui.AvailableThemes[s.staged.Theme]; !exists {
+		s.ui.showError(fmt.Errorf("unknown TUI theme: %s", s.staged.Theme), func() {
+			s.show(s.list.GetCurrentItem())
+		})
+		return
+	}
+	if err := bgm.SaveSettings(s.ui.paths.IniFile, &s.staged); err != nil {
+		s.ui.showError(err, func() { s.show(s.list.GetCurrentItem()) })
+		return
+	}
+	// The file is written, so the in-memory configuration follows it even
+	// when the running service cannot be told about the change.
+	s.apply()
+	if s.staged.PlayInCore != s.original.PlayInCore {
+		message := "set playincore no"
+		if s.staged.PlayInCore {
+			message = "set playincore yes"
+		}
+		if _, _, err := s.ui.send(message); err != nil {
+			s.ui.showError(err, s.ui.mustShowMain)
+			return
+		}
+	}
+	s.ui.mustShowMain()
+}
+
+func (s *settingsPage) apply() {
+	s.staged.ApplyTo(&s.ui.cfg)
+	s.ui.options = s.ui.applicationOptions()
+	_ = tui.SetCurrentTheme(s.ui.options.Theme)
+	s.ui.app.EnableMouse(s.ui.options.Mouse)
+	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
+}
+
+func themeLabel(name string) string {
+	if theme := tui.AvailableThemes[name]; theme != nil {
+		return theme.DisplayName
+	}
+	return name
+}

--- a/cmd/bgm/settings_help.go
+++ b/cmd/bgm/settings_help.go
@@ -1,0 +1,33 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+var settingsHelp = map[string]string{
+	"Start on boot":       "Start the BGM service automatically when MiSTer boots.",
+	"Play music in cores": "Keep playing music while a core is running instead of only in the menu.",
+	"Core boot delay":     "Seconds to wait before a core boot sound plays, for slow display sync.",
+	"Menu volume":         "MiSTer volume while the menu is open; needs Default volume too.",
+	"Default volume":      "MiSTer volume restored when a core runs; needs Menu volume too.",
+	"Debug logging":       "Write detailed service output to /tmp/bgm.log.",
+	"Theme":               "Choose a color palette to apply after saving.",
+	"Mouse":               "Enable mouse input alongside keyboard and controller navigation.",
+	"CRT mode":            "Use a compact 75-column, 15-row layout for CRT displays.",
+	"On-screen keyboard":  "Use controller-friendly text entry; Off needs a physical keyboard.",
+}

--- a/cmd/bgm/ui.go
+++ b/cmd/bgm/ui.go
@@ -1,0 +1,410 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/bgm"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const (
+	pageMain      = "bgm_main"
+	appTitle      = "Background Music"
+	activeMarker  = " [ACTIVE]"
+	statusDelay   = 200 * time.Millisecond
+	refreshPeriod = 2 * time.Second
+)
+
+// status is the parsed reply to the "status" socket command.
+type status struct {
+	playback string
+	playlist string
+	track    string
+	playing  bool
+}
+
+//nolint:govet // Field order groups runtime dependencies and navigation state.
+type ui struct {
+	paths   bgm.Paths
+	cfg     bgm.Config
+	logger  *bgm.Logger
+	app     *tview.Application
+	pages   *tview.Pages
+	options tui.ApplicationOptions
+	// send is the socket client; tests replace it.
+	send        func(string) (string, bool, error)
+	statusDelay time.Duration
+
+	mainSelection int
+	mainList      *tui.MenuList
+	mainBar       *tui.ButtonBar
+
+	mu         sync.Mutex
+	lastStatus status
+	runningApp *tview.Application
+}
+
+func newUI(paths *bgm.Paths, cfg *bgm.Config, logger *bgm.Logger) *ui {
+	view := &ui{
+		paths:       *paths,
+		cfg:         *cfg,
+		logger:      logger,
+		statusDelay: statusDelay,
+	}
+	view.send = func(message string) (string, bool, error) { return bgm.Send(&view.paths, message) }
+	view.options = view.applicationOptions()
+	return view
+}
+
+func (u *ui) applicationOptions() tui.ApplicationOptions {
+	return tui.ApplicationOptions{
+		Theme:            u.cfg.TUI.Theme,
+		Mouse:            u.cfg.TUI.Mouse,
+		CRTMode:          u.cfg.TUI.CRTMode,
+		OnScreenKeyboard: u.cfg.TUI.OnScreenKeyboard,
+	}
+}
+
+func (u *ui) Run() error {
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(u.options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		u.app = app
+		u.pages = tview.NewPages()
+		if err := u.showMain(); err != nil {
+			return nil, err
+		}
+		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
+		app.SetAfterDrawFunc(func(tcell.Screen) { u.markRunning(app) })
+		return app, nil
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	go u.refreshLoop(stop)
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run BGM TUI: %w", err)
+	}
+	return nil
+}
+
+func (u *ui) markRunning(app *tview.Application) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.runningApp = app
+}
+
+func (u *ui) runningApplication() *tview.Application {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.runningApp
+}
+
+func (u *ui) setLastStatus(current status) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.lastStatus = current
+}
+
+func (u *ui) statusChanged(current status) bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.lastStatus != current
+}
+
+// refreshLoop keeps "Now playing" current while the main screen is idle.
+func (u *ui) refreshLoop(stop <-chan struct{}) {
+	ticker := time.NewTicker(refreshPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			app := u.runningApplication()
+			if app == nil {
+				continue
+			}
+			current, err := u.fetchStatus(false)
+			if err != nil || !u.statusChanged(current) {
+				continue
+			}
+			app.QueueUpdateDraw(func() { u.refreshMain(current) })
+		}
+	}
+}
+
+// refreshMain rebuilds the main screen for a new status only while it is the
+// front page and the list has focus, so modals and the Settings page are
+// never disturbed. The cursor row and the highlighted button are kept.
+func (u *ui) refreshMain(current status) bool {
+	if name, _ := u.pages.GetFrontPage(); name != pageMain || u.mainList == nil || !u.mainList.HasFocus() {
+		return false
+	}
+	u.mainSelection = u.mainList.GetCurrentItem()
+	button := u.mainBar.FocusedIndex()
+	if err := u.buildMain(current); err != nil {
+		u.showError(err, u.app.Stop)
+		return false
+	}
+	u.mainBar.SetFocusedIndex(button)
+	return true
+}
+
+// fetchStatus mirrors get_status(), including the pause that gives the
+// service time to apply the previous command.
+func (u *ui) fetchStatus(delay bool) (status, error) {
+	if delay {
+		time.Sleep(u.statusDelay)
+	}
+	reply, replied, err := u.send("status")
+	if err != nil {
+		return status{}, err
+	}
+	if !replied {
+		return status{}, errors.New("BGM service is not running")
+	}
+	parts := strings.Split(reply, "\t")
+	if len(parts) < 4 {
+		return status{}, fmt.Errorf("invalid status from BGM service: %q", reply)
+	}
+	return status{playing: parts[0] == "yes", playback: parts[1], playlist: parts[2], track: parts[3]}, nil
+}
+
+func (u *ui) showMain() error {
+	current, err := u.fetchStatus(false)
+	if err != nil {
+		return err
+	}
+	return u.buildMain(current)
+}
+
+type mainRow struct {
+	action func()
+	label  string
+	help   string
+	kind   tui.MenuRowKind
+}
+
+func (u *ui) mainRows(current status) ([]mainRow, error) {
+	playlists, err := bgm.Playlists(&u.paths)
+	if err != nil {
+		return nil, fmt.Errorf("list BGM playlists: %w", err)
+	}
+	rows := []mainRow{
+		{
+			label: "Skip current track", help: "Stop the current track and move on.", kind: tui.MenuRowAction,
+			action: func() { u.command("skip", nil) },
+		},
+	}
+	if current.playing {
+		rows = append(rows, mainRow{
+			label: "Stop playing", help: "Stop background music until started again.",
+			kind: tui.MenuRowAction, action: func() { u.command("stop", nil) },
+		})
+	} else {
+		rows = append(rows, mainRow{
+			label: "Start playing", help: "Start the configured playlist.",
+			kind: tui.MenuRowAction, action: func() { u.command("play", nil) },
+		})
+	}
+	rows = append(rows, mainRow{label: "Playback", kind: tui.MenuRowHeader})
+	playbackRows := []struct{ label, help, value string }{
+		{"Play random tracks (random)", "Keep picking random tracks from the playlist.", bgm.PlaybackRandom},
+		{"Play a single random track on repeat (loop)", "Pick one track and repeat it.", bgm.PlaybackLoop},
+		{"Disable all playback (disabled)", "Play nothing except boot sounds.", bgm.PlaybackDisabled},
+	}
+	for _, row := range playbackRows {
+		rows = append(rows, mainRow{
+			label: row.label + active(current.playback == row.value), help: row.help, kind: tui.MenuRowItem,
+			action: func() {
+				u.command("set playback "+row.value, func(updated status) error {
+					return bgm.SavePlayback(u.paths.IniFile, updated.playback)
+				})
+			},
+		})
+	}
+	rows = append(rows, mainRow{label: "Playlist", kind: tui.MenuRowHeader})
+	playlistRows := []struct{ label, help, value string }{
+		{"None (just top level files)", "Play only files in the top level of the music folder.", "none"},
+		{"All (all playlists combined)", "Play every file from every playlist folder.", "all"},
+	}
+	for _, name := range playlists {
+		playlistRows = append(playlistRows, struct{ label, help, value string }{
+			name, "Play files from the " + name + " folder.", name,
+		})
+	}
+	for _, row := range playlistRows {
+		kind := tui.MenuRowItem
+		if row.value != "none" && row.value != "all" {
+			kind = tui.MenuRowFolder
+		}
+		rows = append(rows, mainRow{
+			label: row.label + active(current.playlist == row.value), help: row.help, kind: kind,
+			action: func() {
+				u.command("set playlist "+row.value, func(updated status) error {
+					return bgm.SavePlaylist(u.paths.IniFile, bgm.ParsePlaylist(updated.playlist))
+				})
+			},
+		})
+	}
+	return rows, nil
+}
+
+func (u *ui) buildMain(current status) error {
+	u.setLastStatus(current)
+	rows, err := u.mainRows(current)
+	if err != nil {
+		return err
+	}
+	nowPlaying := current.track
+	if nowPlaying == "" {
+		nowPlaying = "---"
+	}
+	details := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText(strings.Join([]string{
+			formatDetail("Now playing", nowPlaying),
+			formatDetail("Playback", titleCase(current.playback)),
+			formatDetail("Playlist", current.playlist),
+		}, "\n"))
+	list := tui.NewMenuList()
+	for _, row := range rows {
+		list.AddRow(row.label, row.kind)
+	}
+	list.SetCurrentItem(min(u.mainSelection, list.GetItemCount()-1))
+	activate := func() {
+		index := list.GetCurrentItem()
+		u.mainSelection = index
+		if index >= 0 && index < len(rows) && rows[index].action != nil {
+			rows[index].action()
+		}
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+	bar := tui.NewButtonBar(u.app).
+		AddButtonWithHelp("Select", "Run the selected action", activate).
+		AddButtonWithHelp("Settings", "Configure Background Music", u.startSettings).
+		AddButtonWithHelp("Exit", "Exit Background Music", u.app.Stop).
+		SetupNavigation(u.app.Stop)
+	content := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(details, 3, 0, false).
+		AddItem(list, 0, 1, true)
+	frame := tui.NewPageFrame(u.app).
+		SetTitle(appTitle).
+		SetContent(content).
+		SetFocusTarget(list).
+		SetHelpText("Select a playback action, playback type or playlist.").
+		SetButtonBar(bar).
+		SetOnEscape(u.app.Stop)
+	showHelp := func(index int) {
+		if index >= 0 && index < len(rows) && rows[index].help != "" {
+			frame.SetHelpText(rows[index].help)
+		}
+	}
+	list.SetRowChangedFunc(showHelp)
+	showHelp(list.GetCurrentItem())
+	bar.SetHelpCallback(func(text string) {
+		if text == "" {
+			showHelp(list.GetCurrentItem())
+		} else {
+			frame.SetHelpText(text)
+		}
+	})
+	frame.SetupContentToButtonNavigation()
+	u.mainList = list
+	u.mainBar = bar
+	u.pages.AddAndSwitchToPage(pageMain, frame, true)
+	u.app.SetFocus(list)
+	return nil
+}
+
+// command sends one socket command, refreshes the status the way the Python
+// menu did, optionally persists the result and rebuilds the main screen.
+func (u *ui) command(message string, persist func(status) error) {
+	if _, _, err := u.send(message); err != nil {
+		u.showError(err, u.app.Stop)
+		return
+	}
+	current, err := u.fetchStatus(true)
+	if err != nil {
+		u.showError(err, u.app.Stop)
+		return
+	}
+	if persist != nil {
+		if err := persist(current); err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+	}
+	if err := u.buildMain(current); err != nil {
+		u.showError(err, u.app.Stop)
+	}
+}
+
+func (u *ui) showError(err error, restore func()) {
+	tui.ShowErrorModal(u.pages, u.app, err.Error(), restore)
+}
+
+func (u *ui) mustShowMain() {
+	if err := u.showMain(); err != nil {
+		u.showError(err, u.app.Stop)
+	}
+}
+
+func active(condition bool) string {
+	if condition {
+		return activeMarker
+	}
+	return ""
+}
+
+func formatDetail(label, value string) string {
+	theme := tui.CurrentTheme()
+	return fmt.Sprintf("[%s::b]%s:[-::-] %s", theme.LabelName, label, tview.Escape(value))
+}
+
+// titleCase mirrors Python's str.title() used for the playback type.
+func titleCase(value string) string {
+	var out strings.Builder
+	previousLetter := false
+	for _, character := range value {
+		switch {
+		case !unicode.IsLetter(character):
+			_, _ = out.WriteRune(character)
+			previousLetter = false
+		case previousLetter:
+			_, _ = out.WriteRune(unicode.ToLower(character))
+		default:
+			_, _ = out.WriteRune(unicode.ToUpper(character))
+			previousLetter = true
+		}
+	}
+	return out.String()
+}

--- a/cmd/bgm/ui.go
+++ b/cmd/bgm/ui.go
@@ -67,6 +67,7 @@ type ui struct {
 
 	mu         sync.Mutex
 	lastStatus status
+	statusRev  uint64
 	runningApp *tview.Application
 }
 
@@ -131,6 +132,15 @@ func (u *ui) setLastStatus(current status) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	u.lastStatus = current
+	u.statusRev++
+}
+
+// statusRevision counts main-screen rebuilds so a refresh fetched before a
+// command completed cannot overwrite the newer status the command installed.
+func (u *ui) statusRevision() uint64 {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.statusRev
 }
 
 func (u *ui) statusChanged(current status) bool {
@@ -152,13 +162,23 @@ func (u *ui) refreshLoop(stop <-chan struct{}) {
 			if app == nil {
 				continue
 			}
+			revision := u.statusRevision()
 			current, err := u.fetchStatus(false)
 			if err != nil || !u.statusChanged(current) {
 				continue
 			}
-			app.QueueUpdateDraw(func() { u.refreshMain(current) })
+			app.QueueUpdateDraw(func() { u.applyRefresh(revision, current) })
 		}
 	}
+}
+
+// applyRefresh drops a status fetched before another rebuild changed the
+// screen, otherwise refreshes with it.
+func (u *ui) applyRefresh(revision uint64, current status) bool {
+	if u.statusRevision() != revision {
+		return false
+	}
+	return u.refreshMain(current)
 }
 
 // refreshMain rebuilds the main screen for a new status only while it is the

--- a/cmd/bgm/ui_test.go
+++ b/cmd/bgm/ui_test.go
@@ -1,0 +1,346 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/bgm"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const stubPlayer = "#!/bin/sh\nexec sleep 30\n"
+
+func installStubPlayers(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"mpg123", "ogg123", "aplay", "aplaymidi", "vgmplay"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(stubPlayer), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func sendUIKey(view *ui, key tcell.Key, value rune) {
+	view.app.GetFocus().InputHandler()(tcell.NewEventKey(key, value, tcell.ModNone), func(p tview.Primitive) {
+		view.app.SetFocus(p)
+	})
+}
+
+// newWorkflowUI runs a fake service on a temporary root and opens the main
+// screen headlessly.
+func newWorkflowUI(t *testing.T) (*ui, *bgm.Player) {
+	t.Helper()
+	installStubPlayers(t)
+	application, _ := newTestApp(t)
+	writeTestFile(t, application.paths.IniFile, bgm.DefaultINI)
+	writeTestFile(t, filepath.Join(application.paths.MusicFolder, "song.wav"), "")
+	writeTestFile(t, filepath.Join(application.paths.MusicFolder, "chip", "one.wav"), "")
+	player := startFakeService(t, application)
+	cfg, err := bgm.LoadConfig(&application.paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(&application.paths, &cfg, application.logger)
+	view.statusDelay = 0
+	app, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view.app = app
+	view.pages = tview.NewPages()
+	if err := view.showMain(); err != nil {
+		t.Fatal(err)
+	}
+	return view, player
+}
+
+// rowLabels returns the rendered row text; tview escapes the marker's
+// closing bracket, so tests compare against escapedActive.
+func rowLabels(view *ui) []string {
+	labels := make([]string, 0, view.mainList.GetItemCount())
+	for index := range view.mainList.GetItemCount() {
+		text, _ := view.mainList.GetItemText(index)
+		labels = append(labels, text)
+	}
+	return labels
+}
+
+var escapedActive = tview.Escape(activeMarker)
+
+func findRow(t *testing.T, view *ui, fragment string) int {
+	t.Helper()
+	for index, label := range rowLabels(view) {
+		if strings.Contains(label, fragment) {
+			return index
+		}
+	}
+	t.Fatalf("row %q not found in %v", fragment, rowLabels(view))
+	return -1
+}
+
+func selectRow(t *testing.T, view *ui, fragment string) {
+	t.Helper()
+	view.mainList.SetCurrentItem(findRow(t, view, fragment))
+	sendUIKey(view, tcell.KeyEnter, 0)
+}
+
+func readINI(t *testing.T, view *ui) string {
+	t.Helper()
+	data, err := os.ReadFile(view.paths.IniFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestMainScreenPlaybackSelectionPersists(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	labels := rowLabels(view)
+	if !strings.Contains(labels[findRow(t, view, "(random)")], escapedActive) {
+		t.Fatalf("random should be active: %v", labels)
+	}
+	if !strings.Contains(labels[findRow(t, view, "None (just top level files)")], escapedActive) {
+		t.Fatalf("none should be active: %v", labels)
+	}
+	selectRow(t, view, "(loop)")
+	if player.Playback() != bgm.PlaybackLoop {
+		t.Fatalf("service playback %q", player.Playback())
+	}
+	if !strings.Contains(readINI(t, view), "playback = loop\n") {
+		t.Fatalf("ini %q", readINI(t, view))
+	}
+	if !strings.Contains(rowLabels(view)[findRow(t, view, "(loop)")], escapedActive) {
+		t.Fatal("loop row should now be active")
+	}
+	if strings.Contains(rowLabels(view)[findRow(t, view, "(random)")], escapedActive) {
+		t.Fatal("random row should no longer be active")
+	}
+	player.StopPlaylist()
+}
+
+func TestMainScreenPlaylistSelectionPersists(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	selectRow(t, view, "chip")
+	if player.Playlist().Name() != "chip" {
+		t.Fatalf("service playlist %q", player.Playlist().Name())
+	}
+	if !strings.Contains(readINI(t, view), "playlist = chip\n") {
+		t.Fatalf("ini %q", readINI(t, view))
+	}
+	selectRow(t, view, "None (just top level files)")
+	if !player.Playlist().IsNone() || !strings.Contains(readINI(t, view), "playlist = none\n") {
+		t.Fatalf("playlist %+v ini %q", player.Playlist(), readINI(t, view))
+	}
+	player.StopPlaylist()
+}
+
+func TestMainScreenStartStopToggle(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	// Like the Python menu, give the service a moment to start the track.
+	view.statusDelay = 100 * time.Millisecond
+	selectRow(t, view, "Start playing")
+	if !player.InPlaylist() {
+		t.Fatal("play should start the playlist")
+	}
+	view.mainList.SetCurrentItem(findRow(t, view, "Stop playing"))
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if player.InPlaylist() {
+		t.Fatal("stop should end the playlist")
+	}
+	findRow(t, view, "Start playing")
+}
+
+func TestRefreshKeepsCursorAndOnlyRunsWhenIdle(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	row := findRow(t, view, "(loop)")
+	view.mainList.SetCurrentItem(row)
+	current, err := view.fetchStatus(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.playing, current.track = true, "one.wav"
+	if !view.refreshMain(current) {
+		t.Fatal("idle main screen should refresh")
+	}
+	if got := view.mainList.GetCurrentItem(); got != row {
+		t.Fatalf("cursor moved from %d to %d", row, got)
+	}
+	if view.statusChanged(current) {
+		t.Fatal("refresh should record the new status")
+	}
+	findRow(t, view, "Stop playing")
+
+	sendUIKey(view, tcell.KeyRight, 0) // highlight Settings
+	current.track = "two.wav"
+	if !view.refreshMain(current) || view.mainBar.FocusedIndex() != 1 {
+		t.Fatalf("refresh should keep the highlighted button, got %d", view.mainBar.FocusedIndex())
+	}
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if name, _ := view.pages.GetFrontPage(); name != pageSettings {
+		t.Fatalf("Enter should open the highlighted Settings button, on %s", name)
+	}
+	if view.refreshMain(current) {
+		t.Fatal("refresh must not run on the Settings page")
+	}
+	sendUIKey(view, tcell.KeyEscape, 0)
+
+	view.showError(errors.New("busy"), func() {})
+	if view.refreshMain(current) {
+		t.Fatal("refresh must not run under a modal")
+	}
+}
+
+func TestSettingsSaveWritesINIAndUpdatesService(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	view.startSettings()
+	view.pages.HasPage(pageSettings)
+	sendUIKey(view, tcell.KeyDown, 0) // Play music in cores
+	sendUIKey(view, tcell.KeyEnter, 0)
+	sendUIKey(view, tcell.KeyRight, 0) // Save
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if name, _ := view.pages.GetFrontPage(); name != pageMain {
+		t.Fatalf("expected to return to the main page, on %s", name)
+	}
+	ini := readINI(t, view)
+	if !strings.Contains(ini, "playincore = yes\n") || !strings.Contains(ini, "[tui]\ntheme = default\n") {
+		t.Fatalf("ini %q", ini)
+	}
+	if !player.PlayInCore() {
+		t.Fatal("service should receive set playincore yes")
+	}
+	if !view.cfg.PlayInCore {
+		t.Fatal("ui config should be updated")
+	}
+}
+
+func TestSettingsSaveKeepsConfigWhenServiceUnreachable(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	realSend := view.send
+	view.send = func(message string) (string, bool, error) {
+		if strings.HasPrefix(message, "set playincore") {
+			return "", false, errors.New("service gone")
+		}
+		return realSend(message)
+	}
+	view.startSettings()
+	sendUIKey(view, tcell.KeyDown, 0) // Play music in cores
+	sendUIKey(view, tcell.KeyEnter, 0)
+	sendUIKey(view, tcell.KeyRight, 0) // Save
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if !view.pages.HasPage("tui_error_modal") {
+		t.Fatal("expected the socket error to be shown")
+	}
+	if !view.cfg.PlayInCore || !strings.Contains(readINI(t, view), "playincore = yes\n") {
+		t.Fatalf("saved settings must be applied: cfg=%v ini=%q", view.cfg.PlayInCore, readINI(t, view))
+	}
+}
+
+func TestSettingsCancelAsksBeforeDiscarding(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	view.startSettings()
+	sendUIKey(view, tcell.KeyEnter, 0) // toggle Start on boot
+	sendUIKey(view, tcell.KeyEscape, 0)
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("expected a discard confirmation")
+	}
+	if strings.Contains(readINI(t, view), "startup = no") {
+		t.Fatal("cancelled settings must not be written")
+	}
+}
+
+func TestSettingsMenuVolumeAppliesLive(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	page := newSettingsPage(view)
+	page.show(0)
+	var index int
+	for candidate, help := range page.help {
+		if help == settingsHelp["Menu volume"] {
+			index = candidate
+		}
+	}
+	page.list.SetCurrentItem(index)
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if !view.pages.HasPage("tui_choice_modal") {
+		t.Fatal("expected the volume picker")
+	}
+	for range 4 { // Disabled -> Mute -> 1 -> 2 -> 3
+		sendUIKey(view, tcell.KeyDown, 0)
+	}
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if page.staged.MenuVolume != 3 {
+		t.Fatalf("staged menu volume %d", page.staged.MenuVolume)
+	}
+	data, err := os.ReadFile(view.paths.CmdInterface)
+	if err != nil || string(data) != "volume 3\n" {
+		t.Fatalf("live volume command %q %v", data, err)
+	}
+}
+
+func TestEverySettingHasHelpAndRenders(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	page := newSettingsPage(view)
+	page.show(0)
+	for index := range page.actions {
+		if help := page.help[index]; help == "" || len(help) > 73 {
+			t.Fatalf("missing or overflowing help for row %d: %q", index, help)
+		}
+	}
+	for _, size := range [][2]int{{75, 15}, {100, 30}} {
+		for _, name := range []string{pageSettings, pageMain} {
+			view.pages.SwitchToPage(name)
+			_, primitive := view.pages.GetFrontPage()
+			screen := tcell.NewSimulationScreen("UTF-8")
+			if err := screen.Init(); err != nil {
+				t.Fatal(err)
+			}
+			screen.SetSize(size[0], size[1])
+			primitive.SetRect(0, 0, size[0], size[1])
+			primitive.Draw(screen)
+			screen.Fini()
+		}
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	cases := map[string]string{"random": "Random", "foo_bar": "Foo_Bar", "abc3def": "Abc3Def", "LOOP": "Loop", "": ""}
+	for input, want := range cases {
+		if got := titleCase(input); got != want {
+			t.Fatalf("titleCase(%q) = %q want %q", input, got, want)
+		}
+	}
+}
+
+func newSettingsPage(view *ui) *settingsPage {
+	return &settingsPage{
+		staged:   bgm.SettingsFromConfig(&view.cfg),
+		original: bgm.SettingsFromConfig(&view.cfg),
+		ui:       view,
+	}
+}

--- a/cmd/bgm/ui_test.go
+++ b/cmd/bgm/ui_test.go
@@ -217,6 +217,31 @@ func TestRefreshKeepsCursorAndOnlyRunsWhenIdle(t *testing.T) {
 	}
 }
 
+func TestRefreshDiscardsStatusFetchedBeforeACommand(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	revision := view.statusRevision()
+	stale, err := view.fetchStatus(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectRow(t, view, "(loop)") // rebuilds with newer status
+	if view.applyRefresh(revision, stale) {
+		t.Fatal("a status fetched before the command must be discarded")
+	}
+	if !strings.Contains(rowLabels(view)[findRow(t, view, "(loop)")], escapedActive) {
+		t.Fatal("the command's status must remain on screen")
+	}
+	fresh, err := view.fetchStatus(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.track = "one.wav"
+	if !view.applyRefresh(view.statusRevision(), fresh) {
+		t.Fatal("a status fetched after the command must apply")
+	}
+	player.StopPlaylist()
+}
+
 func TestSettingsSaveWritesINIAndUpdatesService(t *testing.T) {
 	view, player := newWorkflowUI(t)
 	view.startSettings()

--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -1,0 +1,204 @@
+# BGM
+
+BGM plays background music in MiSTer's menu, stops it while a core runs, and plays boot sounds when MiSTer starts or a core launches. It runs as a standalone Go application and does not require Zaparoo Core.
+
+Zaparoo Core also offers core audio playback. See [MIGRATE.md](../MIGRATE.md) before choosing between them; internet radio and BGM's folder-based configuration have no confirmed equivalent there.
+
+## Installation
+
+Install BGM through the combined mrext Downloader database documented in the [README](../README.md). Downloader installs the ARMv7 binary as:
+
+```text
+/media/fat/Scripts/bgm.sh
+```
+
+The `.sh` filename is retained for compatibility with existing Downloader entries, the `user-startup.sh` hook, and MiSTer Scripts-menu behavior. It is a native executable, not a shell script, but it accepts exactly the same arguments as the Python script it replaces.
+
+Run `bgm` from MiSTer's Scripts menu. The first run creates the `music` folder on the SD card, adds the startup hook, and asks for music files. Once files are present, running `bgm` again starts the service and opens the control screen.
+
+## Features
+
+- Play music in the main MiSTer menu and stop automatically when a core launches.
+- Play boot sounds when MiSTer starts and when specific cores launch.
+- Play `.mp3`, `.ogg`, `.wav`, `.mid`, `.vgm`, `.vgz`, `.vgm.gz` files and `.pls` internet radio streams.
+- Organise tracks into playlist folders and switch between them.
+- Random or single-track-loop playback, and per-track loop counts.
+- Optionally keep music playing inside cores.
+- Automatically switch MiSTer's volume between the menu and cores.
+- Remote control through `/tmp/bgm.sock`, used by mrext Remote's music page.
+
+## Compatibility notes
+
+The Go version preserves the Python script's music folder layout, `bgm.ini` keys and file format, boot-sound and core-boot-sound rules, `_` and `X##_` filename prefixes, playlist semantics (`none`, `all`, folders, missing folders), play history, socket protocol and replies, `start`/`stop`/`restart`/`exec` commands, the `# Startup BGM` line in `user-startup.sh`, the `/tmp/bgm.log` debug log and every volume rule. Existing installations need no changes.
+
+Intentional differences:
+
+- The control screen uses the shared mrext TUI with themes and a controller-friendly Settings page. Playback and playlist choices are written to `bgm.ini` immediately; other settings are written when `Save` is selected.
+- Running `bgm.sh` with no arguments while the service is stopped starts the service and then opens the control screen. The Python script exited after starting the service.
+- Invalid values in `bgm.ini` fall back to their defaults instead of stopping the service. A `%` in a value no longer causes an error.
+- Core changes are detected with a native file watch instead of an `inotifywait` child process, with a short settle so CORENAME is never read while MiSTer is still writing it.
+- The service runs from a copy of the binary in `/tmp` so `bgm.sh` can be updated while music plays. The copy is removed when the service stops.
+- A socket file left behind by a crashed service is removed automatically instead of blocking BGM until reboot. `restart` waits for the old service to exit before starting the new one.
+- Stopping a playlist waits for the running track to be killed, so a stopped playlist can never start one more track. Unknown command-line arguments print usage instead of opening the menu.
+- Playlist folders are listed alphabetically in the menu.
+
+## Music folder
+
+```text
+/media/fat/music/
+  bgm.ini              configuration
+  *.mp3 …              tracks for the "none" playlist (top level only)
+  _startup.mp3         boot sound for the active playlist (underscore prefix)
+  X05_short_loop.mp3   plays five times in a row
+  Chiptunes/           a playlist folder; subfolders are included
+  Radio/station.pls    an internet radio playlist
+  boot/                global boot sounds, no prefix needed
+  boot/SNES/           boot sounds played when the SNES core launches
+```
+
+### Supported files
+
+BGM plays `.mp3`, `.ogg`, `.wav`, `.mid`, `.vgm`, `.vgz` and `.vgm.gz` files through `mpg123`, `ogg123`, `aplay`, `aplaymidi` and `vgmplay` from the MiSTer Linux image. Files can be mixed freely within a playlist.
+
+### Internet radio
+
+Internet radio stations are played from `.pls` files containing a stream URL. The best way to manage these is a playlist folder with a single `.pls` file. Multiple `.pls` files in a folder are only moved on by skipping. The `all` playlist excludes `.pls` files.
+
+### Playback types
+
+- `random` (default): repeatedly pick a random track, avoiding the most recent 20% of the playlist.
+- `loop`: pick one random track and repeat it until a reboot, core change or playlist change.
+- `disabled`: play nothing except boot sounds.
+
+### Playlists
+
+Create a subfolder in `music` and fill it with tracks; it appears in the control screen as a playlist and may contain any depth of subfolders. The `none` playlist (default) uses only files in the top level of `music`. The `all` playlist combines every folder, including `boot`. The chosen playlist is saved to `bgm.ini` and restored on boot. Boot sounds are taken from the active playlist.
+
+### Boot sounds
+
+Prefix a file with `_` to mark it as a boot sound (for example `_Startup.mp3`). One boot sound is picked at random from the active playlist's top level when MiSTer starts, and `_` files are excluded from normal playback. Files placed directly in `music/boot` are global boot sounds that apply to every playlist and need no prefix.
+
+### Core boot sounds
+
+Create a folder inside `music/boot` named after a core, such as `music/boot/SNES`, and add tracks. One is played when that core launches. The match is case-insensitive and also triggers for `.mgl` launches of the core. `corebootdelay` in `bgm.ini` waits the given number of seconds (decimals allowed) before playing, to allow a display to sync.
+
+### Per-track looping
+
+Rename a file with `X##_` in front, where `##` is a two-digit count with a leading zero. `X05_My File.mp3` plays five times before the next track; `X23_My File.mp3` plays twenty-three times.
+
+### Volume control
+
+Set both `Menu volume` and `Default volume` in Settings, or in `bgm.ini`:
+
+```ini
+menuvolume = 7
+defaultvolume = 3
+```
+
+Both values must be set for the feature to work. `0` mutes, `7` is maximum, and `-1` (the default) disables the feature. MiSTer's volume is set to `menuvolume` while the menu is open and to `defaultvolume` while a core runs.
+
+## Configuration
+
+BGM reads `/media/fat/music/bgm.ini`. The file is created with these defaults when missing:
+
+```ini
+[bgm]
+playback = random
+playlist = none
+startup = yes
+playincore = no
+corebootdelay = 0
+menuvolume = -1
+defaultvolume = -1
+debug = no
+```
+
+- `playback`: `random`, `loop` or `disabled`.
+- `playlist`: `none`, `all` or a folder name inside `music`.
+- `startup`: start the service from `user-startup.sh` on boot.
+- `playincore`: keep playing music while a core runs.
+- `corebootdelay`: seconds to wait before core boot sounds.
+- `menuvolume`, `defaultvolume`: `-1` to `7`, see Volume control.
+- `debug`: print service output and append it to `/tmp/bgm.log`. Re-read on every log line, so it can be toggled while the service runs.
+
+Booleans accept `yes`/`no`, `true`/`false`, `on`/`off` and `1`/`0`. Keys are case-insensitive; unknown keys and sections are kept when the control screen writes the file.
+
+### TUI settings
+
+An optional `[tui]` section controls the control screen and is written when settings are saved:
+
+```ini
+[tui]
+theme = default
+mouse = yes
+crt_mode = yes
+on_screen_keyboard = yes
+```
+
+Available themes: `default`, `high_contrast`, `dracula`, `nord`, `gruvbox`, `monogreen`. `crt_mode` uses MiSTer's 75×15 layout. `on_screen_keyboard` enables controller-friendly text entry for the core boot delay.
+
+## Control screen
+
+The main screen shows the current track, playback type and playlist, followed by `Skip current track`, `Start playing`/`Stop playing`, the playback types and the playlists. The active playback type and playlist are marked `[ACTIVE]`. Up and Down select a row, Left and Right select `Select`, `Settings` or `Exit`, and Enter activates the selected button. The screen refreshes itself while music plays.
+
+`Settings` opens a staged page for start on boot, play music in cores, core boot delay, menu and default volume, debug logging, theme, mouse, CRT mode and the on-screen keyboard. Changing the menu volume applies it to MiSTer immediately so it can be heard. Nothing is written until `Save`; `Cancel` or Escape asks before discarding changes.
+
+## Commands
+
+```text
+bgm.sh            interactive: prepare folders, start the service if needed, open the control screen
+bgm.sh start      start the service in the background if startup = yes
+bgm.sh stop       stop the running service
+bgm.sh restart    stop, wait for the service to exit, then start
+bgm.sh exec       run the service in the foreground (used internally)
+```
+
+The first interactive run appends this hook to `/media/fat/linux/user-startup.sh`, creating the file when missing:
+
+```sh
+# Startup BGM
+[[ -e /media/fat/Scripts/bgm.sh ]] && /media/fat/Scripts/bgm.sh $1
+```
+
+MiSTer passes `start` and `stop` through this hook on boot and shutdown.
+
+## Socket protocol
+
+The service listens on the unix socket `/tmp/bgm.sock`. Each connection carries one command of at most 4096 bytes; the service replies where noted and closes the connection.
+
+| Command | Reply |
+|---|---|
+| `status` | `yes` or `no`, playback type, playlist (`none` when unset) and the current track filename, separated by tabs |
+| `play`, `stop`, `skip` | none |
+| `set playback <type>` | none; unknown types play random tracks but are reported verbatim |
+| `set playlist <name>` | none; `none` clears the playlist, names may contain spaces |
+| `set playincore yes` / `set playincore no` | none |
+| `get playback`, `get playincore` | the value |
+| `get playlist` | the name; nothing when no playlist is set |
+| `pid` | the service process id |
+| `quit` | none; stops the socket listener |
+
+Commands are processed one at a time and wait while a core boot sound plays, exactly as before.
+
+## Logging
+
+With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players.
+
+## Local development
+
+Run BGM against a temporary MiSTer root without touching `/media/fat`:
+
+```bash
+go run ./cmd/bgm --root /tmp/bgm-mister
+```
+
+The root gains `music`, `tmp`, `dev` and `linux` folders. `tmp/CORENAME` stands in for MiSTer's core name file, `dev/MiSTer_cmd` is a regular file that records volume commands, and the service socket is `tmp/bgm.sock`. Put stub `mpg123`, `aplay` and similar scripts first on `PATH` to test without audio hardware. All commands accept `--root`:
+
+```bash
+echo MENU > /tmp/bgm-mister/tmp/CORENAME
+go run ./cmd/bgm --root /tmp/bgm-mister start
+printf status | nc -U /tmp/bgm-mister/tmp/bgm.sock
+go run ./cmd/bgm --root /tmp/bgm-mister stop
+```
+
+Keep the root path short: unix socket paths are limited to about 100 characters.

--- a/magefile.go
+++ b/magefile.go
@@ -89,6 +89,13 @@ var apps = []app{
 		inAll:     true,
 	},
 	{
+		name:      "bgm",
+		path:      filepath.Join(cwd, "cmd", "bgm"),
+		bin:       "bgm.sh",
+		releaseId: "mrext/bgm",
+		inAll:     true,
+	},
+	{
 		name:      "launchsync",
 		path:      filepath.Join(cwd, "cmd", "launchsync"),
 		bin:       "launchsync.sh",
@@ -111,11 +118,6 @@ type scriptApp struct {
 }
 
 var scriptApps = []scriptApp{
-	{
-		name: "bgm",
-		path: filepath.Join(cwd, "scripts", "bgm.sh"),
-		bin:  "bgm.sh",
-	},
 	{
 		name: "gamesmenu",
 		path: filepath.Join(cwd, "scripts", "gamesmenu.sh"),

--- a/pkg/bgm/config.go
+++ b/pkg/bgm/config.go
@@ -1,0 +1,399 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// DefaultINI is written byte-for-byte when bgm.ini is missing, exactly as the
+// Python script did.
+const DefaultINI = "[bgm]\nplayback = random\nplaylist = none\nstartup = yes\nplayincore = no\n" +
+	"corebootdelay = 0\nmenuvolume = -1\ndefaultvolume = -1\ndebug = no\n"
+
+const (
+	iniSectionBGM = "bgm"
+	iniSectionTUI = "tui"
+)
+
+const (
+	PlaybackRandom   = "random"
+	PlaybackLoop     = "loop"
+	PlaybackDisabled = "disabled"
+	playlistNoneName = "none"
+	playlistAllName  = "all"
+)
+
+// Playlist is a configured playlist name. The zero value is Python's None,
+// written to the file as "none", and is distinct from an empty name.
+type Playlist struct {
+	name string
+	set  bool
+}
+
+// NamedPlaylist returns a playlist for a folder name.
+func NamedPlaylist(name string) Playlist {
+	return Playlist{name: name, set: true}
+}
+
+// ParsePlaylist converts a configuration value, mapping "none" to no playlist.
+func ParsePlaylist(value string) Playlist {
+	if value == playlistNoneName {
+		return Playlist{}
+	}
+	return NamedPlaylist(value)
+}
+
+// IsNone reports whether no playlist is configured.
+func (p Playlist) IsNone() bool { return !p.set }
+
+// IsAll reports whether the combined "all" playlist is configured.
+func (p Playlist) IsAll() bool { return p.set && p.name == playlistAllName }
+
+// Name returns the folder name; empty for no playlist.
+func (p Playlist) Name() string { return p.name }
+
+// String renders the playlist as stored in bgm.ini and reported over the
+// socket.
+func (p Playlist) String() string {
+	if !p.set {
+		return playlistNoneName
+	}
+	return p.name
+}
+
+// TUIOptions are the optional [tui] settings shared with other mrext apps.
+type TUIOptions struct {
+	Theme            string
+	Mouse            bool
+	CRTMode          bool
+	OnScreenKeyboard bool
+}
+
+// Config is the typed view of bgm.ini with Python's defaults applied.
+type Config struct {
+	Playback      string
+	Playlist      Playlist
+	TUI           TUIOptions
+	CoreBootDelay float64
+	MenuVolume    int
+	DefaultVolume int
+	Startup       bool
+	PlayInCore    bool
+	Debug         bool
+}
+
+// DefaultConfig returns the values used when keys are missing.
+func DefaultConfig() Config {
+	return Config{
+		Playback:      PlaybackRandom,
+		MenuVolume:    -1,
+		DefaultVolume: -1,
+		Startup:       true,
+		TUI: TUIOptions{
+			Theme:            "default",
+			Mouse:            true,
+			CRTMode:          true,
+			OnScreenKeyboard: true,
+		},
+	}
+}
+
+// ShouldChangeVolume mirrors should_change_volume(): both volumes enabled.
+func (c *Config) ShouldChangeVolume() bool {
+	return c.MenuVolume >= 0 && c.DefaultVolume >= 0
+}
+
+// WriteDefaultINI creates the default file when the music folder exists.
+func WriteDefaultINI(paths *Paths) error {
+	if !fileExists(paths.MusicFolder) {
+		return nil
+	}
+	// #nosec G306 -- MiSTer configuration must remain editable through shared storage.
+	if err := os.WriteFile(paths.IniFile, []byte(DefaultINI), 0o644); err != nil {
+		return fmt.Errorf("write default BGM configuration: %w", err)
+	}
+	return nil
+}
+
+// LoadConfig mirrors get_ini(): recreate a missing file, then read it with
+// fallbacks. Defaults are returned alongside any error.
+func LoadConfig(paths *Paths) (Config, error) {
+	if _, err := os.Stat(paths.IniFile); err != nil {
+		if writeErr := WriteDefaultINI(paths); writeErr != nil {
+			return DefaultConfig(), writeErr
+		}
+	}
+	doc, err := ReadINI(paths.IniFile)
+	if err != nil {
+		return DefaultConfig(), err
+	}
+	return ConfigFromDocument(doc), nil
+}
+
+// ConfigFromDocument applies Python's fallbacks and parsing rules. Values
+// Python would have rejected fall back to the default instead of failing.
+func ConfigFromDocument(doc *Document) Config {
+	cfg := DefaultConfig()
+	if value, ok := doc.Get(iniSectionBGM, "playback"); ok {
+		cfg.Playback = value
+	}
+	if value, ok := doc.Get(iniSectionBGM, "playlist"); ok {
+		cfg.Playlist = ParsePlaylist(value)
+	}
+	cfg.Startup = docBool(doc, iniSectionBGM, "startup", cfg.Startup)
+	cfg.PlayInCore = docBool(doc, iniSectionBGM, "playincore", cfg.PlayInCore)
+	cfg.Debug = docBool(doc, iniSectionBGM, "debug", cfg.Debug)
+	cfg.MenuVolume = docInt(doc, iniSectionBGM, "menuvolume", cfg.MenuVolume)
+	cfg.DefaultVolume = docInt(doc, iniSectionBGM, "defaultvolume", cfg.DefaultVolume)
+	if value, ok := doc.Get(iniSectionBGM, "corebootdelay"); ok {
+		if parsed, valid := parsePythonFloat(value); valid {
+			cfg.CoreBootDelay = parsed
+		}
+	}
+	if value, ok := doc.Get(iniSectionTUI, "theme"); ok && strings.TrimSpace(value) != "" {
+		cfg.TUI.Theme = strings.TrimSpace(value)
+	}
+	cfg.TUI.Mouse = docBool(doc, iniSectionTUI, "mouse", cfg.TUI.Mouse)
+	cfg.TUI.CRTMode = docBool(doc, iniSectionTUI, "crt_mode", cfg.TUI.CRTMode)
+	cfg.TUI.OnScreenKeyboard = docBool(doc, iniSectionTUI, "on_screen_keyboard", cfg.TUI.OnScreenKeyboard)
+	return cfg
+}
+
+func docBool(doc *Document, section, key string, fallback bool) bool {
+	value, ok := doc.Get(section, key)
+	if !ok {
+		return fallback
+	}
+	parsed, valid := parsePythonBool(value)
+	if !valid {
+		return fallback
+	}
+	return parsed
+}
+
+func docInt(doc *Document, section, key string, fallback int) int {
+	value, ok := doc.Get(section, key)
+	if !ok {
+		return fallback
+	}
+	parsed, valid := parsePythonInt(value)
+	if !valid {
+		return fallback
+	}
+	return parsed
+}
+
+// parsePythonBool implements ConfigParser.getboolean's accepted states.
+func parsePythonBool(value string) (result, valid bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "yes", "true", "on":
+		return true, true
+	case "0", "no", "false", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+var (
+	pythonIntPattern   = regexp.MustCompile(`^[+-]?\d+(?:_\d+)*$`)
+	pythonFloatPattern = regexp.MustCompile(
+		`^[+-]?(?:\d+(?:_\d+)*)?(?:\.(?:\d+(?:_\d+)*)?)?(?:e[+-]?\d+(?:_\d+)*)?$`,
+	)
+)
+
+// parsePythonInt accepts what Python's int() accepts for decimal text.
+func parsePythonInt(value string) (int, bool) {
+	trimmed := strings.TrimSpace(value)
+	if !pythonIntPattern.MatchString(trimmed) {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(strings.ReplaceAll(trimmed, "_", ""))
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+// parsePythonFloat accepts finite values Python's float() accepts.
+func parsePythonFloat(value string) (float64, bool) {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if !pythonFloatPattern.MatchString(trimmed) || !strings.ContainsAny(trimmed, "0123456789") {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(strings.ReplaceAll(trimmed, "_", ""), 64)
+	if err != nil || math.IsInf(parsed, 0) || math.IsNaN(parsed) {
+		return 0, false
+	}
+	return parsed, true
+}
+
+// UpdateINI reads bgm.ini, lets apply change it, and writes it back
+// atomically while retaining unknown sections and keys.
+func UpdateINI(path string, apply func(*Document)) error {
+	doc, err := ReadINI(path)
+	if err != nil {
+		return err
+	}
+	apply(doc)
+	return doc.WriteFile(path)
+}
+
+// SavePlayback persists the playback type chosen on the main screen.
+func SavePlayback(path, playback string) error {
+	return UpdateINI(path, func(doc *Document) { doc.Set(iniSectionBGM, "playback", playback) })
+}
+
+// SavePlaylist persists the playlist chosen on the main screen.
+func SavePlaylist(path string, playlist Playlist) error {
+	return UpdateINI(path, func(doc *Document) { doc.Set(iniSectionBGM, "playlist", playlist.String()) })
+}
+
+// Settings is the staged view edited on the Settings screen.
+type Settings struct {
+	Theme            string
+	CoreBootDelay    float64
+	MenuVolume       int
+	DefaultVolume    int
+	Startup          bool
+	PlayInCore       bool
+	Debug            bool
+	Mouse            bool
+	CRTMode          bool
+	OnScreenKeyboard bool
+}
+
+// SettingsFromConfig copies the editable values out of a configuration.
+func SettingsFromConfig(cfg *Config) Settings {
+	return Settings{
+		Theme:            cfg.TUI.Theme,
+		CoreBootDelay:    cfg.CoreBootDelay,
+		MenuVolume:       cfg.MenuVolume,
+		DefaultVolume:    cfg.DefaultVolume,
+		Startup:          cfg.Startup,
+		PlayInCore:       cfg.PlayInCore,
+		Debug:            cfg.Debug,
+		Mouse:            cfg.TUI.Mouse,
+		CRTMode:          cfg.TUI.CRTMode,
+		OnScreenKeyboard: cfg.TUI.OnScreenKeyboard,
+	}
+}
+
+// ApplyTo copies the staged values into a configuration.
+func (s *Settings) ApplyTo(cfg *Config) {
+	cfg.TUI.Theme = s.Theme
+	cfg.CoreBootDelay = s.CoreBootDelay
+	cfg.MenuVolume = s.MenuVolume
+	cfg.DefaultVolume = s.DefaultVolume
+	cfg.Startup = s.Startup
+	cfg.PlayInCore = s.PlayInCore
+	cfg.Debug = s.Debug
+	cfg.TUI.Mouse = s.Mouse
+	cfg.TUI.CRTMode = s.CRTMode
+	cfg.TUI.OnScreenKeyboard = s.OnScreenKeyboard
+}
+
+// Equal reports whether two staged settings match.
+func (s *Settings) Equal(other *Settings) bool {
+	return *s == *other
+}
+
+// Validate rejects values the service could not use.
+func (s *Settings) Validate() error {
+	if strings.TrimSpace(s.Theme) == "" {
+		return errors.New("tui.theme must not be empty")
+	}
+	if s.CoreBootDelay < 0 || math.IsInf(s.CoreBootDelay, 0) || math.IsNaN(s.CoreBootDelay) {
+		return errors.New("bgm.corebootdelay must be zero or a positive number of seconds")
+	}
+	for name, volume := range map[string]int{"menuvolume": s.MenuVolume, "defaultvolume": s.DefaultVolume} {
+		if volume < -1 || volume > 7 {
+			return fmt.Errorf("bgm.%s must be between -1 and 7", name)
+		}
+	}
+	return nil
+}
+
+// SaveSettings writes the staged values into bgm.ini, keeping every other
+// key and section untouched.
+func SaveSettings(path string, settings *Settings) error {
+	if err := settings.Validate(); err != nil {
+		return err
+	}
+	return UpdateINI(path, func(doc *Document) {
+		doc.Set(iniSectionBGM, "startup", formatYesNo(settings.Startup))
+		doc.Set(iniSectionBGM, "playincore", formatYesNo(settings.PlayInCore))
+		doc.Set(iniSectionBGM, "corebootdelay", FormatDelay(settings.CoreBootDelay))
+		doc.Set(iniSectionBGM, "menuvolume", strconv.Itoa(settings.MenuVolume))
+		doc.Set(iniSectionBGM, "defaultvolume", strconv.Itoa(settings.DefaultVolume))
+		doc.Set(iniSectionBGM, "debug", formatYesNo(settings.Debug))
+		doc.Set(iniSectionTUI, "theme", settings.Theme)
+		doc.Set(iniSectionTUI, "mouse", formatYesNo(settings.Mouse))
+		doc.Set(iniSectionTUI, "crt_mode", formatYesNo(settings.CRTMode))
+		doc.Set(iniSectionTUI, "on_screen_keyboard", formatYesNo(settings.OnScreenKeyboard))
+	})
+}
+
+// FormatDelay renders a core boot delay without trailing zeros.
+func FormatDelay(seconds float64) string {
+	return strconv.FormatFloat(seconds, 'f', -1, 64)
+}
+
+// ParseDelay validates text entered for the core boot delay.
+func ParseDelay(value string) (float64, error) {
+	parsed, valid := parsePythonFloat(value)
+	if !valid || parsed < 0 {
+		return 0, errors.New("enter zero or a positive number of seconds, such as 0 or 1.5")
+	}
+	return parsed, nil
+}
+
+func formatYesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+// EnsureMusicFolder creates the music folder when missing and reports
+// whether it did so.
+func EnsureMusicFolder(paths *Paths) (bool, error) {
+	if fileExists(paths.MusicFolder) {
+		return false, nil
+	}
+	// #nosec G301 -- MiSTer's shared storage keeps folders world accessible.
+	if err := os.MkdirAll(filepath.Clean(paths.MusicFolder), 0o755); err != nil {
+		return false, fmt.Errorf("create music folder: %w", err)
+	}
+	return true, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/pkg/bgm/config_test.go
+++ b/pkg/bgm/config_test.go
@@ -1,0 +1,201 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParsePythonBool(t *testing.T) {
+	accepted := map[string]bool{
+		"1": true, "yes": true, "TRUE": true, "On": true,
+		"0": false, "No": false, "false": false, "OFF": false,
+	}
+	for value, want := range accepted {
+		got, valid := parsePythonBool(value)
+		if !valid || got != want {
+			t.Fatalf("%q -> %v valid=%v", value, got, valid)
+		}
+	}
+	for _, value := range []string{"y", "t", "maybe", ""} {
+		if _, valid := parsePythonBool(value); valid {
+			t.Fatalf("%q should be rejected like configparser", value)
+		}
+	}
+}
+
+func TestParsePythonNumbers(t *testing.T) {
+	ints := []struct {
+		value string
+		want  int
+	}{{" 7 ", 7}, {"+3", 3}, {"-1", -1}, {"1_0", 10}}
+	for _, item := range ints {
+		got, valid := parsePythonInt(item.value)
+		if !valid || got != item.want {
+			t.Fatalf("int %q -> %d valid=%v", item.value, got, valid)
+		}
+	}
+	for _, value := range []string{"3.0", "", "x", "1__0", "_1"} {
+		if _, valid := parsePythonInt(value); valid {
+			t.Fatalf("int %q should be rejected", value)
+		}
+	}
+	floats := []struct {
+		value string
+		want  float64
+	}{{"0", 0}, {"0.5", 0.5}, {".5", 0.5}, {"2.", 2}, {"1e1", 10}, {" 1_000.5 ", 1000.5}}
+	for _, item := range floats {
+		got, valid := parsePythonFloat(item.value)
+		if !valid || got != item.want {
+			t.Fatalf("float %q -> %v valid=%v", item.value, got, valid)
+		}
+	}
+	for _, value := range []string{"inf", "nan", "", "abc", "."} {
+		if _, valid := parsePythonFloat(value); valid {
+			t.Fatalf("float %q should be rejected", value)
+		}
+	}
+}
+
+func TestConfigFromDocumentAppliesFallbacks(t *testing.T) {
+	doc := ParseINI("[bgm]\nplayback = Loop\nplaylist = none\nstartup = maybe\nplayincore = ON\n" +
+		"corebootdelay = 1.5\nmenuvolume = seven\ndefaultvolume = 4\n[tui]\ntheme = nord\nmouse = no\n")
+	cfg := ConfigFromDocument(doc)
+	if cfg.Playback != "Loop" {
+		t.Fatalf("playback must keep its case, got %q", cfg.Playback)
+	}
+	if !cfg.Playlist.IsNone() {
+		t.Fatal("playlist none should parse as no playlist")
+	}
+	if !cfg.Startup {
+		t.Fatal("invalid startup should fall back to the default true")
+	}
+	if !cfg.PlayInCore || cfg.CoreBootDelay != 1.5 || cfg.MenuVolume != -1 || cfg.DefaultVolume != 4 {
+		t.Fatalf("unexpected config %+v", cfg)
+	}
+	if cfg.TUI.Theme != "nord" || cfg.TUI.Mouse || !cfg.TUI.CRTMode {
+		t.Fatalf("unexpected tui options %+v", cfg.TUI)
+	}
+	empty := ConfigFromDocument(ParseINI("[bgm]\nplaylist =\n"))
+	if empty.Playlist.IsNone() || empty.Playlist.Name() != "" || empty.Playlist.String() != "" {
+		t.Fatalf("empty playlist must be a distinct named playlist: %+v", empty.Playlist)
+	}
+	if ParsePlaylist("None").IsNone() {
+		t.Fatal("only lowercase none means no playlist")
+	}
+}
+
+func TestLoadConfigWritesDefaultOnlyWhenMusicFolderExists(t *testing.T) {
+	paths := newTestPaths(t)
+	cfg, err := LoadConfig(&paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, paths.IniFile); got != DefaultINI {
+		t.Fatalf("default ini = %q", got)
+	}
+	if cfg != DefaultConfig() {
+		t.Fatalf("config %+v != defaults", cfg)
+	}
+
+	missing := RootedPaths(t.TempDir())
+	if _, err := LoadConfig(&missing); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(missing.IniFile); !os.IsNotExist(err) {
+		t.Fatal("ini must not be created without a music folder")
+	}
+}
+
+func TestSaveSettingsPreservesUnknownEntriesAndFormat(t *testing.T) {
+	paths := newTestPaths(t)
+	writeINI(t, &paths, "[bgm]\nplayback = loop\ncustom = keep\nstartup = yes\n[extra]\nfoo = bar\n")
+	settings := Settings{
+		Theme: "nord", CoreBootDelay: 0.5, MenuVolume: 5, DefaultVolume: -1,
+		Startup: false, PlayInCore: true, Debug: true, Mouse: false, CRTMode: true, OnScreenKeyboard: true,
+	}
+	if err := SaveSettings(paths.IniFile, &settings); err != nil {
+		t.Fatal(err)
+	}
+	want := "[bgm]\nplayback = loop\ncustom = keep\nstartup = no\nplayincore = yes\ncorebootdelay = 0.5\n" +
+		"menuvolume = 5\ndefaultvolume = -1\ndebug = yes\n\n[extra]\nfoo = bar\n\n" +
+		"[tui]\ntheme = nord\nmouse = no\ncrt_mode = yes\non_screen_keyboard = yes\n\n"
+	if got := readFile(t, paths.IniFile); got != want {
+		t.Fatalf("saved:\n%q\nwant:\n%q", got, want)
+	}
+	cfg, err := LoadConfig(&paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if SettingsFromConfig(&cfg) != settings {
+		t.Fatalf("round trip %+v != %+v", SettingsFromConfig(&cfg), settings)
+	}
+}
+
+func TestSavePlaybackAndPlaylist(t *testing.T) {
+	paths := newTestPaths(t)
+	writeINI(t, &paths, DefaultINI)
+	if err := SavePlayback(paths.IniFile, PlaybackLoop); err != nil {
+		t.Fatal(err)
+	}
+	if err := SavePlaylist(paths.IniFile, NamedPlaylist("chip tunes")); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := LoadConfig(&paths)
+	if cfg.Playback != PlaybackLoop || cfg.Playlist.Name() != "chip tunes" {
+		t.Fatalf("config %+v", cfg)
+	}
+	if err := SavePlaylist(paths.IniFile, Playlist{}); err != nil {
+		t.Fatal(err)
+	}
+	if doc, _ := ReadINI(paths.IniFile); doc != nil {
+		if value, _ := doc.Get("bgm", "playlist"); value != "none" {
+			t.Fatalf("no playlist must be written as none, got %q", value)
+		}
+	}
+}
+
+func TestSettingsValidateAndDelayParsing(t *testing.T) {
+	defaults := DefaultConfig()
+	settings := SettingsFromConfig(&defaults)
+	if err := settings.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	settings.MenuVolume = 8
+	if err := settings.Validate(); err == nil {
+		t.Fatal("volume 8 must be rejected")
+	}
+	if _, err := ParseDelay("-1"); err == nil {
+		t.Fatal("negative delay must be rejected")
+	}
+	if value, err := ParseDelay(" 2.50 "); err != nil || value != 2.5 {
+		t.Fatalf("ParseDelay = %v %v", value, err)
+	}
+	if FormatDelay(2.5) != "2.5" || FormatDelay(0) != "0" || FormatDelay(3) != "3" {
+		t.Fatal("FormatDelay must not add trailing zeros")
+	}
+	both := Config{MenuVolume: 0, DefaultVolume: 7}
+	menuOnly := Config{MenuVolume: -1, DefaultVolume: 7}
+	if !both.ShouldChangeVolume() || menuOnly.ShouldChangeVolume() {
+		t.Fatal("ShouldChangeVolume requires both volumes enabled")
+	}
+}

--- a/pkg/bgm/daemon.go
+++ b/pkg/bgm/daemon.go
@@ -1,0 +1,170 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ServiceBinaryPath is where the running service copy lives so the installed
+// bgm.sh can be replaced by an updater while music plays.
+func ServiceBinaryPath(paths *Paths) string {
+	return filepath.Join(paths.TempFolder, AppFilename)
+}
+
+// SpawnService mirrors `bgm.sh exec &`: start the service detached. The
+// binary is first copied to the temp folder, as mrext's other daemons do.
+func SpawnService(paths *Paths, root string) error {
+	binary, err := copyServiceBinary(paths)
+	if err != nil {
+		return err
+	}
+	args := make([]string, 0, 3)
+	if root != "" {
+		args = append(args, "--root", root)
+	}
+	args = append(args, "exec")
+	// #nosec G204 -- the executable is the copy of this program created above.
+	cmd := exec.CommandContext(context.Background(), binary, args...)
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = detachAttributes()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start BGM service: %w", err)
+	}
+	_ = cmd.Process.Release()
+	return nil
+}
+
+// copyServiceBinary writes the copy beside its final name and renames it into
+// place: during a restart the previous service can still be exiting from the
+// old copy, and Linux refuses to overwrite a running executable in place.
+func copyServiceBinary(paths *Paths) (string, error) {
+	// #nosec G304 -- the source is this program's own executable path.
+	source, err := os.Open(paths.AppPath)
+	if err != nil {
+		return "", fmt.Errorf("open BGM binary: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	target := ServiceBinaryPath(paths)
+	destination, err := os.CreateTemp(paths.TempFolder, "."+AppFilename+"-*")
+	if err != nil {
+		return "", fmt.Errorf("create BGM service copy: %w", err)
+	}
+	temporaryPath := destination.Name()
+	removeTemporary := true
+	defer func() {
+		_ = destination.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		return "", fmt.Errorf("copy BGM binary: %w", err)
+	}
+	// #nosec G302 -- the service copy must be executable.
+	if err := destination.Chmod(0o755); err != nil {
+		return "", fmt.Errorf("set BGM service copy permissions: %w", err)
+	}
+	if err := destination.Close(); err != nil {
+		return "", fmt.Errorf("close BGM service copy: %w", err)
+	}
+	// #nosec G703 -- destination is the fixed service copy path.
+	if err := os.Rename(temporaryPath, target); err != nil {
+		return "", fmt.Errorf("replace BGM service copy: %w", err)
+	}
+	removeTemporary = false
+	return target, nil
+}
+
+// RemoveServiceBinary deletes the temp copy when this process runs from it.
+func RemoveServiceBinary(paths *Paths) {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if filepath.Clean(exe) == filepath.Clean(ServiceBinaryPath(paths)) {
+		_ = os.Remove(exe)
+	}
+}
+
+// StopService mirrors `bgm.sh stop`: ask the service for its pid and send
+// SIGTERM. A socket nobody listens on is removed instead of crashing.
+func StopService(paths *Paths, logger *Logger) error {
+	if !SocketExists(paths) {
+		logger.Print("BGM service is not running")
+		return nil
+	}
+	if SocketStale(paths) {
+		_ = os.Remove(paths.SocketFile)
+		logger.Print("BGM service is not running")
+		return nil
+	}
+	reply, replied, err := Send(paths, "pid")
+	if err != nil {
+		return err
+	}
+	if !replied {
+		return nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(reply))
+	if err != nil {
+		return fmt.Errorf("parse BGM service pid %q: %w", reply, err)
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find BGM service process: %w", err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("stop BGM service: %w", err)
+	}
+	return nil
+}
+
+// WaitForSocket waits until the socket file exists.
+func WaitForSocket(paths *Paths, timeout time.Duration) bool {
+	return waitUntil(timeout, func() bool { return SocketExists(paths) })
+}
+
+// WaitForSocketGone waits until the socket file has been removed.
+func WaitForSocketGone(paths *Paths, timeout time.Duration) bool {
+	return waitUntil(timeout, func() bool { return !SocketExists(paths) })
+}
+
+func waitUntil(timeout time.Duration, condition func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/bgm/daemon_test.go
+++ b/pkg/bgm/daemon_test.go
@@ -1,0 +1,153 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStopServiceWithoutSocket(t *testing.T) {
+	paths := newTestPaths(t)
+	logger, out := newTestLogger(&paths)
+	if err := StopService(&paths, logger); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "BGM service is not running\n" {
+		t.Fatalf("output %q", out.String())
+	}
+}
+
+func TestStopServiceRemovesStaleSocket(t *testing.T) {
+	paths := newTestPaths(t)
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", paths.SocketFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		t.Fatal("expected a unix listener")
+	}
+	unixListener.SetUnlinkOnClose(false)
+	_ = listener.Close()
+	if !SocketStale(&paths) {
+		t.Fatal("closed listener must be detected as stale")
+	}
+	logger, out := newTestLogger(&paths)
+	if err := StopService(&paths, logger); err != nil {
+		t.Fatal(err)
+	}
+	if SocketExists(&paths) {
+		t.Fatal("stale socket must be removed")
+	}
+	if out.String() != "BGM service is not running\n" {
+		t.Fatalf("output %q", out.String())
+	}
+}
+
+func TestSpawnServiceCopiesBinaryAndPassesRoot(t *testing.T) {
+	paths := newTestPaths(t)
+	record := filepath.Join(t.TempDir(), "args")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$0 $*\" > '" + record + "'\n"
+	paths.AppPath = filepath.Join(t.TempDir(), "bgm.sh")
+	if err := os.WriteFile(paths.AppPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := SpawnService(&paths, "/my/root"); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { _, err := os.Stat(record); return err == nil })
+	waitFor(t, func() bool { return strings.Contains(readFile(t, record), "exec") })
+	want := ServiceBinaryPath(&paths) + " --root /my/root exec\n"
+	if got := readFile(t, record); got != want {
+		t.Fatalf("service argv %q want %q", got, want)
+	}
+}
+
+// A restart can copy the new service while the old one is still exiting from
+// the previous copy; the copy must not fail with "text file busy".
+func TestCopyServiceBinaryReplacesRunningCopy(t *testing.T) {
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep not available")
+	}
+	paths := newTestPaths(t)
+	target := ServiceBinaryPath(&paths)
+	writeFile(t, target, readFile(t, sleepPath))
+	if chmodErr := os.Chmod(target, 0o755); chmodErr != nil {
+		t.Fatal(chmodErr)
+	}
+	running := exec.CommandContext(context.Background(), target, "30")
+	if startErr := running.Start(); startErr != nil {
+		t.Skipf("cannot execute from the temp folder: %v", startErr)
+	}
+	t.Cleanup(func() {
+		_ = running.Process.Kill()
+		_ = running.Wait()
+	})
+	script := "#!/bin/sh\nexit 0\n"
+	paths.AppPath = filepath.Join(t.TempDir(), "bgm.sh")
+	writeFile(t, paths.AppPath, script)
+	got, err := copyServiceBinary(&paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != target || readFile(t, target) != script {
+		t.Fatalf("copy %q content %q", got, readFile(t, target))
+	}
+	info, err := os.Stat(target)
+	if err != nil || info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("copy must be executable: %v %v", info, err)
+	}
+	entries, err := os.ReadDir(paths.TempFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "."+AppFilename+"-") {
+			t.Fatalf("temporary copy left behind: %s", entry.Name())
+		}
+	}
+}
+
+func TestWaitForSocketHelpers(t *testing.T) {
+	paths := newTestPaths(t)
+	if WaitForSocket(&paths, 60*time.Millisecond) {
+		t.Fatal("no socket should time out")
+	}
+	writeFile(t, paths.SocketFile, "")
+	if !WaitForSocket(&paths, time.Second) || WaitForSocketGone(&paths, 60*time.Millisecond) {
+		t.Fatal("socket presence not detected")
+	}
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = os.Remove(paths.SocketFile)
+	}()
+	if !WaitForSocketGone(&paths, time.Second) {
+		t.Fatal("socket removal not detected")
+	}
+}

--- a/pkg/bgm/files.go
+++ b/pkg/bgm/files.go
@@ -1,0 +1,94 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MIDIPort is the ALSA sequencer port passed to aplaymidi.
+const MIDIPort = "128:0"
+
+func hasSuffixFold(name, suffix string) bool {
+	return strings.HasSuffix(strings.ToLower(name), suffix)
+}
+
+// IsMP3 reports an .mp3 file.
+func IsMP3(name string) bool { return hasSuffixFold(name, ".mp3") }
+
+// IsPLS reports a .pls internet radio playlist.
+func IsPLS(name string) bool { return hasSuffixFold(name, ".pls") }
+
+// IsOGG reports an .ogg file.
+func IsOGG(name string) bool { return hasSuffixFold(name, ".ogg") }
+
+// IsWAV reports a .wav file.
+func IsWAV(name string) bool { return hasSuffixFold(name, ".wav") }
+
+// IsMID reports a .mid file.
+func IsMID(name string) bool { return hasSuffixFold(name, ".mid") }
+
+// IsVGM reports a .vgm, .vgz or .vgm.gz file.
+func IsVGM(name string) bool {
+	return hasSuffixFold(name, ".vgm") || hasSuffixFold(name, ".vgz") || hasSuffixFold(name, ".vgm.gz")
+}
+
+// IsValidFile reports whether BGM can play the named file.
+func IsValidFile(name string) bool {
+	return IsMP3(name) || IsOGG(name) || IsWAV(name) || IsMID(name) || IsVGM(name) || IsPLS(name)
+}
+
+var loopPattern = regexp.MustCompile(`^X(\d{2})_`)
+
+// LoopAmount returns the X##_ repeat count from a filename, or 1. X00_ plays
+// nothing, as in the Python script.
+func LoopAmount(path string) int {
+	match := loopPattern.FindStringSubmatch(filepath.Base(path))
+	if match == nil {
+		return 1
+	}
+	loops, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 1
+	}
+	return loops
+}
+
+var plsURLPattern = regexp.MustCompile(`https?:.+`)
+
+// PLSURL extracts the first stream URL from a .pls file, or "" when none is
+// found.
+func PLSURL(path string, logger *Logger) string {
+	// #nosec G304 -- the path comes from the user's music folder listing.
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		logger.Log("Playlist URL not found")
+		return ""
+	}
+	if url := plsURLPattern.FindString(string(data)); url != "" {
+		return url
+	}
+	logger.Log("Playlist URL not found")
+	return ""
+}

--- a/pkg/bgm/files.go
+++ b/pkg/bgm/files.go
@@ -86,7 +86,9 @@ func PLSURL(path string, logger *Logger) string {
 		logger.Log("Playlist URL not found")
 		return ""
 	}
-	if url := plsURLPattern.FindString(string(data)); url != "" {
+	// Python read the file in text mode, so CRLF endings never reached the
+	// URL; trim them here.
+	if url := strings.TrimSpace(plsURLPattern.FindString(string(data))); url != "" {
 		return url
 	}
 	logger.Log("Playlist URL not found")

--- a/pkg/bgm/files_test.go
+++ b/pkg/bgm/files_test.go
@@ -60,7 +60,7 @@ func TestPLSURL(t *testing.T) {
 	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
 	radio := filepath.Join(paths.MusicFolder, "radio.pls")
 	writeFile(t, radio, "[playlist]\nFile1=http://example.com/stream\r\nTitle1=Example\n")
-	if got := PLSURL(radio, logger); got != "http://example.com/stream\r" {
+	if got := PLSURL(radio, logger); got != "http://example.com/stream" {
 		t.Fatalf("url = %q", got)
 	}
 	empty := filepath.Join(paths.MusicFolder, "empty.pls")

--- a/pkg/bgm/files_test.go
+++ b/pkg/bgm/files_test.go
@@ -1,0 +1,74 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFileTypePredicates(t *testing.T) {
+	valid := []string{"a.MP3", "b.pls", "c.Ogg", "d.wav", "e.mid", "f.vgm", "g.VGZ", "h.vgm.gz", "dir.mp3"}
+	for _, name := range valid {
+		if !IsValidFile(name) {
+			t.Fatalf("%s should be valid", name)
+		}
+	}
+	for _, name := range []string{"a.midi", "b.gz", "c.flac", "d.mp3.bak", "e"} {
+		if IsValidFile(name) {
+			t.Fatalf("%s should be rejected", name)
+		}
+	}
+	if !IsVGM("x.vgm.gz") || IsVGM("x.gz") || IsMP3("x.pls") {
+		t.Fatal("suffix checks are wrong")
+	}
+}
+
+func TestLoopAmount(t *testing.T) {
+	cases := map[string]int{
+		"X05_song.mp3": 5, "X23_song.mp3": 23, "X00_song.mp3": 0, "X5_song.mp3": 1, "x05_song.mp3": 1,
+		"song.mp3": 1, "X05song.mp3": 1, filepath.Join("X07_folder", "song.mp3"): 1,
+	}
+	for name, want := range cases {
+		if got := LoopAmount(name); got != want {
+			t.Fatalf("LoopAmount(%q) = %d want %d", name, got, want)
+		}
+	}
+}
+
+func TestPLSURL(t *testing.T) {
+	paths := newTestPaths(t)
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	radio := filepath.Join(paths.MusicFolder, "radio.pls")
+	writeFile(t, radio, "[playlist]\nFile1=http://example.com/stream\r\nTitle1=Example\n")
+	if got := PLSURL(radio, logger); got != "http://example.com/stream\r" {
+		t.Fatalf("url = %q", got)
+	}
+	empty := filepath.Join(paths.MusicFolder, "empty.pls")
+	writeFile(t, empty, "[playlist]\nTitle1=Example\n")
+	if got := PLSURL(empty, logger); got != "" {
+		t.Fatalf("expected no url, got %q", got)
+	}
+	if out.String() != "Playlist URL not found\n" {
+		t.Fatalf("log output %q", out.String())
+	}
+}

--- a/pkg/bgm/helpers_test.go
+++ b/pkg/bgm/helpers_test.go
@@ -1,0 +1,159 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestPaths builds a rooted layout with a short socket path, because unix
+// socket paths are limited to 108 bytes and t.TempDir names are long.
+func newTestPaths(t *testing.T) Paths {
+	t.Helper()
+	root := t.TempDir()
+	paths := RootedPaths(root)
+	folders := []string{
+		paths.MusicFolder, paths.TempFolder, filepath.Dir(paths.CmdInterface), filepath.Dir(paths.StartupScript),
+	}
+	for _, folder := range folders {
+		if err := os.MkdirAll(folder, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	socketDir, err := os.MkdirTemp("", "bgm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	paths.SocketFile = filepath.Join(socketDir, SocketFilename)
+	if len(paths.SocketFile) >= 100 {
+		t.Fatalf("socket path too long for unix sockets: %s", paths.SocketFile)
+	}
+	return paths
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func writeINI(t *testing.T, paths *Paths, content string) {
+	t.Helper()
+	writeFile(t, paths.IniFile, content)
+}
+
+// syncBuffer captures log output written from several goroutines.
+type syncBuffer struct {
+	buf strings.Builder
+	mu  sync.Mutex
+}
+
+func (b *syncBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	count, err := b.buf.Write(data)
+	if err != nil {
+		return count, fmt.Errorf("buffer write: %w", err)
+	}
+	return count, nil
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func newTestLogger(paths *Paths) (*Logger, *syncBuffer) {
+	out := &syncBuffer{}
+	return NewLoggerTo(paths, out), out
+}
+
+const stubScript = `#!/bin/sh
+printf '%s\n' "$(basename "$0") $*" >> "$BGM_STUB_LOG"
+if [ -n "$BGM_STUB_FINISH" ]; then echo "[0:03] Decoding of track finished."; fi
+if [ -n "$BGM_STUB_EXIT" ]; then exit 0; fi
+exec sleep "${BGM_STUB_SLEEP:-30}"
+`
+
+// installStubPlayers puts fake mpg123/ogg123/aplay/aplaymidi/vgmplay scripts
+// first on PATH and returns the log file they append their argv to.
+func installStubPlayers(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"mpg123", "ogg123", "aplay", "aplaymidi", "vgmplay"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(stubScript), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logPath := filepath.Join(dir, "invocations.log")
+	t.Setenv("BGM_STUB_LOG", logPath)
+	t.Setenv("BGM_STUB_FINISH", "")
+	t.Setenv("BGM_STUB_EXIT", "")
+	t.Setenv("BGM_STUB_SLEEP", "")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func stubInvocations(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition not met in time")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func ptr[T any](value T) *T { return &value }

--- a/pkg/bgm/ini.go
+++ b/pkg/bgm/ini.go
@@ -1,0 +1,215 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Document is a minimal model of Python's configparser file format. It keeps
+// sections and keys in file order so unknown entries survive a rewrite, and
+// renders exactly like ConfigParser.write() so existing bgm.ini files keep
+// their shape.
+type Document struct {
+	sections []*iniSection
+}
+
+type iniSection struct {
+	name    string
+	entries []*iniEntry
+}
+
+type iniEntry struct {
+	key   string
+	parts []string
+}
+
+var (
+	iniSectionPattern = regexp.MustCompile(`^\[(.+)\]`)
+	iniOptionPattern  = regexp.MustCompile(`^(.*?)\s*[=:]\s*(.*)$`)
+)
+
+// ParseINI reads configparser syntax: case-sensitive sections, lowercased
+// keys, "=" or ":" delimiters, full-line "#" or ";" comments and indented
+// continuation lines. Malformed lines are skipped where Python would raise.
+func ParseINI(data string) *Document {
+	doc := &Document{}
+	var section *iniSection
+	var option *iniEntry
+	indentLevel := 0
+	for _, rawLine := range strings.Split(data, "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		value := strings.TrimSpace(line)
+		if strings.HasPrefix(value, "#") || strings.HasPrefix(value, ";") {
+			continue
+		}
+		if value == "" {
+			if option != nil {
+				option.parts = append(option.parts, "")
+			}
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t\f\v"))
+		if section != nil && option != nil && indent > indentLevel {
+			option.parts = append(option.parts, value)
+			continue
+		}
+		indentLevel = indent
+		if match := iniSectionPattern.FindStringSubmatch(value); match != nil {
+			section = doc.section(match[1], true)
+			option = nil
+			continue
+		}
+		if section == nil {
+			continue
+		}
+		match := iniOptionPattern.FindStringSubmatch(value)
+		if len(match) < 3 || match[1] == "" {
+			continue
+		}
+		option = section.entry(strings.ToLower(strings.TrimRight(match[1], " \t")), true)
+		option.parts = []string{strings.TrimSpace(match[2])}
+	}
+	return doc
+}
+
+// ReadINI parses the file at path. A missing file yields an empty document,
+// matching ConfigParser.read().
+func ReadINI(path string) (*Document, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Document{}, nil
+		}
+		return nil, fmt.Errorf("read BGM configuration: %w", err)
+	}
+	return ParseINI(string(data)), nil
+}
+
+// Get returns the value of key in section with "%%" unescaped, as
+// ConfigParser.get() does with its default interpolation.
+func (d *Document) Get(section, key string) (string, bool) {
+	sec := d.section(section, false)
+	if sec == nil {
+		return "", false
+	}
+	entry := sec.entry(strings.ToLower(key), false)
+	if entry == nil {
+		return "", false
+	}
+	return strings.ReplaceAll(entry.value(), "%%", "%"), true
+}
+
+// Set stores value under section/key, creating either when missing and
+// escaping "%" so Python can still read the file.
+func (d *Document) Set(section, key, value string) {
+	entry := d.section(section, true).entry(strings.ToLower(key), true)
+	entry.parts = []string{strings.ReplaceAll(value, "%", "%%")}
+}
+
+// HasSection reports whether the section exists.
+func (d *Document) HasSection(section string) bool {
+	return d.section(section, false) != nil
+}
+
+// String renders the document the way ConfigParser.write() does.
+func (d *Document) String() string {
+	var out strings.Builder
+	for _, section := range d.sections {
+		_, _ = fmt.Fprintf(&out, "[%s]\n", section.name)
+		for _, entry := range section.entries {
+			_, _ = fmt.Fprintf(&out, "%s = %s\n", entry.key, strings.ReplaceAll(entry.value(), "\n", "\n\t"))
+		}
+		_, _ = out.WriteString("\n")
+	}
+	return out.String()
+}
+
+// WriteFile atomically replaces path with the rendered document.
+func (d *Document) WriteFile(path string) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".bgm-*.ini")
+	if err != nil {
+		return fmt.Errorf("create temporary BGM configuration: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.WriteString(d.String()); err != nil {
+		return fmt.Errorf("write temporary BGM configuration: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary BGM configuration: %w", err)
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("set BGM configuration permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary BGM configuration: %w", err)
+	}
+	// #nosec G703 -- destination is the explicit BGM configuration path.
+	if err := os.Rename(temporaryPath, filepath.Clean(path)); err != nil {
+		return fmt.Errorf("replace BGM configuration: %w", err)
+	}
+	removeTemporary = false
+	return nil
+}
+
+func (d *Document) section(name string, create bool) *iniSection {
+	for _, section := range d.sections {
+		if section.name == name {
+			return section
+		}
+	}
+	if !create {
+		return nil
+	}
+	section := &iniSection{name: name}
+	d.sections = append(d.sections, section)
+	return section
+}
+
+func (s *iniSection) entry(key string, create bool) *iniEntry {
+	for _, entry := range s.entries {
+		if entry.key == key {
+			return entry
+		}
+	}
+	if !create {
+		return nil
+	}
+	entry := &iniEntry{key: key}
+	s.entries = append(s.entries, entry)
+	return entry
+}
+
+// value joins continuation lines like configparser's _join_multiline_values.
+func (e *iniEntry) value() string {
+	return strings.TrimRight(strings.Join(e.parts, "\n"), " \t\n\r\f\v")
+}

--- a/pkg/bgm/ini_test.go
+++ b/pkg/bgm/ini_test.go
@@ -1,0 +1,122 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Expected output captured from Python 3's ConfigParser.write().
+func TestParseINIMatchesConfigParser(t *testing.T) {
+	source := "[bgm]\nPlayback = Random\nplaylist: none\n  ; indented comment\n# c2\nkeep_me = x\nmulti = a\n  b\n" +
+		"[Other]\nz = 1\n"
+	doc := ParseINI(source)
+	doc.Set("bgm", "menuvolume", "3")
+	want := "[bgm]\nplayback = Random\nplaylist = none\nkeep_me = x\nmulti = a\n\tb\nmenuvolume = 3\n\n" +
+		"[Other]\nz = 1\n\n"
+	if got := doc.String(); got != want {
+		t.Fatalf("rendered:\n%q\nwant:\n%q", got, want)
+	}
+	if value, ok := doc.Get("bgm", "PLAYBACK"); !ok || value != "Random" {
+		t.Fatalf("case-insensitive key lookup failed: %q %v", value, ok)
+	}
+	if value, ok := doc.Get("bgm", "multi"); !ok || value != "a\nb" {
+		t.Fatalf("continuation value = %q", value)
+	}
+}
+
+func TestDefaultINIRoundTripAddsOnlyTrailingBlankLine(t *testing.T) {
+	if got := ParseINI(DefaultINI).String(); got != DefaultINI+"\n" {
+		t.Fatalf("round trip changed the default file:\n%q", got)
+	}
+}
+
+func TestParseINISectionsAreCaseSensitiveAndValuesMayBeEmpty(t *testing.T) {
+	doc := ParseINI("[BGM]\nplayback = loop\n[bgm]\nplaylist =\n")
+	if _, ok := doc.Get("bgm", "playback"); ok {
+		t.Fatal("[BGM] must not satisfy a lookup for [bgm]")
+	}
+	value, ok := doc.Get("bgm", "playlist")
+	if !ok || value != "" {
+		t.Fatalf("empty value = %q ok=%v", value, ok)
+	}
+	if got := doc.String(); got != "[BGM]\nplayback = loop\n\n[bgm]\nplaylist = \n\n" {
+		t.Fatalf("rendered %q", got)
+	}
+}
+
+func TestParseINISkipsLinesPythonWouldRejectAndKeepsLastDuplicate(t *testing.T) {
+	doc := ParseINI("orphan = 1\n[bgm]\nno delimiter here\n= novalue\nplayback = random\nplayback = loop\n")
+	if value, _ := doc.Get("bgm", "playback"); value != "loop" {
+		t.Fatalf("duplicate key should keep last value, got %q", value)
+	}
+	if got := doc.String(); got != "[bgm]\nplayback = loop\n\n" {
+		t.Fatalf("rendered %q", got)
+	}
+}
+
+func TestParseINIPercentEscapes(t *testing.T) {
+	doc := ParseINI("[bgm]\nplaylist = 100%% Hits\n")
+	if value, _ := doc.Get("bgm", "playlist"); value != "100% Hits" {
+		t.Fatalf("unescaped value = %q", value)
+	}
+	doc.Set("bgm", "playlist", "50% Off")
+	if got := doc.String(); got != "[bgm]\nplaylist = 50%% Off\n\n" {
+		t.Fatalf("rendered %q", got)
+	}
+}
+
+func TestParseINIBlankLinesInsideValues(t *testing.T) {
+	doc := ParseINI("[bgm]\nmulti = a\n\n  b\n\n\nnext = c\n")
+	if value, _ := doc.Get("bgm", "multi"); value != "a\n\nb" {
+		t.Fatalf("multi = %q", value)
+	}
+	if value, _ := doc.Get("bgm", "next"); value != "c" {
+		t.Fatalf("next = %q", value)
+	}
+}
+
+func TestReadINIMissingFileIsEmptyAndWriteFileIsAtomic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bgm.ini")
+	doc, err := ReadINI(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.HasSection("bgm") {
+		t.Fatal("missing file produced a section")
+	}
+	doc.Set("bgm", "playback", "loop")
+	if writeErr := doc.WriteFile(path); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if got := readFile(t, path); got != "[bgm]\nplayback = loop\n\n" {
+		t.Fatalf("written %q", got)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("temporary file left behind: %d entries", len(entries))
+	}
+}

--- a/pkg/bgm/log.go
+++ b/pkg/bgm/log.go
@@ -1,0 +1,89 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Logger mirrors the Python log() helper: the debug flag is re-read from
+// bgm.ini on every call so it can be toggled while the service runs, debug
+// output goes to stdout and /tmp/bgm.log, and Print() always reaches stdout.
+type Logger struct {
+	out   io.Writer
+	paths Paths
+	mu    sync.Mutex
+}
+
+// NewLogger writes console output to stdout.
+func NewLogger(paths *Paths) *Logger {
+	return &Logger{out: os.Stdout, paths: *paths}
+}
+
+// NewLoggerTo writes console output to out; used by tests.
+func NewLoggerTo(paths *Paths, out io.Writer) *Logger {
+	return &Logger{out: out, paths: *paths}
+}
+
+// Log records a debug message.
+func (l *Logger) Log(msg string) { l.write(msg, false) }
+
+// Logf records a formatted debug message.
+func (l *Logger) Logf(format string, args ...any) { l.write(fmt.Sprintf(format, args...), false) }
+
+// Print records a message that is always shown to the user.
+func (l *Logger) Print(msg string) { l.write(msg, true) }
+
+func (l *Logger) write(msg string, always bool) {
+	cfg, _ := LoadConfig(&l.paths)
+	if msg == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if always || cfg.Debug {
+		_, _ = fmt.Fprintln(l.out, msg)
+	}
+	if !cfg.Debug {
+		return
+	}
+	// #nosec G302,G304 -- the log lives in MiSTer's world-readable /tmp.
+	file, err := os.OpenFile(filepath.Clean(l.paths.LogFile), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = file.Close() }()
+	_, _ = fmt.Fprintf(file, "[%s] %s\n", isoformat(time.Now()), msg)
+}
+
+// isoformat matches datetime.isoformat(): the microsecond fraction is
+// omitted when zero and otherwise always six digits.
+func isoformat(now time.Time) string {
+	stamp := now.Format("2006-01-02T15:04:05")
+	if micros := now.Nanosecond() / 1000; micros != 0 {
+		stamp += fmt.Sprintf(".%06d", micros)
+	}
+	return stamp
+}

--- a/pkg/bgm/log_test.go
+++ b/pkg/bgm/log_test.go
@@ -1,0 +1,77 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoggerHonoursDebugFlagPerCall(t *testing.T) {
+	paths := newTestPaths(t)
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, DefaultINI)
+
+	logger.Log("hidden")
+	logger.Print("shown")
+	if out.String() != "shown\n" {
+		t.Fatalf("output %q", out.String())
+	}
+	if _, err := os.Stat(paths.LogFile); !os.IsNotExist(err) {
+		t.Fatal("log file must not be written without debug")
+	}
+
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	logger.Log("")
+	logger.Log("visible")
+	if out.String() != "shown\nvisible\n" {
+		t.Fatalf("output %q", out.String())
+	}
+	line := strings.TrimSpace(readFile(t, paths.LogFile))
+	if !regexp.MustCompile(`^\[\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{6})?\] visible$`).MatchString(line) {
+		t.Fatalf("log line %q", line)
+	}
+}
+
+func TestLoggerRecreatesMissingINI(t *testing.T) {
+	paths := newTestPaths(t)
+	logger, _ := newTestLogger(&paths)
+	logger.Log("anything")
+	if got := readFile(t, paths.IniFile); got != DefaultINI {
+		t.Fatalf("ini = %q", got)
+	}
+}
+
+func TestIsoformatOmitsZeroMicroseconds(t *testing.T) {
+	base := time.Date(2026, 9, 5, 17, 25, 19, 0, time.UTC)
+	if got := isoformat(base); got != "2026-09-05T17:25:19" {
+		t.Fatalf("isoformat = %q", got)
+	}
+	if got := isoformat(base.Add(837446 * time.Microsecond)); got != "2026-09-05T17:25:19.837446" {
+		t.Fatalf("isoformat = %q", got)
+	}
+	if got := isoformat(base.Add(5 * time.Microsecond)); got != "2026-09-05T17:25:19.000005" {
+		t.Fatalf("isoformat = %q", got)
+	}
+}

--- a/pkg/bgm/mister.go
+++ b/pkg/bgm/mister.go
@@ -1,0 +1,184 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// RunCmd sends a command to MiSTer exactly like the Python script's
+// os.system('echo "<cmd>" > /dev/MiSTer_cmd'), which worked around hangs seen
+// when opening the command interface in-process.
+func RunCmd(paths *Paths, cmd string) error {
+	script := fmt.Sprintf("echo %q > %s", cmd, shellQuote(paths.CmdInterface))
+	// #nosec G204 -- the command text is a fixed MiSTer volume instruction.
+	if err := exec.CommandContext(context.Background(), "/bin/sh", "-c", script).Run(); err != nil {
+		return fmt.Errorf("send MiSTer command %q: %w", cmd, err)
+	}
+	return nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// VolumeSet clamps volume to MiSTer's 0-7 range and applies it.
+func VolumeSet(paths *Paths, logger *Logger, volume int) {
+	volume = max(0, min(7, volume))
+	logger.Logf("Setting volume to %d", volume)
+	if err := RunCmd(paths, fmt.Sprintf("volume %d", volume)); err != nil {
+		logger.Log(err.Error())
+	}
+}
+
+// GetCore reads /tmp/CORENAME. ok is false when the file is missing.
+func GetCore(paths *Paths) (core string, ok bool) {
+	// #nosec G304 -- CORENAME is a fixed MiSTer runtime path.
+	data, err := os.ReadFile(filepath.Clean(paths.CoreNameFile))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(data)), true
+}
+
+// CoreWatcher blocks until MiSTer rewrites /tmp/CORENAME, replacing the
+// one-shot `inotifywait -e modify` the Python script spawned.
+type CoreWatcher struct {
+	logger        *Logger
+	paths         Paths
+	RetryInterval time.Duration
+	Settle        time.Duration
+	RetryCount    int
+}
+
+// NewCoreWatcher uses the Python script's timings: sixteen one-second
+// retries while the file is missing.
+func NewCoreWatcher(paths *Paths, logger *Logger) *CoreWatcher {
+	return &CoreWatcher{
+		logger:        logger,
+		paths:         *paths,
+		RetryInterval: time.Second,
+		Settle:        100 * time.Millisecond,
+		RetryCount:    16,
+	}
+}
+
+// WaitCoreChange returns the new core name after the next modification, or
+// ok=false when the file never appears, the watch fails, or ctx ends.
+func (w *CoreWatcher) WaitCoreChange(ctx context.Context) (core string, ok bool) {
+	if _, exists := GetCore(&w.paths); !exists {
+		w.logger.Log("CORENAME file does not exist, retrying...")
+		for range w.RetryCount {
+			if !sleepContext(ctx, w.RetryInterval) {
+				return "", false
+			}
+			if _, exists := GetCore(&w.paths); exists {
+				break
+			}
+		}
+		if _, exists := GetCore(&w.paths); !exists {
+			w.logger.Log("No CORENAME file found")
+			return "", false
+		}
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.logger.Log("Error when running inotify watch")
+		return "", false
+	}
+	defer func() { _ = watcher.Close() }()
+	if err := watcher.Add(w.paths.CoreNameFile); err != nil {
+		w.logger.Log("Error when running inotify watch")
+		return "", false
+	}
+	if !w.awaitModify(ctx, watcher) {
+		return "", false
+	}
+	// MiSTer truncates then writes; give the write a moment so the file is
+	// never read empty in between, as the slower Python path did in practice.
+	w.drain(ctx, watcher)
+
+	core, exists := GetCore(&w.paths)
+	if !exists {
+		w.logger.Log("Core change to: None")
+		return "", false
+	}
+	w.logger.Logf("Core change to: %s", core)
+	return core, true
+}
+
+func (w *CoreWatcher) awaitModify(ctx context.Context, watcher *fsnotify.Watcher) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case event, open := <-watcher.Events:
+			if !open {
+				w.logger.Log("Error when running inotify watch")
+				return false
+			}
+			if event.Has(fsnotify.Write) {
+				return true
+			}
+		case <-watcher.Errors:
+			w.logger.Log("Error when running inotify watch")
+			return false
+		}
+	}
+}
+
+func (w *CoreWatcher) drain(ctx context.Context, watcher *fsnotify.Watcher) {
+	if w.Settle <= 0 {
+		return
+	}
+	timer := time.NewTimer(w.Settle)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			return
+		case <-watcher.Events:
+		case <-watcher.Errors:
+		}
+	}
+}
+
+// sleepContext waits for duration unless ctx ends first.
+func sleepContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/pkg/bgm/paths.go
+++ b/pkg/bgm/paths.go
@@ -1,0 +1,100 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+const (
+	// AppFilename is the installed binary name; the .sh suffix is kept for
+	// MiSTer's Scripts menu and existing startup hooks.
+	AppFilename    = "bgm.sh"
+	MusicFolder    = "music"
+	BootFolder     = "boot"
+	IniFilename    = "bgm.ini"
+	SocketFilename = "bgm.sock"
+	LogFilename    = "bgm.log"
+	CoreNameName   = "CORENAME"
+	MenuCore       = config.MenuCore
+)
+
+// Paths holds every filesystem location BGM touches so tests and the --root
+// development mode can relocate the whole application.
+type Paths struct {
+	MusicFolder   string
+	BootFolder    string
+	IniFile       string
+	SocketFile    string
+	CoreNameFile  string
+	LogFile       string
+	StartupScript string
+	CmdInterface  string
+	TempFolder    string
+	AppPath       string
+}
+
+// DefaultPaths returns the locations used on a real MiSTer.
+func DefaultPaths() Paths {
+	paths := pathsUnder(config.SdFolder, config.TempFolder)
+	paths.CoreNameFile = config.CoreNameFile
+	paths.StartupScript = config.StartupFile
+	paths.CmdInterface = config.CmdInterface
+	paths.AppPath = executablePath(filepath.Join(config.ScriptsFolder, AppFilename))
+	return paths
+}
+
+// RootedPaths relocates every location under root, using a regular file in
+// place of the MiSTer command device.
+func RootedPaths(root string) Paths {
+	paths := pathsUnder(root, filepath.Join(root, "tmp"))
+	paths.CoreNameFile = filepath.Join(paths.TempFolder, CoreNameName)
+	paths.StartupScript = filepath.Join(root, "linux", "user-startup.sh")
+	paths.CmdInterface = filepath.Join(root, "dev", "MiSTer_cmd")
+	paths.AppPath = executablePath(filepath.Join(root, "Scripts", AppFilename))
+	return paths
+}
+
+func pathsUnder(sdRoot, tempFolder string) Paths {
+	music := filepath.Join(sdRoot, MusicFolder)
+	return Paths{
+		MusicFolder: music,
+		BootFolder:  filepath.Join(music, BootFolder),
+		IniFile:     filepath.Join(music, IniFilename),
+		SocketFile:  filepath.Join(tempFolder, SocketFilename),
+		LogFile:     filepath.Join(tempFolder, LogFilename),
+		TempFolder:  tempFolder,
+	}
+}
+
+// executablePath mirrors Python's os.path.realpath(__file__).
+func executablePath(fallback string) string {
+	exe, err := os.Executable()
+	if err != nil {
+		return fallback
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(exe); resolveErr == nil {
+		return resolved
+	}
+	return exe
+}

--- a/pkg/bgm/player.go
+++ b/pkg/bgm/player.go
@@ -1,0 +1,614 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"math"
+	"math/rand/v2"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HistorySize is the ratio of total tracks kept in the recently-played list.
+const HistorySize = 0.2
+
+// Player is a one-to-one port of the Python Player class. CmdMu is the
+// script's self.mutex, serialising socket commands against the core-change
+// loop; mu protects the fields below it.
+//
+//nolint:govet // Field order mirrors the Python class for easier comparison.
+type Player struct {
+	paths  Paths
+	logger *Logger
+
+	CmdMu sync.Mutex
+
+	mu           sync.Mutex
+	proc         *playerProcess
+	current      *playState
+	playback     string
+	playlist     Playlist
+	playInCore   bool
+	history      []string
+	endPlaylist  bool
+	playlistDone chan struct{}
+	nextToken    uint64
+
+	// randIndex and sleep are replaced by tests.
+	randIndex func(n int) int
+	sleep     func(time.Duration)
+}
+
+type playState struct {
+	filename   string
+	token      uint64
+	inPlaylist bool
+}
+
+type playerProcess struct {
+	cmd    *exec.Cmd
+	reader *os.File
+}
+
+// NewPlayer initialises playback settings from the configuration.
+func NewPlayer(paths *Paths, logger *Logger, cfg *Config) *Player {
+	return &Player{
+		paths:      *paths,
+		logger:     logger,
+		playback:   cfg.Playback,
+		playlist:   cfg.Playlist,
+		playInCore: cfg.PlayInCore,
+		randIndex:  rand.IntN,
+		sleep:      time.Sleep,
+	}
+}
+
+// Playback returns the current playback type.
+func (p *Player) Playback() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.playback
+}
+
+// SetPlayback stores any playback string, as the socket protocol allows.
+func (p *Player) SetPlayback(playback string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playback = playback
+}
+
+// Playlist returns the current playlist.
+func (p *Player) Playlist() Playlist {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.playlist
+}
+
+// PlayInCore reports whether music keeps playing inside cores.
+func (p *Player) PlayInCore() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.playInCore
+}
+
+// SetPlayInCore updates the play-in-core flag.
+func (p *Player) SetPlayInCore(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playInCore = enabled
+}
+
+// Playing returns the path of the track being played, if any.
+func (p *Player) Playing() (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.current == nil {
+		return "", false
+	}
+	return p.current.filename, true
+}
+
+// InPlaylist mirrors in_playlist(): true until a playlist has been stopped.
+func (p *Player) InPlaylist() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return !p.endPlaylist
+}
+
+// Status renders the tab-separated reply to the "status" socket command.
+func (p *Player) Status() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	isPlaying, filename := "no", ""
+	if p.current != nil {
+		isPlaying = "yes"
+		filename = filepath.Base(p.current.filename)
+	}
+	return fmt.Sprintf("%s\t%s\t%s\t%s", isPlaying, p.playback, p.playlist.String(), filename)
+}
+
+// PlaylistPath mirrors get_playlist_path(): the music folder for no playlist
+// or "all", otherwise the named subfolder, falling back to the music folder
+// when it does not exist.
+func (p *Player) PlaylistPath(playlist Playlist) string {
+	if playlist.IsNone() || playlist.IsAll() {
+		return p.paths.MusicFolder
+	}
+	folder := filepath.Join(p.paths.MusicFolder, playlist.Name())
+	if _, err := os.Stat(folder); err != nil {
+		p.logger.Logf("Playlist folder does not exist: %s", folder)
+		return p.paths.MusicFolder
+	}
+	return folder
+}
+
+// filterTracks mirrors filter_tracks(), including its use of the current
+// playlist rather than the requested one for the .pls rule.
+func (p *Player) filterTracks(names []string, includeBoot bool) []string {
+	current := p.Playlist()
+	tracks := make([]string, 0, len(names))
+	for _, name := range names {
+		if !IsValidFile(name) {
+			continue
+		}
+		if includeBoot {
+			tracks = append(tracks, name)
+			continue
+		}
+		if strings.HasPrefix(name, "_") {
+			continue
+		}
+		if current.IsAll() && IsPLS(name) {
+			continue
+		}
+		tracks = append(tracks, name)
+	}
+	return tracks
+}
+
+// Tracks mirrors get_tracks(): the top level only for no playlist, otherwise
+// a recursive walk of the playlist folder.
+func (p *Player) Tracks(playlist Playlist, includeBoot bool) []string {
+	folder := p.PlaylistPath(playlist)
+	var tracks []string
+	if playlist.IsNone() {
+		entries, err := os.ReadDir(folder)
+		if err != nil {
+			return nil
+		}
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		for _, name := range p.filterTracks(names, includeBoot) {
+			tracks = append(tracks, filepath.Join(folder, name))
+		}
+		return tracks
+	}
+	byFolder := make(map[string][]string)
+	var order []string
+	_ = filepath.WalkDir(folder, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // os.walk silently skips unreadable entries.
+		}
+		if path == folder || entry.IsDir() || isSymlinkToDir(path, entry) {
+			return nil
+		}
+		parent := filepath.Dir(path)
+		if _, seen := byFolder[parent]; !seen {
+			order = append(order, parent)
+		}
+		byFolder[parent] = append(byFolder[parent], entry.Name())
+		return nil
+	})
+	for _, parent := range order {
+		for _, name := range p.filterTracks(byFolder[parent], includeBoot) {
+			tracks = append(tracks, filepath.Join(parent, name))
+		}
+	}
+	return tracks
+}
+
+// isSymlinkToDir mirrors os.walk placing symlinked folders in dirs rather
+// than files.
+func isSymlinkToDir(path string, entry fs.DirEntry) bool {
+	if entry.Type()&fs.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// TotalTracks counts the tracks Tracks would return.
+func (p *Player) TotalTracks(playlist Playlist, includeBoot bool) int {
+	return len(p.Tracks(playlist, includeBoot))
+}
+
+func (p *Player) addHistory(filename string) {
+	size := int(math.Floor(float64(p.TotalTracks(p.Playlist(), false)) * HistorySize))
+	if size < 1 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for len(p.history) > size {
+		p.history = p.history[1:]
+	}
+	p.history = append(p.history, filename)
+}
+
+// History returns a copy of the recently played tracks.
+func (p *Player) History() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.history...)
+}
+
+// Stop mirrors stop(): only when a player process exists is the current
+// track cleared and the process killed.
+func (p *Player) Stop() {
+	p.mu.Lock()
+	proc := p.proc
+	if proc != nil {
+		p.current = nil
+		p.proc = nil
+	}
+	p.mu.Unlock()
+	if proc != nil {
+		killPlayer(proc.cmd)
+		_ = proc.reader.Close()
+	}
+}
+
+// Play mirrors play(): blocking playback honouring the X##_ loop prefix.
+func (p *Player) Play(filename string) {
+	p.playTrack(filename, false)
+}
+
+// playTrack runs one track. Playlist tracks additionally stop as soon as the
+// playlist has ended, so StopPlaylist can never leave a stray track running.
+func (p *Player) playTrack(filename string, inPlaylist bool) {
+	p.Stop()
+	if !IsValidFile(filename) {
+		return
+	}
+	p.mu.Lock()
+	p.nextToken++
+	state := &playState{filename: filename, token: p.nextToken, inPlaylist: inPlaylist}
+	p.current = state
+	p.mu.Unlock()
+	p.addHistory(filename)
+	p.logger.Logf("Now playing: %s", filename)
+
+	for loop := LoopAmount(filename); loop > 0 && p.shouldContinue(state); loop-- {
+		p.logger.Logf("Loop #%d", loop)
+		switch {
+		case IsMP3(filename), IsPLS(filename):
+			p.playMP3(state, filename)
+		case IsOGG(filename):
+			p.playFile(state, "ogg123", filename)
+		case IsWAV(filename):
+			p.playFile(state, "aplay", filename)
+		case IsMID(filename):
+			p.playFile(state, "aplaymidi", filename, "--port="+MIDIPort)
+		case IsVGM(filename):
+			p.playFile(state, "vgmplay", filename)
+		}
+	}
+
+	p.mu.Lock()
+	if p.current == state {
+		p.current = nil
+	}
+	p.mu.Unlock()
+}
+
+// shouldContinue reports whether state is still the current track and, for
+// playlist tracks, whether the playlist is still running.
+func (p *Player) shouldContinue(state *playState) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.current == state && (!state.inPlaylist || !p.endPlaylist)
+}
+
+// playMP3 runs mpg123, killing it as soon as it reports the track finished
+// to work around the hang the Python script describes.
+func (p *Player) playMP3(state *playState, filename string) {
+	if IsPLS(filename) {
+		filename = PLSURL(filename, p.logger)
+	}
+	proc, err := p.startProcess(state, "mpg123", "--no-control", filename)
+	if err != nil {
+		p.logger.Log(err.Error())
+		return
+	}
+	scanner := bufio.NewScanner(proc.reader)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), " \t\r\n\f\v")
+		p.logger.Log(line)
+		if strings.Contains(line, "finished.") {
+			break
+		}
+	}
+	p.finishProcess(proc)
+}
+
+// playFile runs a player until it exits, logging its output.
+func (p *Player) playFile(state *playState, name string, args ...string) {
+	proc, err := p.startProcess(state, name, args...)
+	if err != nil {
+		p.logger.Log(err.Error())
+		return
+	}
+	scanner := bufio.NewScanner(proc.reader)
+	for scanner.Scan() {
+		p.logger.Log(strings.TrimRight(scanner.Text(), " \t\r\n\f\v"))
+	}
+	p.finishProcess(proc)
+}
+
+func (p *Player) startProcess(state *playState, name string, args ...string) (*playerProcess, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create %s output pipe: %w", name, err)
+	}
+	// #nosec G204 -- players are fixed MiSTer tools; arguments are music file paths.
+	cmd := exec.CommandContext(context.Background(), name, args...)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	cmd.SysProcAttr = playerAttributes()
+	if err := cmd.Start(); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		return nil, fmt.Errorf("start %s: %w", name, err)
+	}
+	_ = writer.Close()
+	proc := &playerProcess{cmd: cmd, reader: reader}
+	p.mu.Lock()
+	p.proc = proc
+	ended := state.inPlaylist && p.endPlaylist
+	p.mu.Unlock()
+	if ended {
+		// The playlist stopped while this player was starting.
+		killPlayer(cmd)
+	}
+	return proc, nil
+}
+
+// finishProcess mirrors kill_player() for the process this call started.
+func (p *Player) finishProcess(proc *playerProcess) {
+	p.mu.Lock()
+	if p.proc == proc {
+		p.proc = nil
+	}
+	p.mu.Unlock()
+	killPlayer(proc.cmd)
+	_ = proc.reader.Close()
+	_ = proc.cmd.Wait()
+}
+
+// randomTrack mirrors get_random_track() with a guard against the Python
+// infinite loop when every remaining track is in the history.
+func (p *Player) randomTrack() (string, bool) {
+	tracks := p.Tracks(p.Playlist(), false)
+	if len(tracks) == 0 {
+		return "", false
+	}
+	history := p.History()
+	candidates := make([]string, 0, len(tracks))
+	for _, track := range tracks {
+		if !containsString(history, track) {
+			candidates = append(candidates, track)
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = tracks
+	}
+	return candidates[p.randIndex(len(candidates))], true
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Player) beginPlaylist() chan struct{} {
+	done := make(chan struct{})
+	p.mu.Lock()
+	p.endPlaylist = false
+	p.playlistDone = done
+	p.mu.Unlock()
+	return done
+}
+
+func (p *Player) startRandomPlaylist() {
+	p.logger.Log("Starting random playlist...")
+	done := p.beginPlaylist()
+	go func() {
+		defer close(done)
+		for p.InPlaylist() {
+			track, ok := p.randomTrack()
+			if !ok {
+				break
+			}
+			p.playTrack(track, true)
+		}
+		p.logger.Log("Random playlist ended")
+	}()
+}
+
+func (p *Player) startLoopPlaylist() {
+	p.logger.Log("Starting loop playlist...")
+	done := p.beginPlaylist()
+	track, ok := p.randomTrack()
+	go func() {
+		defer close(done)
+		for p.InPlaylist() && ok {
+			p.playTrack(track, true)
+		}
+		p.logger.Log("Loop playlist ended")
+	}()
+}
+
+// StartPlaylist mirrors start_playlist(): known types are stored, "disabled"
+// only stops, and anything else plays random tracks without changing the
+// stored playback value.
+func (p *Player) StartPlaylist(playback string) {
+	p.StopPlaylist()
+	switch playback {
+	case PlaybackRandom:
+		p.SetPlayback(PlaybackRandom)
+		p.startRandomPlaylist()
+	case PlaybackLoop:
+		p.SetPlayback(PlaybackLoop)
+		p.startLoopPlaylist()
+	case PlaybackDisabled:
+		p.SetPlayback(PlaybackDisabled)
+	default:
+		p.startRandomPlaylist()
+	}
+}
+
+// StartCurrentPlaylist mirrors start_playlist() with no argument.
+func (p *Player) StartCurrentPlaylist() {
+	p.StartPlaylist(p.Playback())
+}
+
+// StopPlaylist mirrors stop_playlist() and additionally waits for the
+// playlist goroutine so a stopped playlist can never start one more track.
+func (p *Player) StopPlaylist() {
+	p.mu.Lock()
+	p.endPlaylist = true
+	done := p.playlistDone
+	p.mu.Unlock()
+	p.Stop()
+	if done != nil {
+		<-done
+	}
+}
+
+// ChangePlaylist mirrors change_playlist(), including accepting names whose
+// folder does not exist because the count falls back to the music folder.
+func (p *Player) ChangePlaylist(name string) {
+	target := ParsePlaylist(name)
+	check := target
+	if target.IsNone() {
+		check = p.Playlist()
+	}
+	p.PlaylistPath(target)
+	if p.TotalTracks(check, true) == 0 {
+		return
+	}
+	logName := target.Name()
+	if target.IsNone() {
+		logName = "None"
+	}
+	p.logger.Logf("Changed playlist: %s", logName)
+	p.mu.Lock()
+	p.playlist = target
+	p.mu.Unlock()
+	if p.InPlaylist() {
+		p.StartCurrentPlaylist()
+	}
+}
+
+// BootTrack mirrors get_boot_track(): underscore-prefixed files at the top of
+// the current playlist folder plus every file at the top of music/boot.
+func (p *Player) BootTrack() (string, bool) {
+	var candidates []string
+	folder := p.PlaylistPath(p.Playlist())
+	if entries, err := os.ReadDir(folder); err == nil {
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "_") && IsValidFile(entry.Name()) {
+				candidates = append(candidates, filepath.Join(folder, entry.Name()))
+			}
+		}
+	}
+	if entries, err := os.ReadDir(p.paths.BootFolder); err == nil {
+		for _, entry := range entries {
+			if IsValidFile(entry.Name()) {
+				candidates = append(candidates, filepath.Join(p.paths.BootFolder, entry.Name()))
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+	return candidates[p.randIndex(len(candidates))], true
+}
+
+// PlayBoot plays a boot track synchronously when one exists.
+func (p *Player) PlayBoot() {
+	track, ok := p.BootTrack()
+	if !ok {
+		return
+	}
+	p.logger.Logf("Selected boot track: %s", track)
+	p.Play(track)
+}
+
+// PlayCoreBoot mirrors play_core_boot(): a case-insensitive folder match in
+// music/boot plays one random track after the configured delay. An empty
+// matching folder ends the search; a played one lets it continue.
+func (p *Player) PlayCoreBoot(core string) {
+	entries, err := os.ReadDir(p.paths.BootFolder)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !strings.EqualFold(entry.Name(), core) {
+			continue
+		}
+		folder := filepath.Join(p.paths.BootFolder, entry.Name())
+		info, statErr := os.Stat(folder)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		files, readErr := os.ReadDir(folder)
+		if readErr != nil {
+			continue
+		}
+		var tracks []string
+		for _, file := range files {
+			if IsValidFile(file.Name()) {
+				tracks = append(tracks, filepath.Join(folder, file.Name()))
+			}
+		}
+		if len(tracks) == 0 {
+			return
+		}
+		cfg, _ := LoadConfig(&p.paths)
+		p.sleep(time.Duration(cfg.CoreBootDelay * float64(time.Second)))
+		p.logger.Log("Playing core boot track...")
+		p.Play(tracks[p.randIndex(len(tracks))])
+	}
+}

--- a/pkg/bgm/player_test.go
+++ b/pkg/bgm/player_test.go
@@ -1,0 +1,495 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestPlayer(t *testing.T, paths *Paths, cfg *Config) *Player {
+	t.Helper()
+	logger, _ := newTestLogger(paths)
+	player := NewPlayer(paths, logger, cfg)
+	player.randIndex = func(int) int { return 0 }
+	player.sleep = func(time.Duration) {}
+	t.Cleanup(player.StopPlaylist)
+	return player
+}
+
+func touchTracks(t *testing.T, folder string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		writeFile(t, filepath.Join(folder, name), "")
+	}
+}
+
+func relativeTracks(t *testing.T, paths *Paths, tracks []string) []string {
+	t.Helper()
+	relative := make([]string, 0, len(tracks))
+	for _, track := range tracks {
+		rel, err := filepath.Rel(paths.MusicFolder, track)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relative = append(relative, filepath.ToSlash(rel))
+	}
+	slices.Sort(relative)
+	return relative
+}
+
+func TestPlaylistPathFallsBackToMusicFolder(t *testing.T) {
+	paths := newTestPaths(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	if err := os.MkdirAll(filepath.Join(paths.MusicFolder, "chip"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := player.PlaylistPath(Playlist{}); got != paths.MusicFolder {
+		t.Fatalf("none -> %s", got)
+	}
+	if got := player.PlaylistPath(NamedPlaylist("all")); got != paths.MusicFolder {
+		t.Fatalf("all -> %s", got)
+	}
+	if got := player.PlaylistPath(NamedPlaylist("chip")); got != filepath.Join(paths.MusicFolder, "chip") {
+		t.Fatalf("chip -> %s", got)
+	}
+	if got := player.PlaylistPath(NamedPlaylist("missing")); got != paths.MusicFolder {
+		t.Fatalf("missing -> %s", got)
+	}
+}
+
+func layoutMusic(t *testing.T, paths *Paths) {
+	t.Helper()
+	touchTracks(t, paths.MusicFolder, "top.mp3", "_boot.mp3", "radio.pls", "notes.txt")
+	touchTracks(t, filepath.Join(paths.MusicFolder, "chip"), "one.ogg", "_intro.wav", "stream.pls")
+	touchTracks(t, filepath.Join(paths.MusicFolder, "chip", "deep"), "two.vgm")
+	touchTracks(t, paths.BootFolder, "global.wav")
+	touchTracks(t, filepath.Join(paths.BootFolder, "SNES"), "snes.mp3")
+	if err := os.MkdirAll(filepath.Join(paths.MusicFolder, "folder.mp3"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTracksNoneIsTopLevelOnly(t *testing.T) {
+	paths := newTestPaths(t)
+	layoutMusic(t, &paths)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	got := relativeTracks(t, &paths, player.Tracks(Playlist{}, false))
+	want := []string{"folder.mp3", "radio.pls", "top.mp3"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("tracks %v want %v", got, want)
+	}
+	withBoot := relativeTracks(t, &paths, player.Tracks(Playlist{}, true))
+	if !slices.Contains(withBoot, "_boot.mp3") || len(withBoot) != 4 {
+		t.Fatalf("include_boot tracks %v", withBoot)
+	}
+}
+
+func TestTracksAllIsRecursiveWithoutPLS(t *testing.T) {
+	paths := newTestPaths(t)
+	layoutMusic(t, &paths)
+	cfg := DefaultConfig()
+	cfg.Playlist = NamedPlaylist("all")
+	player := newTestPlayer(t, &paths, &cfg)
+	got := relativeTracks(t, &paths, player.Tracks(player.Playlist(), false))
+	want := []string{"boot/SNES/snes.mp3", "boot/global.wav", "chip/deep/two.vgm", "chip/one.ogg", "top.mp3"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("tracks %v want %v", got, want)
+	}
+}
+
+func TestTracksNamedPlaylistKeepsPLSAndUsesCurrentPlaylistRule(t *testing.T) {
+	paths := newTestPaths(t)
+	layoutMusic(t, &paths)
+	cfg := DefaultConfig()
+	cfg.Playlist = NamedPlaylist("chip")
+	player := newTestPlayer(t, &paths, &cfg)
+	got := relativeTracks(t, &paths, player.Tracks(player.Playlist(), false))
+	want := []string{"chip/deep/two.vgm", "chip/one.ogg", "chip/stream.pls"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("tracks %v want %v", got, want)
+	}
+	// A non-existent playlist falls back to the music folder recursively and
+	// still keeps .pls files because the current playlist is not "all".
+	missing := relativeTracks(t, &paths, player.Tracks(NamedPlaylist("missing"), false))
+	if !slices.Contains(missing, "radio.pls") || !slices.Contains(missing, "boot/global.wav") {
+		t.Fatalf("missing playlist tracks %v", missing)
+	}
+	// The .pls rule follows the *current* playlist, not the requested one.
+	player.playlist = NamedPlaylist("all")
+	chipUnderAll := relativeTracks(t, &paths, player.Tracks(NamedPlaylist("chip"), false))
+	if slices.Contains(chipUnderAll, "chip/stream.pls") {
+		t.Fatalf("pls should be excluded while current playlist is all: %v", chipUnderAll)
+	}
+}
+
+func TestHistoryTrimsToOneMoreThanTwentyPercent(t *testing.T) {
+	paths := newTestPaths(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	touchTracks(t, paths.MusicFolder, "a.mp3", "b.mp3", "c.mp3", "d.mp3")
+	player.addHistory("a.mp3")
+	if len(player.History()) != 0 {
+		t.Fatal("fewer than five tracks must keep no history")
+	}
+	for _, name := range []string{"e", "f", "g", "h", "i", "j"} {
+		touchTracks(t, paths.MusicFolder, name+".mp3")
+	}
+	for _, name := range []string{"1", "2", "3", "4", "5"} {
+		player.addHistory(name)
+	}
+	if got := player.History(); !slices.Equal(got, []string{"3", "4", "5"}) {
+		t.Fatalf("history %v", got)
+	}
+}
+
+func TestRandomTrackAvoidsHistoryAndFallsBackWhenExhausted(t *testing.T) {
+	paths := newTestPaths(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	touchTracks(t, paths.MusicFolder, "a.mp3", "b.mp3")
+	player.history = []string{filepath.Join(paths.MusicFolder, "a.mp3")}
+	track, ok := player.randomTrack()
+	if !ok || filepath.Base(track) != "b.mp3" {
+		t.Fatalf("expected b.mp3, got %q %v", track, ok)
+	}
+	player.history = append(player.history, filepath.Join(paths.MusicFolder, "b.mp3"))
+	if _, ok := player.randomTrack(); !ok {
+		t.Fatal("exhausted history must still return a track")
+	}
+	_ = os.Remove(filepath.Join(paths.MusicFolder, "a.mp3"))
+	_ = os.Remove(filepath.Join(paths.MusicFolder, "b.mp3"))
+	if _, ok := player.randomTrack(); ok {
+		t.Fatal("no tracks must return ok=false")
+	}
+}
+
+func TestPlayLoopsAndKillsOnFinished(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_FINISH", "1")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	track := filepath.Join(paths.MusicFolder, "X03_song.mp3")
+	touchTracks(t, paths.MusicFolder, "X03_song.mp3")
+
+	start := time.Now()
+	player.Play(track)
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("mpg123 was not killed after reporting finished")
+	}
+	invocations := stubInvocations(t, logPath)
+	if len(invocations) != 3 {
+		t.Fatalf("expected three loops, got %v", invocations)
+	}
+	if invocations[0] != "mpg123 --no-control "+track {
+		t.Fatalf("argv %q", invocations[0])
+	}
+	if _, playing := player.Playing(); playing {
+		t.Fatal("playing must be cleared after the track ends")
+	}
+}
+
+func TestPlayX00PlaysNothingButRecordsHistory(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	for _, name := range []string{"X00_a.mp3", "b.mp3", "c.mp3", "d.mp3", "e.mp3"} {
+		touchTracks(t, paths.MusicFolder, name)
+	}
+	track := filepath.Join(paths.MusicFolder, "X00_a.mp3")
+	player.Play(track)
+	if len(stubInvocations(t, logPath)) != 0 {
+		t.Fatal("X00_ must not start a player")
+	}
+	if !slices.Contains(player.History(), track) {
+		t.Fatal("X00_ tracks are still added to the history")
+	}
+	player.Play(filepath.Join(paths.MusicFolder, "notes.txt"))
+	if len(stubInvocations(t, logPath)) != 0 {
+		t.Fatal("invalid files must be ignored")
+	}
+}
+
+func TestPlayerCommandsAndArguments(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	writeFile(t, filepath.Join(paths.MusicFolder, "radio.pls"), "File1=http://example.com/live\n")
+	for _, name := range []string{"a.ogg", "b.wav", "c.mid", "d.vgz", "radio.pls"} {
+		touchTracks(t, paths.MusicFolder, name)
+	}
+	writeFile(t, filepath.Join(paths.MusicFolder, "radio.pls"), "File1=http://example.com/live\n")
+	for _, name := range []string{"a.ogg", "b.wav", "c.mid", "d.vgz", "radio.pls"} {
+		player.Play(filepath.Join(paths.MusicFolder, name))
+	}
+	got := stubInvocations(t, logPath)
+	want := []string{
+		"ogg123 " + filepath.Join(paths.MusicFolder, "a.ogg"),
+		"aplay " + filepath.Join(paths.MusicFolder, "b.wav"),
+		"aplaymidi " + filepath.Join(paths.MusicFolder, "c.mid") + " --port=128:0",
+		"vgmplay " + filepath.Join(paths.MusicFolder, "d.vgz"),
+		"mpg123 --no-control http://example.com/live",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("invocations %v want %v", got, want)
+	}
+}
+
+func TestStopKillsRunningPlayerAndAbandonsLoops(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	track := filepath.Join(paths.MusicFolder, "X05_long.wav")
+	touchTracks(t, paths.MusicFolder, "X05_long.wav")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		player.Play(track)
+	}()
+	waitFor(t, func() bool { return len(stubInvocations(t, logPath)) == 1 })
+	waitFor(t, func() bool { _, playing := player.Playing(); return playing })
+	if status := player.Status(); status != "yes\trandom\tnone\tX05_long.wav" {
+		t.Fatalf("status %q", status)
+	}
+	player.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Play did not return after Stop")
+	}
+	if len(stubInvocations(t, logPath)) != 1 {
+		t.Fatal("remaining loops must be abandoned after Stop")
+	}
+	if status := player.Status(); status != "no\trandom\tnone\t" {
+		t.Fatalf("status %q", status)
+	}
+	player.Stop()
+}
+
+func TestStartPlaylistSemantics(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	touchTracks(t, paths.MusicFolder, "a.wav")
+	if !player.InPlaylist() {
+		t.Fatal("in_playlist() is true before any playlist starts")
+	}
+	player.StartPlaylist(PlaybackDisabled)
+	if player.InPlaylist() || player.Playback() != PlaybackDisabled {
+		t.Fatal("disabled must stop and store the playback type")
+	}
+	player.StartPlaylist("shuffle")
+	if player.Playback() != PlaybackDisabled || !player.InPlaylist() {
+		t.Fatal("unknown playback plays random without changing the stored value")
+	}
+	player.StopPlaylist()
+	player.StartPlaylist(PlaybackLoop)
+	if player.Playback() != PlaybackLoop {
+		t.Fatal("loop must be stored")
+	}
+	player.StopPlaylist()
+	if player.InPlaylist() {
+		t.Fatal("stopping ends the playlist")
+	}
+}
+
+func TestLoopPlaylistRepeatsTheSameTrack(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	touchTracks(t, paths.MusicFolder, "a.wav", "b.wav")
+	calls := 0
+	player.randIndex = func(n int) int {
+		calls++
+		return (calls * 7) % n
+	}
+	player.StartPlaylist(PlaybackLoop)
+	waitFor(t, func() bool { return len(stubInvocations(t, logPath)) >= 3 })
+	player.StopPlaylist()
+	invocations := stubInvocations(t, logPath)
+	for _, invocation := range invocations[1:] {
+		if invocation != invocations[0] {
+			t.Fatalf("loop playlist changed track: %v", invocations)
+		}
+	}
+}
+
+func TestRandomPlaylistEndsWithoutTracks(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	defaults := DefaultConfig()
+	player := NewPlayer(&paths, logger, &defaults)
+	player.StartPlaylist(PlaybackRandom)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Random playlist ended") })
+	player.StopPlaylist()
+}
+
+func TestChangePlaylistQuirks(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	cfg := DefaultConfig()
+	cfg.Playlist = NamedPlaylist("chip")
+	player := NewPlayer(&paths, logger, &cfg)
+	player.randIndex = func(int) int { return 0 }
+	t.Cleanup(player.StopPlaylist)
+	touchTracks(t, filepath.Join(paths.MusicFolder, "chip"), "one.ogg")
+	if err := os.MkdirAll(filepath.Join(paths.MusicFolder, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	player.StopPlaylist()
+
+	player.ChangePlaylist("empty")
+	if player.Playlist().Name() != "chip" {
+		t.Fatal("an empty folder must be rejected")
+	}
+	// "none" counts the *current* playlist, so it is accepted although the
+	// top level has no files.
+	player.ChangePlaylist("none")
+	if !player.Playlist().IsNone() {
+		t.Fatal("none must be accepted when the current playlist has tracks")
+	}
+	if !strings.Contains(out.String(), "Changed playlist: None") {
+		t.Fatalf("log %q", out.String())
+	}
+	player.ChangePlaylist("chip")
+	// Missing folders fall back to the music folder and are accepted.
+	player.ChangePlaylist("does not exist")
+	if player.Playlist().Name() != "does not exist" {
+		t.Fatalf("playlist %q", player.Playlist().Name())
+	}
+	if strings.Contains(out.String(), "Starting random playlist") {
+		t.Fatal("changing a playlist while stopped must not start music")
+	}
+}
+
+func TestChangePlaylistRestartsWhenPlaying(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	defaults := DefaultConfig()
+	player := NewPlayer(&paths, logger, &defaults)
+	player.randIndex = func(int) int { return 0 }
+	t.Cleanup(player.StopPlaylist)
+	touchTracks(t, paths.MusicFolder, "a.wav")
+	touchTracks(t, filepath.Join(paths.MusicFolder, "chip"), "one.wav")
+	player.StartPlaylist(PlaybackRandom)
+	player.ChangePlaylist("chip")
+	if strings.Count(out.String(), "Starting random playlist...") != 2 {
+		t.Fatalf("expected a restart, log %q", out.String())
+	}
+	player.StopPlaylist()
+}
+
+func TestBootTrackSources(t *testing.T) {
+	paths := newTestPaths(t)
+	layoutMusic(t, &paths)
+	cfg := DefaultConfig()
+	cfg.Playlist = NamedPlaylist("chip")
+	player := newTestPlayer(t, &paths, &cfg)
+	seen := map[string]bool{}
+	for index := range 2 {
+		player.randIndex = func(int) int { return index }
+		track, ok := player.BootTrack()
+		if !ok {
+			t.Fatal("expected a boot track")
+		}
+		seen[filepath.Base(track)] = true
+	}
+	if !seen["_intro.wav"] || !seen["global.wav"] {
+		t.Fatalf("boot candidates %v", seen)
+	}
+	player.playlist = NamedPlaylist("all")
+	player.randIndex = func(int) int { return 0 }
+	if track, _ := player.BootTrack(); filepath.Base(track) != "_boot.mp3" {
+		t.Fatalf("all should use top-level underscore files, got %q", track)
+	}
+	if err := os.RemoveAll(paths.BootFolder); err != nil {
+		t.Fatal(err)
+	}
+	player.playlist = NamedPlaylist("chip")
+	touchTracks(t, filepath.Join(paths.MusicFolder, "chip"), "_only.wav")
+	_ = os.Remove(filepath.Join(paths.MusicFolder, "chip", "_intro.wav"))
+	if track, ok := player.BootTrack(); !ok || filepath.Base(track) != "_only.wav" {
+		t.Fatalf("boot track %q %v", track, ok)
+	}
+}
+
+func TestPlayCoreBoot(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	writeINI(t, &paths, "[bgm]\ncorebootdelay = 1.5\n")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	var slept time.Duration
+	player.sleep = func(duration time.Duration) { slept += duration }
+	touchTracks(t, filepath.Join(paths.BootFolder, "Genesis"), "start.wav")
+	if err := os.MkdirAll(filepath.Join(paths.BootFolder, "Empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	touchTracks(t, paths.BootFolder, "NES.mp3")
+
+	player.PlayCoreBoot("genesis")
+	if got := stubInvocations(t, logPath); len(got) != 1 || !strings.HasSuffix(got[0], "start.wav") {
+		t.Fatalf("invocations %v", got)
+	}
+	if slept != 1500*time.Millisecond {
+		t.Fatalf("slept %v", slept)
+	}
+	player.PlayCoreBoot("empty")
+	player.PlayCoreBoot("NES")
+	player.PlayCoreBoot("")
+	if got := stubInvocations(t, logPath); len(got) != 1 {
+		t.Fatalf("empty folders and files must not play: %v", got)
+	}
+}
+
+func TestPlaylistTrackStartedAfterStopIsKilledImmediately(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	track := filepath.Join(paths.MusicFolder, "long.wav")
+	touchTracks(t, paths.MusicFolder, "long.wav")
+	player.StopPlaylist()
+
+	start := time.Now()
+	player.playTrack(track, true)
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("a playlist track started after StopPlaylist must not run")
+	}
+	if len(stubInvocations(t, logPath)) != 0 {
+		t.Fatal("no player may start once the playlist has ended")
+	}
+	if _, playing := player.Playing(); playing {
+		t.Fatal("playing must be cleared")
+	}
+}

--- a/pkg/bgm/proc_unix.go
+++ b/pkg/bgm/proc_unix.go
@@ -1,0 +1,49 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !windows
+
+package bgm
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachAttributes starts the service in its own session so it survives the
+// Scripts-menu terminal closing.
+func detachAttributes() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// playerAttributes gives each audio player its own process group so a kill
+// also reaches anything it spawned.
+func playerAttributes() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killPlayer force-kills a player process group, falling back to the process.
+func killPlayer(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/pkg/bgm/proc_windows.go
+++ b/pkg/bgm/proc_windows.go
@@ -1,0 +1,37 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package bgm
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachAttributes() *syscall.SysProcAttr { return nil }
+
+func playerAttributes() *syscall.SysProcAttr { return nil }
+
+func killPlayer(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/pkg/bgm/remote.go
+++ b/pkg/bgm/remote.go
@@ -1,0 +1,212 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// MessageSize is the maximum socket payload, matching the Python script.
+const MessageSize = 4096
+
+// Remote serves the /tmp/bgm.sock line protocol: one command per connection,
+// an optional reply, then the connection is closed.
+type Remote struct {
+	listener  net.Listener
+	logger    *Logger
+	player    *Player
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// StartRemote binds the socket and serves commands in the background.
+func StartRemote(paths *Paths, logger *Logger, player *Player) (*Remote, error) {
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", paths.SocketFile)
+	if err != nil {
+		return nil, fmt.Errorf("bind BGM socket: %w", err)
+	}
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		// Python left the file behind after "quit"; cleanup removes it.
+		unixListener.SetUnlinkOnClose(false)
+	}
+	remote := &Remote{listener: listener, logger: logger, player: player, done: make(chan struct{})}
+	logger.Log("Starting remote...")
+	go remote.serve()
+	return remote, nil
+}
+
+// Done is closed once the accept loop has stopped.
+func (r *Remote) Done() <-chan struct{} { return r.done }
+
+// Close stops accepting commands and waits for the loop to exit.
+func (r *Remote) Close() {
+	r.closeOnce.Do(func() { _ = r.listener.Close() })
+	<-r.done
+}
+
+func (r *Remote) serve() {
+	defer close(r.done)
+	for {
+		conn, err := r.listener.Accept()
+		if err != nil {
+			break
+		}
+		buffer := make([]byte, MessageSize)
+		count, _ := conn.Read(buffer)
+		if count == 0 {
+			// A liveness probe connected without sending a command.
+			_ = conn.Close()
+			continue
+		}
+		command := string(buffer[:count])
+		if command == "quit" {
+			_ = conn.Close()
+			break
+		}
+		if reply, ok := r.Handle(command); ok {
+			_, _ = conn.Write([]byte(reply))
+		}
+		_ = conn.Close()
+	}
+	r.closeOnce.Do(func() { _ = r.listener.Close() })
+	r.logger.Log("Remote stopped")
+}
+
+// Handle runs one command under the command mutex. ok=false means Python
+// returned None and sent nothing.
+func (r *Remote) Handle(command string) (reply string, ok bool) {
+	player := r.player
+	player.CmdMu.Lock()
+	defer player.CmdMu.Unlock()
+
+	switch {
+	case command == "stop":
+		player.StopPlaylist()
+	case command == "play":
+		player.StartCurrentPlaylist()
+	case command == "skip":
+		player.Stop()
+	case command == "pid":
+		return strconv.Itoa(os.Getpid()), true
+	case command == "status":
+		return player.Status(), true
+	case strings.HasPrefix(command, "set playlist"):
+		if parts := strings.SplitN(command, " ", 3); len(parts) > 2 {
+			player.ChangePlaylist(parts[2])
+		}
+	case strings.HasPrefix(command, "set playback"):
+		if parts := strings.SplitN(command, " ", 3); len(parts) > 2 {
+			player.SetPlayback(parts[2])
+			if player.InPlaylist() {
+				player.StartCurrentPlaylist()
+			}
+		}
+	case command == "set playincore yes":
+		player.SetPlayInCore(true)
+	case command == "set playincore no":
+		player.SetPlayInCore(false)
+	case strings.HasPrefix(command, "get"):
+		return r.handleGet(command)
+	default:
+		r.logger.Logf("Unknown command: %s", command)
+	}
+	return "", false
+}
+
+func (r *Remote) handleGet(command string) (reply string, ok bool) {
+	parts := strings.SplitN(command, " ", 2)
+	if len(parts) < 2 {
+		return "", true
+	}
+	switch parts[1] {
+	case "playlist":
+		playlist := r.player.Playlist()
+		if playlist.IsNone() {
+			return "", false
+		}
+		return playlist.Name(), true
+	case "playback":
+		return r.player.Playback(), true
+	case "playincore":
+		if r.player.PlayInCore() {
+			return "yes", true
+		}
+		return "no", true
+	default:
+		return "", true
+	}
+}
+
+// Send mirrors send_socket(): nothing happens without a socket file, and an
+// empty reply is reported as no reply.
+func Send(paths *Paths, message string) (reply string, replied bool, err error) {
+	if _, statErr := os.Stat(paths.SocketFile); statErr != nil {
+		return "", false, nil
+	}
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialer.DialContext(context.Background(), "unix", paths.SocketFile)
+	if err != nil {
+		return "", false, fmt.Errorf("connect to BGM service: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, writeErr := conn.Write([]byte(message)); writeErr != nil {
+		return "", false, fmt.Errorf("send BGM command: %w", writeErr)
+	}
+	buffer := make([]byte, MessageSize)
+	count, err := conn.Read(buffer)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", false, fmt.Errorf("read BGM reply: %w", err)
+	}
+	if count == 0 {
+		return "", false, nil
+	}
+	return string(buffer[:count]), true, nil
+}
+
+// SocketExists reports whether the socket file is present.
+func SocketExists(paths *Paths) bool {
+	_, err := os.Stat(paths.SocketFile)
+	return err == nil
+}
+
+// SocketStale reports a socket file nobody is listening on, which the Python
+// script could never recover from without a reboot.
+func SocketStale(paths *Paths) bool {
+	if !SocketExists(paths) {
+		return false
+	}
+	dialer := net.Dialer{Timeout: time.Second}
+	conn, err := dialer.DialContext(context.Background(), "unix", paths.SocketFile)
+	if err != nil {
+		return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT)
+	}
+	_ = conn.Close()
+	return false
+}

--- a/pkg/bgm/remote.go
+++ b/pkg/bgm/remote.go
@@ -36,6 +36,10 @@ import (
 // MessageSize is the maximum socket payload, matching the Python script.
 const MessageSize = 4096
 
+// idleReadTimeout bounds how long the accept loop waits for a connected
+// client to send its command, so Close never hangs on an idle client.
+var idleReadTimeout = 5 * time.Second
+
 // Remote serves the /tmp/bgm.sock line protocol: one command per connection,
 // an optional reply, then the connection is closed.
 type Remote struct {
@@ -79,9 +83,11 @@ func (r *Remote) serve() {
 			break
 		}
 		buffer := make([]byte, MessageSize)
+		_ = conn.SetReadDeadline(time.Now().Add(idleReadTimeout))
 		count, _ := conn.Read(buffer)
 		if count == 0 {
-			// A liveness probe connected without sending a command.
+			// A liveness probe connected without sending a command, or an
+			// idle client never did.
 			_ = conn.Close()
 			continue
 		}

--- a/pkg/bgm/remote_test.go
+++ b/pkg/bgm/remote_test.go
@@ -21,11 +21,14 @@
 package bgm
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func startTestRemote(t *testing.T, paths *Paths, cfg *Config) (*Remote, *Player, *syncBuffer) {
@@ -140,6 +143,29 @@ func TestRemoteQuitStopsListeningButKeepsSocketFile(t *testing.T) {
 		t.Fatalf("log %q", out.String())
 	}
 	remote.Close()
+}
+
+func TestRemoteCloseCompletesWithIdleClient(t *testing.T) {
+	previous := idleReadTimeout
+	idleReadTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { idleReadTimeout = previous })
+	paths := newTestPaths(t)
+	remote, _, _ := startTestRemote(t, &paths, ptr(DefaultConfig()))
+	idle, err := (&net.Dialer{}).DialContext(context.Background(), "unix", paths.SocketFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idle.Close() }()
+	closed := make(chan struct{})
+	go func() {
+		remote.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close must not wait on an idle client")
+	}
 }
 
 func TestRemoteRefusesSecondBind(t *testing.T) {

--- a/pkg/bgm/remote_test.go
+++ b/pkg/bgm/remote_test.go
@@ -1,0 +1,153 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func startTestRemote(t *testing.T, paths *Paths, cfg *Config) (*Remote, *Player, *syncBuffer) {
+	t.Helper()
+	out := &syncBuffer{}
+	logger := NewLoggerTo(paths, out)
+	player := NewPlayer(paths, logger, cfg)
+	player.randIndex = func(int) int { return 0 }
+	remote, err := StartRemote(paths, logger, player)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		remote.Close()
+		player.StopPlaylist()
+	})
+	return remote, player, out
+}
+
+func TestSendWithoutSocket(t *testing.T) {
+	paths := newTestPaths(t)
+	reply, replied, err := Send(&paths, "status")
+	if err != nil || replied || reply != "" {
+		t.Fatalf("Send = %q %v %v", reply, replied, err)
+	}
+	if SocketExists(&paths) || SocketStale(&paths) {
+		t.Fatal("no socket file expected")
+	}
+}
+
+func TestRemoteProtocol(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	touchTracks(t, filepath.Join(paths.MusicFolder, "my music"), "a.wav")
+	_, player, out := startTestRemote(t, &paths, ptr(DefaultConfig()))
+	player.StopPlaylist()
+
+	reply, replied, err := Send(&paths, "status")
+	if err != nil || !replied || reply != "no\trandom\tnone\t" {
+		t.Fatalf("status = %q %v %v", reply, replied, err)
+	}
+	reply, replied, _ = Send(&paths, "pid")
+	if !replied || reply != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("pid = %q", reply)
+	}
+	if _, replied, _ = Send(&paths, "get playlist"); replied {
+		t.Fatal("get playlist with no playlist must send nothing")
+	}
+	if reply, _, _ = Send(&paths, "get playback"); reply != "random" {
+		t.Fatalf("get playback = %q", reply)
+	}
+	if reply, _, _ = Send(&paths, "get playincore"); reply != "no" {
+		t.Fatalf("get playincore = %q", reply)
+	}
+	if _, replied, _ = Send(&paths, "get bogus"); replied {
+		t.Fatal("unknown get sends an empty reply")
+	}
+	if _, replied, _ = Send(&paths, "set playincore yes"); replied {
+		t.Fatal("set commands send nothing")
+	}
+	if reply, _, _ = Send(&paths, "get playincore"); reply != "yes" {
+		t.Fatalf("get playincore = %q", reply)
+	}
+	_, _, _ = Send(&paths, "set playlist my music")
+	if reply, _, _ = Send(&paths, "get playlist"); reply != "my music" {
+		t.Fatalf("playlist names keep their spaces, got %q", reply)
+	}
+	_, _, _ = Send(&paths, "set playback shuffle")
+	if reply, _, _ = Send(&paths, "status"); reply != "no\tshuffle\tmy music\t" {
+		t.Fatalf("status = %q", reply)
+	}
+	if strings.Contains(out.String(), "Starting random playlist") {
+		t.Fatal("set playback must not start music while stopped")
+	}
+	_, _, _ = Send(&paths, "play")
+	if !player.InPlaylist() {
+		t.Fatal("play starts the playlist")
+	}
+	_, _, _ = Send(&paths, "stop")
+	if player.InPlaylist() {
+		t.Fatal("stop ends the playlist")
+	}
+	_, _, _ = Send(&paths, "dance")
+	if !strings.Contains(out.String(), "Unknown command: dance") {
+		t.Fatalf("log %q", out.String())
+	}
+	if SocketStale(&paths) {
+		t.Fatal("a live service must not look stale")
+	}
+	if strings.Contains(out.String(), "Unknown command: \n") {
+		t.Fatal("liveness probes must not be logged as commands")
+	}
+}
+
+func TestRemoteQuitStopsListeningButKeepsSocketFile(t *testing.T) {
+	paths := newTestPaths(t)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	remote, _, out := startTestRemote(t, &paths, ptr(DefaultConfig()))
+	if _, replied, err := Send(&paths, "quit"); replied || err != nil {
+		t.Fatalf("quit reply %v %v", replied, err)
+	}
+	<-remote.Done()
+	if !SocketExists(&paths) {
+		t.Fatal("quit must leave the socket file behind like Python")
+	}
+	if !SocketStale(&paths) {
+		t.Fatal("nobody listens after quit")
+	}
+	if !strings.Contains(out.String(), "Remote stopped") {
+		t.Fatalf("log %q", out.String())
+	}
+	remote.Close()
+}
+
+func TestRemoteRefusesSecondBind(t *testing.T) {
+	paths := newTestPaths(t)
+	startTestRemote(t, &paths, ptr(DefaultConfig()))
+	logger, _ := newTestLogger(&paths)
+	defaults := DefaultConfig()
+	if _, err := StartRemote(&paths, logger, NewPlayer(&paths, logger, &defaults)); err == nil {
+		t.Fatal("binding an existing socket must fail")
+	}
+}

--- a/pkg/bgm/service.go
+++ b/pkg/bgm/service.go
@@ -1,0 +1,162 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Service is the long-running "exec" process: boot sound, remote socket and
+// the core-change loop that starts and stops music.
+type Service struct {
+	logger      *Logger
+	player      *Player
+	remote      *Remote
+	watcher     *CoreWatcher
+	paths       Paths
+	cleanupOnce sync.Once
+}
+
+// NewService builds the player from the current configuration.
+func NewService(paths *Paths, logger *Logger) *Service {
+	cfg, _ := LoadConfig(paths)
+	return &Service{
+		paths:   *paths,
+		logger:  logger,
+		player:  NewPlayer(paths, logger, &cfg),
+		watcher: NewCoreWatcher(paths, logger),
+	}
+}
+
+// Player exposes the service player for tests.
+func (s *Service) Player() *Player { return s.player }
+
+// Watcher exposes the core watcher so tests can shorten its timings.
+func (s *Service) Watcher() *CoreWatcher { return s.watcher }
+
+// Run mirrors start_service(). It returns when CORENAME disappears, the
+// watch fails, or ctx ends.
+func (s *Service) Run(ctx context.Context) error {
+	s.logger.Log("Starting service...")
+	s.logger.Logf("Playlist folder: %s", s.player.PlaylistPath(s.player.Playlist()))
+
+	cfg, _ := LoadConfig(&s.paths)
+
+	remote, err := StartRemote(&s.paths, s.logger, s.player)
+	if err != nil {
+		return err
+	}
+	s.remote = remote
+
+	if cfg.ShouldChangeVolume() {
+		VolumeSet(&s.paths, s.logger, cfg.MenuVolume)
+		s.player.PlayBoot()
+		VolumeSet(&s.paths, s.logger, cfg.DefaultVolume)
+	} else {
+		s.player.PlayBoot()
+	}
+
+	core, hasCore := GetCore(&s.paths)
+	if core == MenuCore || !hasCore || s.player.PlayInCore() {
+		if cfg.ShouldChangeVolume() && core == MenuCore {
+			VolumeSet(&s.paths, s.logger, cfg.MenuVolume)
+		}
+		s.player.StartPlaylist(cfg.Playback)
+	}
+
+	for {
+		newCore, ok := s.watcher.WaitCoreChange(ctx)
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("BGM service stopped: %w", err)
+		}
+		cfg, _ = LoadConfig(&s.paths)
+		s.player.SetPlayInCore(cfg.PlayInCore)
+
+		if !ok {
+			s.logger.Log("CORENAME file is missing, exiting...")
+			return nil
+		}
+
+		switch {
+		case hasCore && strings.EqualFold(core, newCore):
+			s.logger.Log("CORENAME file changed, but core is the same")
+		case s.player.PlayInCore():
+			s.logger.Log("playincore is enabled")
+		case newCore == MenuCore:
+			s.enterMenu(&cfg)
+		default:
+			s.enterCore(&cfg, newCore)
+		}
+
+		core, hasCore = newCore, true
+	}
+}
+
+func (s *Service) enterMenu(cfg *Config) {
+	s.logger.Log("Switched to menu core, starting playlist...")
+	s.logger.Log("Grabbing mutex")
+	s.player.CmdMu.Lock()
+	defer func() {
+		s.logger.Log("Releasing mutex")
+		s.player.CmdMu.Unlock()
+	}()
+	if cfg.ShouldChangeVolume() {
+		s.logger.Log("Changing volume to menu volume")
+		VolumeSet(&s.paths, s.logger, cfg.MenuVolume)
+	}
+	s.logger.Log("Starting playlist")
+	s.player.StartCurrentPlaylist()
+}
+
+func (s *Service) enterCore(cfg *Config, core string) {
+	s.logger.Log("Exited menu core, stopping playlist...")
+	s.logger.Log("Grabbing mutex")
+	s.player.CmdMu.Lock()
+	defer func() {
+		s.logger.Log("Releasing mutex")
+		s.player.CmdMu.Unlock()
+	}()
+	s.logger.Log("Stopping playlist")
+	s.player.StopPlaylist()
+	s.logger.Log("Playing core boot")
+	s.player.PlayCoreBoot(core)
+	if cfg.ShouldChangeVolume() {
+		s.logger.Log("Changing volume to default volume")
+		VolumeSet(&s.paths, s.logger, cfg.DefaultVolume)
+	}
+}
+
+// Cleanup mirrors cleanup(): stop music, stop the remote, remove the socket.
+// It is safe to call more than once and from a signal handler.
+func (s *Service) Cleanup() {
+	s.cleanupOnce.Do(func() {
+		s.player.StopPlaylist()
+		if s.remote != nil {
+			s.remote.Close()
+		}
+		if SocketExists(&s.paths) {
+			_ = os.Remove(s.paths.SocketFile)
+		}
+	})
+}

--- a/pkg/bgm/service_test.go
+++ b/pkg/bgm/service_test.go
@@ -1,0 +1,215 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T, paths *Paths) (*Service, *syncBuffer) {
+	t.Helper()
+	out := &syncBuffer{}
+	logger := NewLoggerTo(paths, out)
+	service := NewService(paths, logger)
+	service.Watcher().RetryInterval = time.Millisecond
+	service.Watcher().Settle = 20 * time.Millisecond
+	service.Player().randIndex = func(int) int { return 0 }
+	service.Player().sleep = func(time.Duration) {}
+	return service, out
+}
+
+func runService(t *testing.T, service *Service) (cancel context.CancelFunc, errs <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	results := make(chan error, 1)
+	go func() { results <- service.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		service.Cleanup()
+	})
+	return cancel, results
+}
+
+func setCore(t *testing.T, paths *Paths, core string) {
+	t.Helper()
+	writeFile(t, paths.CoreNameFile, core)
+}
+
+func TestServiceFollowsCoreChanges(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	writeINI(t, &paths, "[bgm]\nmenuvolume = 5\ndefaultvolume = 2\ndebug = yes\n")
+	touchTracks(t, paths.MusicFolder, "_boot.wav", "song.wav")
+	touchTracks(t, filepath.Join(paths.BootFolder, "SNES"), "snes.wav")
+	setCore(t, &paths, MenuCore)
+
+	service, out := newTestService(t, &paths)
+	cancel, errs := runService(t, service)
+
+	waitFor(t, func() bool { return SocketExists(&paths) })
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Starting random playlist...") })
+	invocations := stubInvocations(t, logPath)
+	if len(invocations) == 0 || !strings.HasSuffix(invocations[0], "_boot.wav") {
+		t.Fatalf("boot track should play first: %v", invocations)
+	}
+	if got := readFile(t, paths.CmdInterface); got != "volume 5\n" {
+		t.Fatalf("menu volume expected after boot, got %q", got)
+	}
+	if !strings.Contains(out.String(), "Setting volume to 2") {
+		t.Fatal("default volume must be set after the boot track")
+	}
+
+	// Ensure the watch is established before triggering a change.
+	time.Sleep(50 * time.Millisecond)
+	setCore(t, &paths, "SNES")
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Playing core boot track...") })
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Releasing mutex") })
+	if service.Player().InPlaylist() {
+		t.Fatal("entering a core stops the playlist")
+	}
+	if got := readFile(t, paths.CmdInterface); got != "volume 2\n" {
+		t.Fatalf("default volume expected in core, got %q", got)
+	}
+	if !strings.Contains(strings.Join(stubInvocations(t, logPath), "\n"), "snes.wav") {
+		t.Fatal("core boot track did not play")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	setCore(t, &paths, "snes")
+	waitFor(t, func() bool { return strings.Contains(out.String(), "core is the same") })
+
+	time.Sleep(50 * time.Millisecond)
+	setCore(t, &paths, MenuCore)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Switched to menu core") })
+	waitFor(t, func() bool { return service.Player().InPlaylist() })
+	waitFor(t, func() bool { return readFile(t, paths.CmdInterface) == "volume 5\n" })
+
+	cancel()
+	if err := <-errs; !errors.Is(err, context.Canceled) {
+		t.Fatal(err)
+	}
+	service.Cleanup()
+	if SocketExists(&paths) {
+		t.Fatal("cleanup must remove the socket")
+	}
+	if !strings.Contains(out.String(), "Remote stopped") {
+		t.Fatal("remote must be stopped")
+	}
+}
+
+func TestServiceExitsWhenCoreNameNeverAppears(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	touchTracks(t, paths.MusicFolder, "song.wav")
+	service, out := newTestService(t, &paths)
+	service.Watcher().RetryCount = 2
+	_, errs := runService(t, service)
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("service did not exit")
+	}
+	expected := []string{
+		"CORENAME file does not exist, retrying...", "No CORENAME file found", "CORENAME file is missing, exiting...",
+	}
+	for _, want := range expected {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("missing %q in %q", want, out.String())
+		}
+	}
+	// Music still started because a missing CORENAME counts as the menu.
+	if !strings.Contains(out.String(), "Starting random playlist...") {
+		t.Fatal("playlist should start while CORENAME is missing")
+	}
+}
+
+func TestServicePlayInCoreIgnoresCoreChanges(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	writeINI(t, &paths, "[bgm]\nplayincore = yes\ndebug = yes\n")
+	touchTracks(t, paths.MusicFolder, "song.wav")
+	setCore(t, &paths, "NES")
+	service, out := newTestService(t, &paths)
+	runService(t, service)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "Starting random playlist...") })
+	time.Sleep(50 * time.Millisecond)
+	setCore(t, &paths, "SNES")
+	waitFor(t, func() bool { return strings.Contains(out.String(), "playincore is enabled") })
+	if !service.Player().InPlaylist() {
+		t.Fatal("music keeps playing inside cores")
+	}
+}
+
+func TestServiceDoesNotStartInCore(t *testing.T) {
+	paths := newTestPaths(t)
+	installStubPlayers(t)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	touchTracks(t, paths.MusicFolder, "song.wav")
+	setCore(t, &paths, "NES")
+	service, out := newTestService(t, &paths)
+	runService(t, service)
+	waitFor(t, func() bool { return SocketExists(&paths) })
+	time.Sleep(50 * time.Millisecond)
+	if strings.Contains(out.String(), "Starting random playlist...") {
+		t.Fatal("music must not start while a core is running")
+	}
+	if !service.Player().InPlaylist() {
+		t.Fatal("in_playlist() stays true until a playlist is stopped")
+	}
+}
+
+func TestVolumeSetClampsAndWritesCommand(t *testing.T) {
+	paths := newTestPaths(t)
+	logger, out := newTestLogger(&paths)
+	writeINI(t, &paths, "[bgm]\ndebug = yes\n")
+	VolumeSet(&paths, logger, 9)
+	if got := readFile(t, paths.CmdInterface); got != "volume 7\n" {
+		t.Fatalf("command %q", got)
+	}
+	VolumeSet(&paths, logger, -3)
+	if got := readFile(t, paths.CmdInterface); got != "volume 0\n" {
+		t.Fatalf("command %q", got)
+	}
+	if !strings.Contains(out.String(), "Setting volume to 7\nSetting volume to 0\n") {
+		t.Fatalf("log %q", out.String())
+	}
+}
+
+func TestGetCoreTrimsWhitespace(t *testing.T) {
+	paths := newTestPaths(t)
+	if _, ok := GetCore(&paths); ok {
+		t.Fatal("missing file must report ok=false")
+	}
+	setCore(t, &paths, " MENU\n")
+	if core, ok := GetCore(&paths); !ok || core != "MENU" {
+		t.Fatalf("core %q %v", core, ok)
+	}
+}

--- a/pkg/bgm/startup.go
+++ b/pkg/bgm/startup.go
@@ -1,0 +1,84 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const startupMarker = "Startup BGM"
+
+// TryAddToStartup mirrors try_add_to_startup(): create user-startup.sh when
+// missing, then append the BGM hook once.
+func TryAddToStartup(paths *Paths, logger *Logger) error {
+	if _, err := os.Stat(paths.StartupScript); err != nil {
+		// #nosec G306 -- MiSTer's startup script must stay editable and executable.
+		if writeErr := os.WriteFile(paths.StartupScript, []byte("#!/bin/sh\n"), 0o755); writeErr != nil {
+			return fmt.Errorf("create startup script: %w", writeErr)
+		}
+	}
+	// #nosec G304 -- the startup script path is fixed by MiSTer.
+	data, err := os.ReadFile(filepath.Clean(paths.StartupScript))
+	if err != nil {
+		return fmt.Errorf("read startup script: %w", err)
+	}
+	if strings.Contains(string(data), startupMarker) {
+		return nil
+	}
+	// #nosec G302,G304 -- appending to MiSTer's shared startup script.
+	file, err := os.OpenFile(filepath.Clean(paths.StartupScript), os.O_APPEND|os.O_WRONLY, 0o755)
+	if err != nil {
+		return fmt.Errorf("open startup script: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	command := paths.AppPath
+	if strings.ContainsAny(command, " \t") {
+		command = strconv.Quote(command)
+	}
+	entry := fmt.Sprintf("\n# %s\n[[ -e %s ]] && %s $1\n", startupMarker, command, command)
+	if _, err := file.WriteString(entry); err != nil {
+		return fmt.Errorf("append BGM startup entry: %w", err)
+	}
+	logger.Print("Added service to startup script.")
+	return nil
+}
+
+// Playlists lists the playlist folders shown in the menu: every directory in
+// the music folder except boot, sorted.
+func Playlists(paths *Paths) ([]string, error) {
+	entries, err := os.ReadDir(paths.MusicFolder)
+	if err != nil {
+		return nil, fmt.Errorf("list playlists: %w", err)
+	}
+	playlists := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Name() == BootFolder || !entry.IsDir() {
+			continue
+		}
+		playlists = append(playlists, entry.Name())
+	}
+	sort.Strings(playlists)
+	return playlists, nil
+}

--- a/pkg/bgm/startup_test.go
+++ b/pkg/bgm/startup_test.go
@@ -1,0 +1,101 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in temporary directories.
+package bgm
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTryAddToStartupCreatesAndAppendsOnce(t *testing.T) {
+	paths := newTestPaths(t)
+	paths.AppPath = "/media/fat/Scripts/bgm.sh"
+	logger, out := newTestLogger(&paths)
+	if err := TryAddToStartup(&paths, logger); err != nil {
+		t.Fatal(err)
+	}
+	want := "#!/bin/sh\n\n# Startup BGM\n[[ -e /media/fat/Scripts/bgm.sh ]] && /media/fat/Scripts/bgm.sh $1\n"
+	if got := readFile(t, paths.StartupScript); got != want {
+		t.Fatalf("startup script %q", got)
+	}
+	if out.String() != "Added service to startup script.\n" {
+		t.Fatalf("output %q", out.String())
+	}
+	if err := TryAddToStartup(&paths, logger); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, paths.StartupScript); got != want {
+		t.Fatal("entry must only be added once")
+	}
+}
+
+func TestTryAddToStartupAppendsToExistingScript(t *testing.T) {
+	paths := newTestPaths(t)
+	paths.AppPath = filepath.Join(t.TempDir(), "my scripts", "bgm.sh")
+	writeFile(t, paths.StartupScript, "#!/bin/sh\necho hi\n")
+	logger, _ := newTestLogger(&paths)
+	if err := TryAddToStartup(&paths, logger); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, paths.StartupScript)
+	if !strings.HasPrefix(got, "#!/bin/sh\necho hi\n\n# Startup BGM\n[[ -e \"") {
+		t.Fatalf("startup script %q", got)
+	}
+	info, err := os.Stat(paths.StartupScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Log("existing permissions are kept as-is")
+	}
+}
+
+func TestPlaylistsListsFoldersExceptBoot(t *testing.T) {
+	paths := newTestPaths(t)
+	for _, folder := range []string{"zeta", "alpha", "boot", "Mid"} {
+		if err := os.MkdirAll(filepath.Join(paths.MusicFolder, folder), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	touchTracks(t, paths.MusicFolder, "file.mp3")
+	playlists, err := Playlists(&paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(playlists, []string{"Mid", "alpha", "zeta"}) {
+		t.Fatalf("playlists %v", playlists)
+	}
+}
+
+func TestEnsureMusicFolder(t *testing.T) {
+	paths := RootedPaths(t.TempDir())
+	created, err := EnsureMusicFolder(&paths)
+	if err != nil || !created {
+		t.Fatalf("created=%v err=%v", created, err)
+	}
+	created, err = EnsureMusicFolder(&paths)
+	if err != nil || created {
+		t.Fatalf("second call created=%v err=%v", created, err)
+	}
+}

--- a/pkg/tui/button_bar.go
+++ b/pkg/tui/button_bar.go
@@ -105,6 +105,21 @@ func (bb *ButtonBar) SetOnRight(callback func()) *ButtonBar {
 	return bb
 }
 
+// FocusedIndex returns the highlighted button.
+func (bb *ButtonBar) FocusedIndex() int {
+	return bb.focusedIndex
+}
+
+// SetFocusedIndex highlights a button without activating it, so a rebuilt
+// page can keep the button the user had moved to.
+func (bb *ButtonBar) SetFocusedIndex(index int) *ButtonBar {
+	if index >= 0 && index < len(bb.buttons) {
+		bb.focusedIndex = index
+		bb.triggerHelp()
+	}
+	return bb
+}
+
 func (bb *ButtonBar) triggerHelp() {
 	if bb.helpCallback != nil && bb.focusedIndex < len(bb.helpTexts) {
 		bb.helpCallback(bb.helpTexts[bb.focusedIndex])

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -279,6 +279,24 @@ func TestButtonBarNavigationAndActivation(t *testing.T) {
 	if selected != "second" {
 		t.Fatalf("selected = %q", selected)
 	}
+	if bar.FocusedIndex() != 1 {
+		t.Fatalf("focused index = %d", bar.FocusedIndex())
+	}
+
+	// A rebuilt page restores the highlight; out-of-range values are ignored.
+	help := ""
+	rebuilt := NewButtonBar(app).
+		AddButtonWithHelp("First", "first help", func() { selected = "first" }).
+		AddButtonWithHelp("Second", "second help", func() { selected = "second" }).
+		SetHelpCallback(func(text string) { help = text })
+	rebuilt.SetFocusedIndex(bar.FocusedIndex()).SetFocusedIndex(5).SetFocusedIndex(-1)
+	if rebuilt.FocusedIndex() != 1 || help != "second help" {
+		t.Fatalf("focused index = %d help = %q", rebuilt.FocusedIndex(), help)
+	}
+	rebuilt.InputHandler()(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), setFocus)
+	if selected != "second" {
+		t.Fatalf("selected = %q", selected)
+	}
 }
 
 func TestModalDismissalRestoresPageFocus(t *testing.T) {

--- a/scripts/generate_repo.py
+++ b/scripts/generate_repo.py
@@ -9,8 +9,9 @@ from pathlib import Path
 from zipfile import ZipFile
 from typing import TypedDict, Union, Optional, List
 
-APPS = ["favorites", "lastplayed", "launchsync", "playlog", "random", "remote", "search"]
+APPS = ["bgm", "favorites", "lastplayed", "launchsync", "playlog", "random", "remote", "search"]
 FILES = {
+    "bgm": ["bgm.sh"],
     "favorites": ["favorites.sh"],
     "lastplayed": ["lastplayed.sh"],
     "launchsync": ["launchsync.sh"],
@@ -21,7 +22,6 @@ FILES = {
 }
 REBOOT = ["remote"]
 SCRIPT_FILES = [
-    "scripts/bgm.sh",
     "scripts/gamesmenu.sh",
 ]
 


### PR DESCRIPTION
- Port `scripts/bgm.sh` to `cmd/bgm` and `pkg/bgm`. The music folder layout, `bgm.ini` format and defaults, boot and core boot sound rules, playlist semantics, play history, socket protocol, `user-startup.sh` hook and the `exec`/`start`/`stop`/`restart` commands are unchanged, so existing installations keep working.
- Replace the dialog menu with the shared mrext TUI used by Favorites: a main screen with playback actions, playback types and playlists that refreshes while music plays, and a staged Settings page for startup, play in core, core boot delay, menu and default volume, debug logging and TUI options.
- Detect core changes with fsnotify instead of an `inotifywait` child, run the service from a copy in `/tmp` so `bgm.sh` can be updated while music plays, recover from stale sockets left by a crashed service, and make `restart` wait for the old service to exit.
- Add `ButtonBar.FocusedIndex` and `SetFocusedIndex` to `pkg/tui` so a page can be rebuilt in place without losing the highlighted button.
- Build and release `bgm.sh` as a Go app in `magefile.go`, `generate_repo.py` and the repo workflow. Add `docs/bgm.md`, including the intentional differences from the Python script, and point the README at it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the BGM application with an interactive terminal interface for playback controls, playlists, volume, looping, themes, and settings.
  - Added menu music, boot and core sounds, internet radio playlists, multiple audio formats, and remote playback control.
  - Added commands for starting, stopping, restarting, and foreground execution.
  - BGM is now included in standard and complete releases.

- **Bug Fixes**
  - Improved screen refresh behavior to prevent outdated status from replacing newer changes.

- **Documentation**
  - Added comprehensive BGM installation, configuration, usage, and command documentation.
  - Updated download links for releases and dedicated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->