### PR TITLE
feat(gamesmenu): rewrite GamesMenu in Go with shared TUI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,0 @@
-mrext is maintained for legacy users. Before proposing new MiSTer work based on this repository, read `MIGRATE.md` and consider whether current Zaparoo features provide a maintained replacement.
-
-Use the mapped Zaparoo option when it meets the requirement. mrext and raw MiSTer approaches can remain appropriate where the guide records a replacement gap, especially when Zaparoo Core is not part of the target system. Preserve existing legacy behavior and state gaps explicitly.

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DL_URL=https://github.com/wizzomafizzo/mrext/releases/download/${{ steps.mrextreleaseinfo.outputs.tag_name }}
           mkdir -p _bin/releases
-          for file in bgm.sh favorites.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
+          for file in bgm.sh favorites.sh gamesmenu.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh; do
             curl -fsSL "$DL_URL/$file" -o "_bin/releases/$file"
           done
       - name: Create databases

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pkg/games/system_metadata.json
 pkg/games/system_metadata.gen.json
 .DS_Store
 .pi/
+/CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,161 @@
-# Agent Instructions
+# AGENTS.md
 
-mrext is a legacy repository. Before proposing new MiSTer work based on it, check whether Zaparoo provides a maintained replacement.
+mrext (MiSTer Extensions) is a single Go module that builds a set of standalone
+apps for the MiSTer FPGA Linux userspace: Remote, BGM, Favorites, GamesMenu,
+LastPlayed, LaunchSync, PlayLog, Random and Search. The
+project is under active development again. Its job is stock-MiSTer workflows:
+generating menu shortcuts, tracking the running core, controller-driven TUIs and
+a network remote, all without requiring Zaparoo Core on the device.
 
-- Read [MIGRATE.md](MIGRATE.md) before recommending an implementation or migration.
-- For new MiSTer integrations, consider the mapped Zaparoo Core API, `@zaparoo/cli`, ZapScript, and Agent Skill workflows first.
-- Do not present mrext's REST/WebSocket API, Go packages, or `.mgl` and `.sync` generation as the maintained default when `MIGRATE.md` identifies a Zaparoo replacement.
-- Zaparoo Core maintains `/tmp/ACTIVEGAME` on MiSTer for compatibility. Existing readers can keep using it, but new cross-platform integrations should prefer Core's public state, notification, or MQTT interfaces.
-- If a user explicitly needs to maintain an existing mrext installation, keep the work limited to that legacy request.
-- Raw MiSTer conventions may still be appropriate when software must work without Zaparoo Core. State that requirement clearly instead of presenting it as the preferred Zaparoo architecture.
-- Do not claim complete replacement parity. Preserve and report the gaps documented in `MIGRATE.md`.
+Human docs live in [README.md](README.md), [docs/dev.md](docs/dev.md) and
+`docs/<app>.md`. This file covers what an agent cannot infer from them.
+
+## Scope and Zaparoo
+
+- Read [MIGRATE.md](MIGRATE.md) before proposing a new MiSTer integration or a
+  new cross-platform feature. Where it maps an mrext component to a maintained
+  Zaparoo replacement, do not present mrext's REST/WebSocket API, Go packages,
+  or `.mgl`/`.sync` generation as the preferred path for new integrations.
+- Work that keeps mrext apps working, or improves stock-MiSTer behaviour that
+  MIGRATE.md records as a gap, is in scope. Say plainly when a change targets
+  stock MiSTer without Core rather than presenting it as Zaparoo architecture.
+- Do not claim replacement parity. Preserve and report the gaps in MIGRATE.md.
+- `/tmp/ACTIVEGAME` is a MiSTer-specific compatibility file that both mrext and
+  Zaparoo Core maintain. Keep existing readers working; new integrations should
+  prefer Core's public state, notification or MQTT interfaces.
+- Zaparoo Core's dependency-free `mister/catalog` and `mister/mgl` modules are
+  the source of truth for system IDs, aliases, folders, extensions, RBF paths,
+  set names, groups, MGL slots and MGL generation. mrext must not grow a
+  parallel catalog. Fix catalog data upstream, then bump `coreRevision` in
+  `internal/gensystemmetadata/main.go` and the module version in `go.mod`.
+
+## Commands
+
+Run from the repo root. Go 1.27.1 is pinned in `go.mod`, golangci-lint v2.13.2
+in `.github/workflows/lint.yml`. `mage` is `go run github.com/magefile/mage`
+if it is not installed.
+
+```sh
+mage test                 # go test ./... (generates system metadata first)
+mage lint                 # golangci-lint run ./... (same generation step)
+mage lintFix              # apply auto-fixes, then re-run mage lint
+mage build <app>          # host binary into _bin/<os>_<arch>/
+mage mister <app>         # static linux/arm GOARM=7 CGO_ENABLED=0 binary for MiSTer
+mage mister all           # every app; also rebuilds the Remote web UI
+mage generateSystemMetadata   # refresh pkg/games/system_metadata.gen.json
+mage genSystemsDoc        # regenerate docs/systems.md after a catalog bump
+npm ci --prefix web/remote && npm test --prefix web/remote && npm run build --prefix web/remote
+actionlint .github/workflows/*.yml   # after editing workflows
+```
+
+- Before finishing any Go change, `mage test` and `mage lint` must both pass,
+  and `mage mister <app>` must build for each touched app.
+- Build, test and lint first generate `pkg/games/system_metadata.gen.json`
+  (gitignored) from a pinned Zaparoo Core revision. The first run needs Git and
+  network access and caches a checkout under the user cache dir. Set
+  `ZAPAROO_CORE_SOURCE` to a local Core checkout to generate from it instead.
+- Cross-compiling needs no C toolchain, container or Docker. Everything is pure
+  Go, including SQLite (`modernc.org/sqlite`).
+- `mage release` and `mage prepRelease` need UPX (`UPX_BIN`) and are for
+  maintainers. Do not run them, tag, or publish releases unless asked.
+
+## Architecture
+
+- `cmd/<app>/` is one binary per folder. Apps never import each other; shared
+  code goes in `pkg/`. `cmd/remote` is the only app with subpackages, and it
+  embeds the web UI built from `web/remote` into `cmd/remote/_client/build`.
+- `internal/` holds build-time generators only (`gensystemmetadata`,
+  `gensystemsdoc`).
+- `pkg/config` owns every MiSTer path, `/tmp` state file and the per-app INI
+  model (`UserConfig`, `LoadUserConfig`, `MREXT_CONFIG`, `MREXT_APP_PATH`).
+  A hardcoded path or magic value belongs here, not in an app.
+- `pkg/games` adapts the Zaparoo catalog plus generated display metadata into
+  `games.System`, and does stock-filesystem scanning, folder-to-system matching
+  and BIOS/setname hooks. `pkg/mister` wraps MiSTer itself: MGL generation and
+  launching via `/dev/MiSTer_cmd`, `MiSTer.ini`, `user-startup.sh`, screen
+  mode, shared memory and update helpers. `pkg/input` fakes keyboard and mouse
+  with uinput.
+- `pkg/tracker` watches `/tmp/CORENAME` and friends, resolves the active core
+  and game, writes `/tmp/ACTIVEGAME` and emits events. `pkg/service` is the
+  daemon harness (pid file, `/tmp/<app>.log`, start/stop, logger). PlayLog,
+  LastPlayed and Remote are built on both.
+- `pkg/gamesdb` is the bbolt game-name index at `config.GamesDB`
+  (`/media/fat/Scripts/.config/mrext/games.db`) used by Search, LaunchSync and
+  Remote. PlayLog keeps its own SQLite database.
+- `pkg/tui` is the shared controller-first terminal UI on tview/tcell: themes,
+  responsive/CRT layout, page frame, button bar, menu list, dialogs, on-screen
+  keyboard and the MiSTer TTY retry in `BuildAndRetry`. All interactive apps
+  must be fully usable with only a controller.
+- `pkg/bgm`, `pkg/favorites` and `pkg/gamesmenu` are domain packages for the Go ports;
+  their `cmd/` folders contain only CLI parsing and TUI.
+- `scripts/` is internal. `gamesmenu.sh`, `bgm.sh` and `favorites.sh` are the
+  original Python implementations, kept as behavioural references for their Go
+  ports; `generate_repo.py` builds Downloader databases in CI.
+- `releases/*.json` and `releases/all.json` are Downloader databases written by
+  `mage release` and the `repo.yml` workflow after a tagged release. Never edit
+  them by hand. `docs/systems.md` is generated too.
+
+## Conventions that are not enforced by tooling
+
+- Release binaries are named `<app>.sh` although they are native ARM
+  executables. The suffix is load-bearing: MiSTer's Scripts menu, Downloader
+  entries and `user-startup.sh` hooks all depend on it. Keep it.
+- Porting a Python script to Go: runtime behaviour must stay quirk-for-quirk
+  compatible. Config file names, keys and locations, folder layouts, socket
+  protocols, CLI arguments, startup-hook lines and generated file contents are
+  all contracts with installed systems. Users must never need to change
+  existing config or folders. Only the TUI may change, and new TUIs copy the
+  Favorites shape: `cmd/favorites/ui.go` and `settings.go` (main page, staged
+  Settings page with Change/Save/Cancel, footer help, themes). Every intentional
+  deviation goes in the "Compatibility notes" section of `docs/<app>.md`.
+- Existing user config files are never rewritten or reformatted wholesale.
+  Create commented defaults only when missing, and save changes with atomic
+  writes that preserve unknown keys and comments.
+- Remote's REST and WebSocket API in `docs/remote-api.md` is a contract with
+  existing clients. Extend it, do not change existing shapes.
+- App-facing changes update `docs/<app>.md` in the same change. README.md holds
+  only the per-app blurb and download links.
+- Apps minimise SD-card writes, disk footprint and daemon CPU, and avoid
+  depending on programs shipped with the MiSTer Linux image. BGM's audio
+  players (`mpg123`, `ogg123`, `aplay`, `aplaymidi`, `vgmplay`) are the known
+  exception; do not add new ones.
+- Every new `.go` file needs the GPL header block; copy it from any existing
+  file or `mage lint` fails on `goheader`. The `log` stdlib package is banned
+  (use `pkg/service` logging or explicit command output), and so are `ioutil`
+  and `http.DefaultClient`. Wrap returned errors with context.
+
+## Testing
+
+- Standard library `testing` only, no testify. Tests are table-light and
+  fixture-heavy: build a fake MiSTer root under `t.TempDir()` and inject it
+  (`bgm.RootedPaths`, `favorites.NewManagerWithPaths`,
+  `gamesmenu.NewManagerWithPaths`, `config.LoadUserConfigAt`).
+  Tests must never touch the real `/media/fat`, `/tmp/CORENAME` or
+  `/dev/MiSTer_cmd`; if a package cannot be pointed at a temp root, add that
+  seam first.
+- TUI tests render through `tcell.NewSimulationScreen` and assert on the drawn
+  cells or the focused widget; see `pkg/tui/foundation_test.go` and
+  `cmd/favorites/ui_test.go`.
+- Add or update tests for behaviour you change. Do not delete or skip a failing
+  test to make lint or CI pass.
+- Desktop runs of BGM, Favorites and GamesMenu take `--root PATH` to operate on a local
+  fake MiSTer filesystem. Other apps mostly need a real device.
+- Device testing: `mage mister <app>`, copy `_bin/linux_arm/<app>.sh` to
+  `/media/fat/Scripts/` on a MiSTer, run it from the Scripts menu. Never run
+  anything that mutates a live MiSTer (launching cores, editing `MiSTer.ini`,
+  startup hooks, deleting menu entries) without the user's explicit go-ahead
+  for that device.
+
+## Git and CI
+
+- Commits follow Conventional Commits with the app as scope, for example
+  `feat(bgm): ...`, `fix(favorites): ...`, `docs(random): ...`, `ci: ...`.
+  Branches are `<type>/<topic>`, such as `refactor/bgm-go`.
+- CI on pull requests runs golangci-lint, the Remote web UI tests and build, and
+  a dependency review that fails on any new advisory. Tags trigger
+  `build-and-release.yml`, which runs `mage prepRelease`; `repo.yml` then
+  regenerates the Downloader databases.
+- Never commit `.env`, `_bin/`, `cmd/remote/_client/build`, generated metadata
+  JSON, `.pi/` or `node_modules`. Never commit secrets or device addresses.
+- GitHub issues are labelled per app (`bgm`, `favorites`, `remote`, `gamesmenu`
+  and so on) and use the same `type(scope): summary` titles.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Create and manage shortcuts for favorite games and cores in MiSTer menu.
 
 Browse a game collection from MiSTer menu. GamesMenu scans games and creates launchers matching collection folder layout.
 
-<a href="https://github.com/wizzomafizzo/mrext/raw/main/scripts/gamesmenu.sh"><img src="docs/images/download.svg" alt="Download GamesMenu" title="Download GamesMenu" width="140"></a>
-<a href="https://github.com/wizzomafizzo/mrext#gamesmenu"><img src="docs/images/readme.svg" alt="Readme GamesMenu" title="Readme GamesMenu" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/releases/latest/download/gamesmenu.sh"><img src="docs/images/download.svg" alt="Download GamesMenu" title="Download GamesMenu" width="140"></a>
+<a href="https://github.com/wizzomafizzo/mrext/blob/main/docs/gamesmenu.md"><img src="docs/images/readme.svg" alt="Readme GamesMenu" title="Readme GamesMenu" width="140"></a>
 
 ## LastPlayed
 

--- a/cmd/gamesmenu/main.go
+++ b/cmd/gamesmenu/main.go
@@ -1,0 +1,101 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
+)
+
+type cliOptions struct{ root string }
+
+func parseCLI(args []string) (cliOptions, error) {
+	flags := flag.NewFlagSet("gamesmenu", flag.ContinueOnError)
+	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	if err := flags.Parse(args); err != nil {
+		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
+	}
+	if flags.NArg() != 0 {
+		return cliOptions{}, errors.New("usage: gamesmenu.sh [--root PATH]")
+	}
+	return cliOptions{root: *root}, nil
+}
+
+func loadRuntime(root string) (*config.UserConfig, *gamesmenu.Manager, error) {
+	var cfg *config.UserConfig
+	var err error
+	paths := gamesmenu.DefaultPaths()
+	if root == "" {
+		cfg, err = gamesmenu.LoadConfig()
+	} else {
+		absolute, absErr := filepath.Abs(root)
+		if absErr != nil {
+			return nil, nil, fmt.Errorf("resolve local MiSTer root: %w", absErr)
+		}
+		scripts := filepath.Join(absolute, "Scripts")
+		// #nosec G301 -- local fixture mirrors MiSTer's shared filesystem permissions.
+		if mkdirErr := os.MkdirAll(scripts, 0o755); mkdirErr != nil {
+			return nil, nil, fmt.Errorf("create local MiSTer root: %w", mkdirErr)
+		}
+		cfg, err = gamesmenu.LoadConfigAt(
+			filepath.Join(scripts, gamesmenu.IniFilename), filepath.Join(scripts, gamesmenu.AppFilename),
+		)
+		if err == nil {
+			cfg.Systems.GamesFolder = append([]string{absolute}, cfg.Systems.GamesFolder...)
+		}
+		paths = gamesmenu.RootedPaths(absolute)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("load GamesMenu configuration: %w", err)
+	}
+	manager, err := gamesmenu.NewManagerWithPaths(cfg, paths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create GamesMenu manager: %w", err)
+	}
+	return cfg, manager, nil
+}
+
+func run(args []string) error {
+	options, err := parseCLI(args)
+	if err != nil {
+		return err
+	}
+	cfg, manager, err := loadRuntime(options.root)
+	if err != nil {
+		return err
+	}
+	if err := gamesmenu.EnsureConfigFile(cfg); err != nil {
+		return fmt.Errorf("create GamesMenu configuration: %w", err)
+	}
+	return newUI(cfg, manager).Run()
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/gamesmenu/main_test.go
+++ b/cmd/gamesmenu/main_test.go
@@ -1,0 +1,52 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalRootRuntime(t *testing.T) {
+	root := t.TempDir()
+	cfg, manager, err := loadRuntime(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manager.Paths().SDRoot != root || manager.Paths().MenuFolder != filepath.Join(root, "_Games") ||
+		cfg.Systems.GamesFolder[0] != root {
+		t.Fatalf("paths=%+v roots=%v", manager.Paths(), cfg.Systems.GamesFolder)
+	}
+	if cfg.IniPath != filepath.Join(root, "Scripts", "gamesmenu.ini") {
+		t.Fatal(cfg.IniPath)
+	}
+}
+
+func TestInvalidCLIArguments(t *testing.T) {
+	for _, args := range [][]string{{"refresh"}, {"unexpected"}, {"--invalid"}, {"--root"}} {
+		if _, err := parseCLI(args); err == nil {
+			t.Errorf("accepted %v", args)
+		}
+	}
+	options, err := parseCLI([]string{"--root", t.TempDir()})
+	if err != nil || options.root == "" {
+		t.Fatalf("root: %+v, %v", options, err)
+	}
+}

--- a/cmd/gamesmenu/settings.go
+++ b/cmd/gamesmenu/settings.go
@@ -1,0 +1,144 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const pageSettings = "gamesmenu_settings"
+
+//nolint:govet // Groups staged values and widgets.
+type settingsPage struct {
+	ui               *ui
+	original, staged gamesmenu.Settings
+	list             *tui.MenuList
+	actions          []func()
+	help             []string
+}
+
+func (u *ui) startSettings() { newSettingsPage(u).show(1) }
+
+func newSettingsPage(u *ui) *settingsPage {
+	settings := gamesmenu.SettingsFromConfig(u.cfg)
+	return &settingsPage{ui: u, original: settings, staged: settings}
+}
+
+func (s *settingsPage) show(selection int) {
+	s.list = tui.NewMenuList()
+	s.actions, s.help = nil, nil
+	s.list.AddHeader("Interface")
+	s.actions = append(s.actions, nil)
+	s.help = append(s.help, "Controller-friendly interface and display options")
+	s.addRow("Theme", themeLabel(s.staged.Theme), func() {
+		names := make([]string, 0, len(tui.AvailableThemes))
+		for name := range tui.AvailableThemes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		choices := make([]tui.Choice, len(names))
+		selected := 0
+		for index, name := range names {
+			choices[index] = tui.Choice{Label: themeLabel(name), Help: "Use the " + themeLabel(name) + " color theme"}
+			if name == s.staged.Theme {
+				selected = index
+			}
+		}
+		tui.ShowChoiceModal(s.ui.pages, s.ui.app, "Theme", choices, selected, func(index int) {
+			s.staged.Theme = names[index]
+			s.show(1)
+		}, func() { s.show(1) })
+	})
+	s.addRow("Mouse", boolLabel(s.staged.Mouse), func() { s.staged.Mouse = !s.staged.Mouse; s.show(2) })
+	s.addRow("CRT mode", boolLabel(s.staged.CRTMode), func() { s.staged.CRTMode = !s.staged.CRTMode; s.show(3) })
+	activate := func() {
+		if action := s.actions[s.list.GetCurrentItem()]; action != nil {
+			action()
+		}
+	}
+	s.list.SetSelectedFunc(func(int, string, string, rune) { activate() })
+	bar := tui.NewButtonBar(s.ui.app).
+		AddButtonWithHelp("Change", "Change the selected setting", activate).
+		AddButtonWithHelp("Save", "Save settings and return to GamesMenu", s.save).
+		AddButtonWithHelp("Cancel", "Return without saving settings", s.back).SetupNavigation(s.back)
+	frame := tui.NewPageFrame(s.ui.app).SetTitle("GamesMenu Settings").
+		SetContent(s.list).SetButtonBar(bar).SetOnEscape(s.back)
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	s.list.SetRowChangedFunc(func(index int) {
+		if index >= 0 && index < len(s.help) {
+			frame.SetHelpText(s.help[index])
+		}
+	})
+	frame.SetupContentToButtonNavigation()
+	s.list.SetCurrentItem(min(selection, s.list.GetItemCount()-1))
+	frame.SetHelpText(s.help[s.list.GetCurrentItem()])
+	s.ui.pages.AddAndSwitchToPage(pageSettings, frame, true)
+	s.ui.app.SetFocus(s.list)
+}
+
+func (s *settingsPage) addRow(label, value string, action func()) {
+	s.list.AddRow(fmt.Sprintf("%s: %s", label, value), tui.MenuRowItem)
+	s.actions = append(s.actions, action)
+	s.help = append(s.help, settingHelp(label))
+}
+
+func (s *settingsPage) back() {
+	if s.staged.Equal(&s.original) {
+		s.ui.renderMain()
+		return
+	}
+	tui.ShowConfirmModal(
+		s.ui.pages, s.ui.app, "Discard Settings", "Discard unsaved settings?",
+		s.ui.renderMain, func() { s.show(s.list.GetCurrentItem()) },
+	)
+}
+
+func (s *settingsPage) save() {
+	if err := gamesmenu.SaveSettings(s.ui.cfg.IniPath, &s.staged); err != nil {
+		s.ui.showError(err, func() { s.show(s.list.GetCurrentItem()) })
+		return
+	}
+	s.staged.ApplyTo(s.ui.cfg)
+	s.ui.options = tui.ApplicationOptions{
+		Theme: s.ui.cfg.TUI.Theme, Mouse: s.ui.cfg.TUI.Mouse, CRTMode: s.ui.cfg.TUI.CRTMode,
+	}
+	_ = tui.SetCurrentTheme(s.ui.options.Theme)
+	s.ui.app.EnableMouse(s.ui.options.Mouse)
+	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
+	s.ui.renderMain()
+}
+
+func themeLabel(name string) string {
+	if theme := tui.AvailableThemes[name]; theme != nil {
+		return theme.DisplayName
+	}
+	return name
+}
+
+func boolLabel(value bool) string {
+	if value {
+		return "Yes"
+	}
+	return "No"
+}

--- a/cmd/gamesmenu/settings_help.go
+++ b/cmd/gamesmenu/settings_help.go
@@ -1,0 +1,33 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+func settingHelp(label string) string {
+	switch label {
+	case "Theme":
+		return "Choose interface colors; changes apply after Save"
+	case "Mouse":
+		return "Allow mouse navigation; controller navigation always works"
+	case "CRT mode":
+		return "Limit the interface to a centered 75 x 15 area on larger screens"
+	default:
+		return ""
+	}
+}

--- a/cmd/gamesmenu/ui.go
+++ b/cmd/gamesmenu/ui.go
@@ -1,0 +1,273 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+const pageMain = "gamesmenu_main"
+
+const welcomeText = "This script will generate a new folder in your main menu called Games, " +
+	"which will allow you to directly launch games without first opening a core. " +
+	"This process will take up a lot of storage space if you have large game sets. " +
+	"Press the Generate button to continue."
+
+//nolint:govet // Groups runtime dependencies and navigation state.
+type ui struct {
+	manager                   *gamesmenu.Manager
+	cfg                       *config.UserConfig
+	app                       *tview.Application
+	pages                     *tview.Pages
+	options                   tui.ApplicationOptions
+	entries                   []gamesmenu.Entry
+	mainSelection, mainButton int
+}
+
+func newUI(cfg *config.UserConfig, manager *gamesmenu.Manager) *ui {
+	return &ui{
+		manager: manager, cfg: cfg,
+		options: tui.ApplicationOptions{Theme: cfg.TUI.Theme, Mouse: cfg.TUI.Mouse, CRTMode: cfg.TUI.CRTMode},
+	}
+}
+
+func (u *ui) Run() error {
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(u.options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		u.app, u.pages = app, tview.NewPages()
+		if err := u.showMain(); err != nil {
+			return nil, err
+		}
+		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
+		u.showWelcome()
+		return app, nil
+	}
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run GamesMenu TUI: %w", err)
+	}
+	return nil
+}
+
+func (u *ui) showWelcome() {
+	if !u.manager.MenuExists() {
+		tui.ShowInfoModal(u.pages, u.app, "Welcome", welcomeText, u.renderMain)
+	}
+}
+
+func (u *ui) showMain() error {
+	entries, err := u.manager.Discover()
+	if err != nil {
+		return fmt.Errorf("discover games folders: %w", err)
+	}
+	u.entries = entries
+	u.renderMain()
+	return nil
+}
+
+func (u *ui) mustShowMain() {
+	if err := u.showMain(); err != nil {
+		u.showError(err, u.app.Stop)
+	}
+}
+
+func (u *ui) renderMain() {
+	list := tui.NewMenuList()
+	for _, entry := range u.entries {
+		marker := "[ ] "
+		if entry.Selected {
+			marker = "[x] "
+		}
+		list.AddRow(marker+entry.Display, tui.MenuRowItem)
+	}
+	if len(u.entries) == 0 {
+		list.AddHeader("No games folders found")
+	} else {
+		list.SetCurrentItem(min(u.mainSelection, len(u.entries)-1))
+	}
+	bar := tui.NewButtonBar(u.app)
+	toggle := func() {
+		if len(u.entries) == 0 {
+			return
+		}
+		u.mainSelection, u.mainButton = list.GetCurrentItem(), bar.FocusedIndex()
+		buttonFocus := bar.HasFocus()
+		u.entries[u.mainSelection].Selected = !u.entries[u.mainSelection].Selected
+		u.renderMain()
+		if buttonFocus {
+			_, primitive := u.pages.GetFrontPage()
+			frame, ok := primitive.(*tui.PageFrame)
+			if ok {
+				frame.FocusButtonBar()
+			}
+		}
+	}
+	remember := func(action func()) func() {
+		return func() { u.mainSelection, u.mainButton = list.GetCurrentItem(), bar.FocusedIndex(); action() }
+	}
+	list.SetSelectedFunc(func(int, string, string, rune) { toggle() })
+	bar.AddButtonWithHelp("Toggle", "Include or exclude this games folder", toggle).
+		AddButtonWithHelp("Generate", "Create shortcuts; confirm folder removal", remember(u.startGenerate)).
+		AddButtonWithHelp("Clean Up", "Remove shortcuts whose game is gone", remember(u.startCleanUp)).
+		AddButtonWithHelp("Settings", "Configure GamesMenu interface", remember(u.startSettings)).
+		AddButtonWithHelp("Exit", "Exit without changing the Games menu", u.app.Stop).
+		SetupNavigation(u.app.Stop)
+	frame := tui.NewPageFrame(u.app).SetTitle("GamesMenu").SetContent(list).
+		SetButtonBar(bar).SetOnEscape(u.app.Stop)
+	help := func(index int) {
+		if index >= 0 && index < len(u.entries) {
+			frame.SetHelpText(tview.Escape(strings.Join(u.entries[index].Paths, ", ")))
+		} else {
+			frame.SetHelpText("Add games to a supported system folder, then restart GamesMenu.")
+		}
+	}
+	list.SetRowChangedFunc(func(index int) { u.mainSelection = index; help(index) })
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	bar.SetFocusedIndex(u.mainButton)
+	help(list.GetCurrentItem())
+	u.pages.AddAndSwitchToPage(pageMain, frame, true)
+	u.app.SetFocus(list)
+}
+
+func (u *ui) showError(err error, onDismiss func()) {
+	tui.ShowErrorModal(u.pages, u.app, tview.Escape(err.Error()), onDismiss)
+}
+
+func (u *ui) startGenerate() {
+	var selected []gamesmenu.Entry
+	for _, entry := range u.entries {
+		if entry.Selected {
+			selected = append(selected, entry)
+		}
+	}
+	if len(selected) == 0 {
+		tui.ShowConfirmModal(u.pages, u.app, "Remove Games menu", "Remove the Games menu from your system?", func() {
+			if err := u.manager.RemoveAll(); err != nil {
+				u.showError(err, u.renderMain)
+				return
+			}
+			tui.ShowInfoModal(u.pages, u.app, "GamesMenu", "Games menu removed.", u.mustShowMain)
+		}, u.renderMain)
+		return
+	}
+	removed, err := u.manager.DeselectedFolders(selected)
+	if err != nil {
+		u.showError(err, u.renderMain)
+		return
+	}
+	generate := func() { u.generate(selected) }
+	if len(removed) > 0 {
+		message := fmt.Sprintf("Generate will remove %d folders and everything inside them:\n", len(removed)) +
+			tview.Escape(strings.Join(removed, "\n"))
+		tui.ShowConfirmModal(u.pages, u.app, "Remove deselected folders", message, generate, u.renderMain)
+	} else {
+		generate()
+	}
+}
+
+func (u *ui) generate(selected []gamesmenu.Entry) {
+	var result gamesmenu.GenerateResult
+	options := tui.ProgressOptions{Title: "Creating MGL files..."}
+	tui.ShowProgressModal(u.pages, u.app, options, func(update func(tui.ProgressUpdate)) error {
+		var err error
+		result, err = u.manager.Generate(selected, func(p gamesmenu.Progress) {
+			text := "Finished scanning"
+			if p.Entry != nil {
+				text = fmt.Sprintf("Scanning %s (%s)", p.Entry.Display, p.Folder)
+			}
+			percent := 100
+			if p.Total > 0 {
+				percent = (p.Index*100 + p.Total - 1) / p.Total
+			}
+			update(tui.ProgressUpdate{
+				Text: fmt.Sprintf("%s\n%d shortcuts created", text, p.Created), Current: percent, Total: 100,
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("generate menu: %w", err)
+		}
+		return nil
+	}, func(err error) {
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		text := fmt.Sprintf("Created: %d\nSkipped: %d\nFailed: %d\nFolders removed: %d",
+			result.Scan.Created, result.Scan.Skipped, result.Scan.Failed, len(result.Removed))
+		if len(result.Removed) > 0 {
+			text += "\n" + strings.Join(result.Removed, ", ")
+		}
+		text += errorSummary(result.Scan.Errors, result.Scan.ErrorsDropped)
+		tui.ShowInfoModal(u.pages, u.app, "Finished scanning", tview.Escape(text), u.mustShowMain)
+	})
+}
+
+func errorSummary(errs []error, dropped int) string {
+	var text strings.Builder
+	for _, err := range errs {
+		_, _ = text.WriteString("\n" + err.Error())
+	}
+	if dropped > 0 {
+		_, _ = fmt.Fprintf(&text, "\n%d more errors", dropped)
+	}
+	return text.String()
+}
+
+func (u *ui) startCleanUp() {
+	if !u.manager.MenuExists() {
+		tui.ShowInfoModal(u.pages, u.app, "Clean Up", "No Games menu exists yet.", u.renderMain)
+		return
+	}
+	message := "Remove shortcuts whose game or ZIP member is gone? Empty subfolders will also be removed."
+	tui.ShowConfirmModal(u.pages, u.app, "Clean Up", message, u.cleanUp, u.renderMain)
+}
+
+func (u *ui) cleanUp() {
+	var result gamesmenu.CleanupResult
+	options := tui.ProgressOptions{Title: "Cleaning up..."}
+	tui.ShowProgressModal(u.pages, u.app, options, func(update func(tui.ProgressUpdate)) error {
+		var err error
+		result, err = u.manager.CleanUp(func(p gamesmenu.CleanupProgress) {
+			update(tui.ProgressUpdate{Text: fmt.Sprintf("Checked: %d\nRemoved: %d", p.Checked, p.Removed)})
+		})
+		if err != nil {
+			return fmt.Errorf("clean up menu: %w", err)
+		}
+		return nil
+	}, func(err error) {
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		text := fmt.Sprintf("Checked: %d\nRemoved: %d\nEmpty folders pruned: %d\nUnreadable: %d",
+			result.Checked, result.Removed, result.PrunedFolders, result.Unreadable)
+		text += errorSummary(result.Errors, result.ErrorsDropped)
+		tui.ShowInfoModal(u.pages, u.app, "Clean Up complete", tview.Escape(text), u.mustShowMain)
+	})
+}

--- a/cmd/gamesmenu/ui_test.go
+++ b/cmd/gamesmenu/ui_test.go
@@ -1,0 +1,323 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+func newWorkflowUI(t *testing.T, menuExists bool) *ui {
+	t.Helper()
+	cfg, manager, err := loadRuntime(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, system := range []string{"NES", "SNES"} {
+		folder := filepath.Join(manager.Paths().SDRoot, "games", system)
+		if mkdirErr := os.MkdirAll(folder, 0o755); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+		if menuExists {
+			if mkdirErr := os.MkdirAll(filepath.Join(manager.Paths().MenuFolder, "_"+system), 0o755); mkdirErr != nil {
+				t.Fatal(mkdirErr)
+			}
+		}
+	}
+	if configErr := gamesmenu.EnsureConfigFile(cfg); configErr != nil {
+		t.Fatal(configErr)
+	}
+	app, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := newUI(cfg, manager)
+	view.app, view.pages = app, tview.NewPages()
+	if err := view.showMain(); err != nil {
+		t.Fatal(err)
+	}
+	app.SetRoot(view.pages, true)
+	t.Cleanup(func() { _ = tui.SetCurrentTheme("default") })
+	return view
+}
+
+func sendUIKey(view *ui, key tcell.Key) {
+	view.app.GetFocus().InputHandler()(tcell.NewEventKey(key, 0, tcell.ModNone), func(p tview.Primitive) {
+		view.app.SetFocus(p)
+	})
+}
+
+func drawText(t *testing.T, view *ui, width, height int) string {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(width, height)
+	view.pages.SetRect(0, 0, width, height)
+	view.pages.Draw(screen)
+	screen.Show()
+	var text strings.Builder
+	for y := range height {
+		for x := range width {
+			ch, _, _ := screen.Get(x, y)
+			_, _ = text.WriteString(ch)
+		}
+		_ = text.WriteByte('\n')
+	}
+	return text.String()
+}
+
+func TestMainPageRendersAndPreservesToggleFocus(t *testing.T) {
+	view := newWorkflowUI(t, false)
+	for _, size := range [][2]int{{75, 15}, {100, 30}} {
+		text := drawText(t, view, size[0], size[1])
+		for _, label := range []string{"[x] NES", "[x] SNES", "Toggle", "Generate", "Clean Up", "Settings", "Exit"} {
+			if !strings.Contains(text, label) {
+				t.Errorf("missing %q:\n%s", label, text)
+			}
+		}
+	}
+	sendUIKey(view, tcell.KeyDown)
+	sendUIKey(view, tcell.KeyEnter)
+	if view.entries[1].Selected || view.mainSelection != 1 {
+		t.Fatal("toggle lost selection")
+	}
+	if text := drawText(t, view, 75, 15); !strings.Contains(text, "[ ] SNES") {
+		t.Fatal(text)
+	}
+	_, primitive := view.pages.GetFrontPage()
+	frame, ok := primitive.(*tui.PageFrame)
+	if !ok {
+		t.Fatalf("page: %T", primitive)
+	}
+	frame.FocusButtonBar()
+	bar, ok := view.app.GetFocus().(*tui.ButtonBar)
+	if !ok {
+		t.Fatalf("focus: %T", view.app.GetFocus())
+	}
+	bar.SetFocusedIndex(0)
+	sendUIKey(view, tcell.KeyEnter)
+	if !view.entries[1].Selected {
+		t.Fatal("button did not toggle")
+	}
+	if bar, ok := view.app.GetFocus().(*tui.ButtonBar); !ok || bar.FocusedIndex() != 0 {
+		t.Fatal("button focus lost")
+	}
+}
+
+func TestWelcomeOnlyWhenMenuMissing(t *testing.T) {
+	for _, exists := range []bool{false, true} {
+		view := newWorkflowUI(t, exists)
+		view.showWelcome()
+		if view.pages.HasPage("tui_info_modal") == exists {
+			t.Fatalf("welcome for exists=%v", exists)
+		}
+	}
+}
+
+func TestGenerateRemovalConfirmationAndCancel(t *testing.T) {
+	view := newWorkflowUI(t, true)
+	view.entries[1].Selected = false
+	view.startGenerate()
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("missing confirmation")
+	}
+	if text := drawText(t, view, 100, 30); !strings.Contains(text, "_SNES") {
+		t.Fatal(text)
+	}
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	if name, _ := view.pages.GetFrontPage(); name != pageMain {
+		t.Fatal(name)
+	}
+	if view.entries[1].Selected {
+		t.Fatal("cancel lost staged toggles")
+	}
+	view.entries[0].Selected = false
+	view.startGenerate()
+	if text := drawText(t, view, 100, 30); !strings.Contains(text, "Remove the Games menu") {
+		t.Fatal(text)
+	}
+	sendUIKey(view, tcell.KeyEnter)
+	if view.manager.MenuExists() {
+		t.Fatal("menu not removed")
+	}
+	sendUIKey(view, tcell.KeyEnter)
+	for _, entry := range view.entries {
+		if !entry.Selected {
+			t.Fatal("removal did not restore first-run state")
+		}
+	}
+}
+
+func TestCleanUpWithoutMenuShowsInfo(t *testing.T) {
+	view := newWorkflowUI(t, false)
+	view.startCleanUp()
+	if !view.pages.HasPage("tui_info_modal") {
+		t.Fatal("missing info")
+	}
+	if text := drawText(t, view, 75, 15); !strings.Contains(text, "No Games menu exists") {
+		t.Fatal(text)
+	}
+}
+
+func TestRemovalPreviewScrollsWithoutConfirming(t *testing.T) {
+	view := newWorkflowUI(t, true)
+	for index := 1; index <= 20; index++ {
+		folder := filepath.Join(view.manager.Paths().MenuFolder, fmt.Sprintf("_User%02d", index))
+		if err := os.Mkdir(folder, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	view.startGenerate()
+	text := drawText(t, view, 75, 15)
+	if !strings.Contains(text, "20 folders") || !strings.Contains(text, "scroll") {
+		t.Fatalf("missing removal count or scrolling help: %s", text)
+	}
+	for range 30 {
+		sendUIKey(view, tcell.KeyDown)
+		text = drawText(t, view, 75, 15)
+	}
+	if !strings.Contains(text, "_User20") {
+		t.Fatalf("last removal is inaccessible: %s", text)
+	}
+	if name, _ := view.pages.GetFrontPage(); name != "tui_confirm_modal" {
+		t.Fatalf("scrolling dismissed confirmation: %s", name)
+	}
+	if _, err := os.Stat(filepath.Join(view.manager.Paths().MenuFolder, "_User20")); err != nil {
+		t.Fatalf("scrolling removed a folder: %v", err)
+	}
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	if name, _ := view.pages.GetFrontPage(); name != pageMain {
+		t.Fatalf("No did not return to main: %s", name)
+	}
+	if _, err := os.Stat(filepath.Join(view.manager.Paths().MenuFolder, "_User20")); err != nil {
+		t.Fatalf("No removed a folder: %v", err)
+	}
+}
+
+func TestSettingsStageSaveHelpAndDiscard(t *testing.T) {
+	view := newWorkflowUI(t, false)
+	settings := newSettingsPage(view)
+	settings.show(1)
+	if len(settings.actions) != 4 {
+		t.Fatalf("rows: %d", len(settings.actions))
+	}
+	for index, help := range settings.help {
+		if help == "" || len(help) > 73 {
+			t.Errorf("row %d help: %q", index, help)
+		}
+	}
+	settings.actions[2]()
+	if !view.cfg.TUI.Mouse || settings.staged.Mouse {
+		t.Fatal("setting applied before Save")
+	}
+	settings.back()
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("discard confirmation missing")
+	}
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	settings.staged.Theme = "dracula"
+	settings.save()
+	if view.cfg.TUI.Mouse || view.cfg.TUI.Theme != "dracula" {
+		t.Fatal("settings not applied")
+	}
+	cfg, err := gamesmenu.LoadConfigAt(view.cfg.IniPath, view.cfg.AppPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.Mouse || cfg.TUI.Theme != "dracula" {
+		t.Fatal("settings not persisted")
+	}
+	settings = newSettingsPage(view)
+	settings.show(2)
+	settings.actions[2]()
+	settings.back()
+	sendUIKey(view, tcell.KeyEnter)
+	if view.cfg.TUI.Mouse {
+		t.Fatal("discard applied setting")
+	}
+}
+
+func TestGenerateAndCleanupProgressWorkflow(t *testing.T) {
+	view := newWorkflowUI(t, false)
+	game := filepath.Join(view.manager.Paths().SDRoot, "games", "NES", "game.nes")
+	if err := os.WriteFile(game, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	screen := tcell.NewSimulationScreen("UTF-8")
+	view.app.SetScreen(screen)
+	screen.SetSize(75, 15)
+	done := make(chan error, 1)
+	go func() { done <- view.app.Run() }()
+	t.Cleanup(func() {
+		view.app.Stop()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Error(err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("UI did not stop")
+		}
+	})
+	view.app.QueueUpdateDraw(view.startGenerate)
+	waitForInfo := func() {
+		t.Helper()
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			ready := false
+			view.app.QueueUpdate(func() { ready = view.pages.HasPage("tui_info_modal") })
+			if ready {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatal("progress did not complete")
+	}
+	waitForInfo()
+	shortcut := filepath.Join(view.manager.Paths().MenuFolder, "_NES", "game.mgl")
+	if _, err := os.Stat(shortcut); err != nil {
+		t.Fatal(err)
+	}
+	view.app.QueueUpdateDraw(func() { sendUIKey(view, tcell.KeyEnter) })
+	if err := os.Remove(game); err != nil {
+		t.Fatal(err)
+	}
+	view.app.QueueUpdateDraw(view.cleanUp)
+	waitForInfo()
+	if _, err := os.Stat(shortcut); !os.IsNotExist(err) {
+		t.Fatalf("shortcut remains: %v", err)
+	}
+}

--- a/cmd/remote/menu/menu.go
+++ b/cmd/remote/menu/menu.go
@@ -35,8 +35,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/service"
 )
 
-// TODO: should be in config
-const namesTxtPath = "/media/fat/names.txt"
+const namesTxtPath = config.NamesFile
 
 type MenuSystem struct {
 	ID       string `json:"id"`

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -1,0 +1,107 @@
+# GamesMenu
+
+GamesMenu mirrors game libraries into `/media/fat/_Games`, letting you launch games directly from the stock MiSTer menu without opening a core first. It does not require Zaparoo Core.
+
+For new Zaparoo integrations, prefer Frontend library browsing and Core's public interfaces. Frontend does not mirror libraries into stock-menu folders; see [migration guidance](../MIGRATE.md).
+
+## Installation
+
+Download [gamesmenu.sh](https://github.com/wizzomafizzo/mrext/releases/latest/download/gamesmenu.sh) into `/media/fat/Scripts/`, then run it from MiSTer's Scripts menu. Despite its suffix, this is a native Go binary: **keep the `.sh` filename**. Downloader's existing `Scripts/gamesmenu.sh` entry upgrades in place; existing games and menu folders need no changes.
+
+## Main screen
+
+Each row represents an existing games folder supported by the Zaparoo MiSTer catalog's MGL definitions. Shared folders appear once. Names are sorted by folder key and displayed using `names.txt` replacements. The footer shows the selected row's source paths.
+
+- **Toggle** changes `[x]` (include) to `[ ]` (exclude), or back.
+- **Generate** creates missing shortcuts for selected folders.
+- **Clean Up** explicitly removes broken shortcuts.
+- **Settings** opens staged interface settings.
+- **Exit**, or Back/Escape on the main screen, exits without changing the menu.
+
+Use Up/Down to choose rows, Left/Right to choose footer buttons, and Select/Enter to activate the highlighted button. Mouse navigation is optional; every action works with a controller. On first run, all discovered folders are selected and a welcome message appears. Otherwise selection reflects existing `_Games` folders, not a separate saved list.
+
+## Generating the menu
+
+**Large sets can consume substantial SD-card space**, even though each shortcut is small. Generation is additive within selected folders: existing filenames are skipped, including hand-edited shortcuts. It does not run system hooks or launch cores.
+
+Shortcuts mirror source subfolders, prefixing each menu folder with `_`. For example:
+
+```text
+/media/fat/games/NES/Packs/set.zip/dir/game.nes
+/media/fat/_Games/_NES/_Packs/_dir/game.mgl
+```
+
+The ZIP filename adds no folder level. Duplicate game basenames in the same output folder use the first source encountered; subsequent collisions are skipped. Like Python, each source directory's files and ZIPs are processed before descending into subfolders, so a parent ZIP member wins over a colliding loose game below. Regular files, ZIP members, source roots and catalog MGL slots determine which core each shortcut uses. Built-in SD, USB and network roots are scanned, plus configured `games_folder` roots.
+
+**Generate removes every deselected directory under `_Games`, including custom user folders.** Plain files at the `_Games` root remain untouched. Before removal, a confirmation shows the total and lists affected folders; choose No to preserve everything and return to your selections. In long dialogs, use Up/Down to scroll through every folder, Left/Right to choose Yes or No, and Select/Enter to activate that choice. Scrolling never confirms removal. With nothing selected, Generate asks whether to remove the entire Games menu, including its root-level files. Removal returns to the main screen.
+
+Progress shows the current source folder and shortcut count. Completion reports created, skipped and failed shortcuts, removed folders, and up to ten error details. Long summaries and errors also scroll with Up/Down. Leave GamesMenu running until it finishes; progress is not cancellable.
+
+## Clean Up
+
+Clean Up asks for confirmation, then checks `.mgl` targets. It removes shortcuts when the referenced file or ZIP member is missing, and prunes empty nested menu folders. System-level folders remain so toggle state is preserved. Both Go-generated shortcuts and legacy Python shortcuts with absolute paths and raw ampersands are understood.
+
+Malformed, unreadable or ambiguous shortcuts, invalid/unreadable archives, and core-only launchers are kept. Cleanup checks every file target in custom multi-file MGLs; an unknown target prevents deletion. Menu symlinks are not traversed. The summary reports checked and removed shortcuts, pruned folders and unreadable paths.
+
+**Reconnect removable drives and mount network libraries before cleanup.** A disconnected library can look like missing games. Cleanup is never automatic and has no undo; back up custom shortcuts first.
+
+## Settings and configuration
+
+Settings contains **Theme**, **Mouse** and **CRT mode**. Change stages edits; Save writes and applies them. Cancel/Back asks before discarding unsaved edits. CRT mode centers a 75 × 15 interface on larger screens. No on-screen keyboard option is offered because GamesMenu needs no text entry.
+
+On first interactive run, GamesMenu creates `Scripts/gamesmenu.ini` beside the binary only if missing:
+
+```ini
+[tui]
+theme = default
+mouse = true
+crt_mode = true
+
+[systems]
+; Add custom game roots by repeating this key. Built-in MiSTer roots remain enabled.
+; games_folder = /media/network
+```
+
+Available themes: `default`, `high_contrast`, `dracula`, `nord`, `gruvbox`, `monogreen`. Settings saves preserve unknown keys, sections and comments using an atomic replacement; existing configuration is never replaced with defaults. Shared `MREXT_CONFIG` and `MREXT_APP_PATH` overrides are supported.
+
+To add libraries, repeat `games_folder` under `[systems]`. Each root and its `games` subfolder are considered. Built-in roots remain enabled on MiSTer. Shared `[systems] set_core` overrides are honored when generating new shortcuts, for example `set_core = NES:_Console/Custom`. Existing shortcuts are not rewritten when overrides change.
+
+## names.txt
+
+`/media/fat/names.txt` supplies display and menu folder names:
+
+```text
+SNES: Super Nintendo
+NES: Famicom/Disk
+```
+
+Keys are trimmed and compared case-insensitively; the first matching line wins. Replacement values are trimmed, `/` becomes ` & `, and other filename-illegal characters become spaces. Every path component is looked up, including nested folders. The example creates `_Super Nintendo` and `_Famicom & Disk` under `_Games`.
+
+Existing menu folder spelling is reused case-insensitively. Changing a replacement after generation changes the desired output folder name: review the removal confirmation carefully before generating again.
+
+## Compatibility notes
+
+Preserved: `_Games` at the SD root, `_`-prefixed system and nested folders, `names.txt` rules, mirrored folder layouts, flattened ZIP contents, never overwriting existing shortcuts, selection derived from folder existence, removal of deselected folders, first-run welcome, and Exit without menu changes. The Python reference remains at `scripts/gamesmenu.sh` but is no longer shipped as the release artifact.
+
+Intentional differences:
+
+- Shared controller-first TUI, `[x]`/`[ ]` markers, staged Settings, removal confirmations and result summaries. Removing the entire menu returns to the main screen instead of exiting.
+- Systems and MGL slots come solely from Zaparoo's MiSTer catalog, not the old script's 44-entry table. Every supported MGL games folder can appear; Arcade is excluded. Shared folders choose systems per extension, such as `.gbc` in `GAMEBOY` and `.gg` in `SMS`. Candidate priority is folder position in the catalog system, then system ID; longer suffixes match first.
+- Catalog RBF paths, slot indices, delays, extensions, set names and reset flags replace the script's table. Genesis now uses `_Console/MegaDrive`; FDS and Gameboy Color shortcuts carry their catalog set names, and Jaguar carries its reset flag. **The `ATARI2600` folder no longer generates shortcuts for `.a78` or `.bin`, and `VECTREX` no longer generates them for `.ovr`.** Existing shortcuts for these files remain untouched. See [supported systems](systems.md); no separate GamesMenu catalog is maintained.
+- New MGLs use XML-escaped, `../../../../..`-prefixed absolute target paths and honor `set_core`. Legacy MGL bytes remain untouched. Filename collisions are compared case-insensitively, matching MiSTer's SD filesystem behavior.
+- Source files and subfolders are each scanned in name order rather than Python's filesystem-dependent order; ZIP members retain archive order. Current-directory files still precede all subfolders. If same-level sources collide, the first name wins.
+- Existing `_NeoGeo` and `_ATARI2600` folder spelling survives catalog casing differences. Source directory symlinks are followed with loop protection. Additional network and configured roots are supported.
+- Dotfiles, AppleDouble files and hidden ZIP members are skipped. Absolute and parent-traversing ZIP paths are rejected, but harmless `./` and repeated separators are accepted. Exact ZIP member names and Python's `_.`/`_` menu-folder quirks are preserved (for example, `./game.nes` creates `_./game.mgl`). Output writes are confined to the SD root; symlinks escaping it fail rather than writing elsewhere. Exclusive file creation protects existing shortcuts against concurrent writers.
+- Optional `gamesmenu.ini` and explicit, conservative Clean Up are new. Errors are reported rather than silently discarded (invalid source ZIPs are still silently ignored).
+
+## Local development
+
+Use a disposable filesystem, not a mounted live MiSTer:
+
+```sh
+mkdir -p /tmp/gamesmenu-mister/games/NES
+# Place fixture ROMs or ZIPs under games/NES.
+go run ./cmd/gamesmenu --root /tmp/gamesmenu-mister
+```
+
+This relocates `_Games`, `names.txt` and `Scripts/gamesmenu.ini` and disables built-in device root discovery. Explicit extra roots in the fixture INI remain enabled. Tests use temporary fixtures and simulated terminal screens. Device testing requires explicit approval; never point destructive tests at a live installation.

--- a/magefile.go
+++ b/magefile.go
@@ -96,6 +96,13 @@ var apps = []app{
 		inAll:     true,
 	},
 	{
+		name:      "gamesmenu",
+		path:      filepath.Join(cwd, "cmd", "gamesmenu"),
+		bin:       "gamesmenu.sh",
+		releaseId: "mrext/gamesmenu",
+		inAll:     true,
+	},
+	{
 		name:      "launchsync",
 		path:      filepath.Join(cwd, "cmd", "launchsync"),
 		bin:       "launchsync.sh",
@@ -108,20 +115,6 @@ var apps = []app{
 		bin:       "playlog.sh",
 		releaseId: "mrext/playlog",
 		inAll:     true,
-	},
-}
-
-type scriptApp struct {
-	name string
-	path string
-	bin  string
-}
-
-var scriptApps = []scriptApp{
-	{
-		name: "gamesmenu",
-		path: filepath.Join(cwd, "scripts", "gamesmenu.sh"),
-		bin:  "gamesmenu.sh",
 	},
 }
 
@@ -329,13 +322,6 @@ func PrepRelease() {
 		if app.releaseId != "" {
 			fmt.Println("Preparing release:", app.name)
 			Release(app.name)
-		}
-	}
-	for _, app := range scriptApps {
-		fmt.Println("Preparing release:", app.name)
-		if err := sh.Copy(filepath.Join(binReleasesDir, app.bin), app.path); err != nil {
-			fmt.Println("Error copying script", app.name, err)
-			os.Exit(1)
 		}
 	}
 }

--- a/pkg/config/ini.go
+++ b/pkg/config/ini.go
@@ -1,0 +1,165 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/ini.v1"
+)
+
+// UpdateINI loads the INI file at path with shadow keys enabled, lets update
+// change only the keys it manages, re-attaches full-line comments the parser
+// drops, and replaces the file atomically. Unknown sections and keys survive.
+// A missing file is an error; callers create defaults first.
+func UpdateINI(path string, update func(*ini.File) error) error {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("read configuration for update: %w", err)
+	}
+	file, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true}, data)
+	if err != nil {
+		return fmt.Errorf("load configuration for update: %w", err)
+	}
+	if err := update(file); err != nil {
+		return err
+	}
+	if err := RetainINIComments(data, file); err != nil {
+		return err
+	}
+	return WriteINIAtomically(path, file)
+}
+
+// RetainINIComments keeps full-line notes that the INI parser replaced when
+// loading shadow keys as file comments, even when a key is removed.
+func RetainINIComments(original []byte, file *ini.File) error {
+	var rendered strings.Builder
+	if _, err := file.WriteTo(&rendered); err != nil {
+		return fmt.Errorf("render configuration comments: %w", err)
+	}
+	present := make(map[string]bool)
+	for _, line := range strings.Split(rendered.String(), "\n") {
+		present[strings.TrimSpace(line)] = true
+	}
+	for _, line := range strings.Split(string(original), "\n") {
+		line = strings.TrimSpace(line)
+		if (strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")) && !present[line] {
+			section := file.Section(ini.DefaultSection)
+			section.Comment = strings.TrimSpace(section.Comment + "\n" + line)
+			present[line] = true
+		}
+	}
+	return nil
+}
+
+// GetOrCreateSection returns the named section, creating it when missing.
+func GetOrCreateSection(file *ini.File, name string) (*ini.Section, error) {
+	section, err := file.GetSection(name)
+	if err == nil {
+		return section, nil
+	}
+	section, err = file.NewSection(name)
+	if err != nil {
+		return nil, fmt.Errorf("create %s configuration section: %w", name, err)
+	}
+	return section, nil
+}
+
+// SetKey sets a single-valued key, creating it when missing.
+func SetKey(section *ini.Section, name, value string) {
+	section.Key(name).SetValue(value)
+}
+
+// SetShadowKeys replaces a repeated key with values, keeping any comment
+// attached to the first existing occurrence. An empty list removes the key and
+// moves its comment to the section so the note is not lost.
+func SetShadowKeys(section *ini.Section, name string, values []string) error {
+	comment := ""
+	if existing, err := section.GetKey(name); err == nil {
+		comment = existing.Comment
+	}
+	section.DeleteKey(name)
+	if len(values) == 0 {
+		if comment != "" {
+			section.Comment = strings.TrimSpace(section.Comment + "\n" + comment)
+		}
+		return nil
+	}
+	key, err := section.NewKey(name, values[0])
+	if err != nil {
+		return fmt.Errorf("create %s setting: %w", name, err)
+	}
+	key.Comment = comment
+	for _, value := range values[1:] {
+		if err := key.AddShadow(value); err != nil {
+			return fmt.Errorf("add %s setting: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// FormatBool renders a boolean the way mrext INI files spell it.
+func FormatBool(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+// WriteINIAtomically writes file to a temporary sibling and renames it over
+// path, so a failure never leaves a truncated configuration behind.
+func WriteINIAtomically(path string, file *ini.File) error {
+	path = filepath.Clean(path)
+	directory := filepath.Dir(path)
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	temporary, err := os.CreateTemp(directory, "."+base+"-*.ini")
+	if err != nil {
+		return fmt.Errorf("create temporary configuration: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := file.WriteTo(temporary); err != nil {
+		return fmt.Errorf("write temporary configuration: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary configuration: %w", err)
+	}
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("set configuration permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary configuration: %w", err)
+	}
+	// #nosec G703 -- destination is the explicit configuration path chosen by the caller.
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace configuration: %w", err)
+	}
+	removeTemporary = false
+	return nil
+}

--- a/pkg/config/ini.go
+++ b/pkg/config/ini.go
@@ -57,17 +57,21 @@ func RetainINIComments(original []byte, file *ini.File) error {
 	if _, err := file.WriteTo(&rendered); err != nil {
 		return fmt.Errorf("render configuration comments: %w", err)
 	}
-	present := make(map[string]bool)
+	present := make(map[string]int)
 	for _, line := range strings.Split(rendered.String(), "\n") {
-		present[strings.TrimSpace(line)] = true
+		present[strings.TrimSpace(line)]++
 	}
 	for _, line := range strings.Split(string(original), "\n") {
 		line = strings.TrimSpace(line)
-		if (strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")) && !present[line] {
-			section := file.Section(ini.DefaultSection)
-			section.Comment = strings.TrimSpace(section.Comment + "\n" + line)
-			present[line] = true
+		if !strings.HasPrefix(line, ";") && !strings.HasPrefix(line, "#") {
+			continue
 		}
+		if present[line] > 0 {
+			present[line]--
+			continue
+		}
+		section := file.Section(ini.DefaultSection)
+		section.Comment = strings.TrimSpace(section.Comment + "\n" + line)
 	}
 	return nil
 }

--- a/pkg/config/ini_test.go
+++ b/pkg/config/ini_test.go
@@ -73,6 +73,32 @@ func TestUpdateINIRetainsCommentsAndUnknownContent(t *testing.T) {
 	}
 }
 
+func TestUpdateINIRetainsRepeatedComments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.ini")
+	const note = "; shared root note"
+	initial := "[systems]\n" + note + "\ngames_folder = /mnt/old\n" +
+		note + "\ngames_folder = /mnt/second\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Repeated saves must neither lose identical notes nor add more copies.
+	for range 2 {
+		err := UpdateINI(path, func(file *ini.File) error {
+			return SetShadowKeys(file.Section("systems"), "games_folder", []string{"/mnt/new", "/mnt/second"})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count := strings.Count(string(data), note); count != 2 {
+			t.Fatalf("retained %d identical comments, want 2:\n%s", count, data)
+		}
+	}
+}
+
 func TestUpdateINIRepeatedKeysRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "app.ini")
 	if err := os.WriteFile(path, []byte("[systems]\n; roots\ngames_folder = /mnt/old\n"), 0o600); err != nil {

--- a/pkg/config/ini_test.go
+++ b/pkg/config/ini_test.go
@@ -1,0 +1,133 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on paths rooted in t.TempDir.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/ini.v1"
+)
+
+func TestUpdateINIRetainsCommentsAndUnknownContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.ini")
+	initial := "; file note\n[tui]\ntheme = default\n; root notes\ngames_folder = /mnt/old\n" +
+		"; second root notes\ngames_folder = /mnt/second\n\n[custom]\n; keep this comment\nvalue = untouched\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateINI(path, func(file *ini.File) error {
+		section, sectionErr := GetOrCreateSection(file, "tui")
+		if sectionErr != nil {
+			return sectionErr
+		}
+		SetKey(section, "theme", "nord")
+		SetKey(section, "mouse", FormatBool(false))
+		return SetShadowKeys(section, "games_folder", nil)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, expected := range []string{
+		"; file note", "; root notes", "; second root notes", "theme = nord", "mouse = false",
+		"[custom]", "; keep this comment", "value = untouched",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("updated configuration lost %q:\n%s", expected, text)
+		}
+	}
+	if strings.Contains(text, "games_folder") {
+		t.Fatalf("cleared repeated key still present:\n%s", text)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("temporary files left behind: %v", entries)
+	}
+}
+
+func TestUpdateINIRepeatedKeysRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.ini")
+	if err := os.WriteFile(path, []byte("[systems]\n; roots\ngames_folder = /mnt/old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateINI(path, func(file *ini.File) error {
+		section, sectionErr := GetOrCreateSection(file, "systems")
+		if sectionErr != nil {
+			return sectionErr
+		}
+		return SetShadowKeys(section, "games_folder", []string{"/mnt/new", "/mnt/second"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := ini.ShadowLoad(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := loaded.Section("systems").Key("games_folder").ValueWithShadows()
+	if len(values) != 2 || values[0] != "/mnt/new" || values[1] != "/mnt/second" {
+		t.Fatalf("repeated values = %v", values)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "; roots") {
+		t.Fatalf("repeated key note lost:\n%s", data)
+	}
+}
+
+func TestUpdateINIRequiresExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.ini")
+	err := UpdateINI(path, func(*ini.File) error { return nil })
+	if err == nil {
+		t.Fatal("missing configuration accepted")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("missing configuration was created: %v", statErr)
+	}
+}
+
+func TestWriteINIAtomicallyUsesFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.ini")
+	file := ini.Empty()
+	file.Section("tui").Key("theme").SetValue("default")
+	if err := WriteINIAtomically(path, file); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("permissions = %v", info.Mode().Perm())
+	}
+}

--- a/pkg/config/mister.go
+++ b/pkg/config/mister.go
@@ -66,6 +66,12 @@ const (
 // TODO: this can't be hardcoded if we want dynamic arcade folders
 const ArcadeCoresFolder = "/media/fat/_Arcade/cores"
 
+// NamesFile is MiSTer's optional display-name mapping, one "Key: Name" per line.
+const NamesFile = SdFolder + "/names.txt"
+
+// GamesMenuFolder is the stock-menu folder GamesMenu mirrors game libraries into.
+const GamesMenuFolder = SdFolder + "/_Games"
+
 // TODO: not the order mister actually checks, it does games folders second, but this is simpler for checking prefix
 var GamesFolders = []string{
 	"/media/usb0/games",

--- a/pkg/favorites/settings.go
+++ b/pkg/favorites/settings.go
@@ -21,8 +21,6 @@ package favorites
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -107,152 +105,43 @@ func SaveSettings(path string, settings *Settings) error {
 	if err := settings.Validate(); err != nil {
 		return err
 	}
-	data, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
-		return fmt.Errorf("read Favorites configuration for update: %w", err)
-	}
-	file, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true}, data)
-	if err != nil {
-		return fmt.Errorf("load Favorites configuration for update: %w", err)
-	}
-	favoritesSection, err := getOrCreateSection(file, "favorites")
-	if err != nil {
-		return err
-	}
-	setKey(favoritesSection, "default_folder", settings.DefaultFolder)
-	setKey(favoritesSection, "folder_name_contains", strings.Join(settings.FolderNameContains, ","))
-	setKey(favoritesSection, "create_default_folder", formatBool(settings.CreateDefaultFolder))
-	setKey(favoritesSection, "manage_arcade_core_links", formatBool(settings.ManageArcadeCoreLinks))
-	setKey(favoritesSection, "hide_root_files", formatBool(settings.HideRootFiles))
-	setKey(favoritesSection, "external_folder", settings.ExternalFolder)
-	setKey(favoritesSection, "core_prefix", settings.CorePrefix)
-	if shadowErr := setShadowKeys(favoritesSection, "games_folder", settings.GamesFolders); shadowErr != nil {
-		return shadowErr
-	}
-
-	coresSection, err := getOrCreateSection(file, "cores")
-	if err != nil {
-		return err
-	}
-	setKey(coresSection, "all", settings.AlternateCore)
-
-	tuiSection, err := getOrCreateSection(file, "tui")
-	if err != nil {
-		return err
-	}
-	setKey(tuiSection, "theme", settings.Theme)
-	setKey(tuiSection, "mouse", formatBool(settings.Mouse))
-	setKey(tuiSection, "crt_mode", formatBool(settings.CRTMode))
-	setKey(tuiSection, "on_screen_keyboard", formatBool(settings.OnScreenKeyboard))
-
-	if err := retainINIComments(data, file); err != nil {
-		return err
-	}
-	return writeINIAtomically(path, file)
-}
-
-// The INI parser replaces attached comments when loading shadow keys. Keep
-// otherwise lost full-line notes as file comments, even when a key is removed.
-func retainINIComments(original []byte, file *ini.File) error {
-	var rendered strings.Builder
-	if _, err := file.WriteTo(&rendered); err != nil {
-		return fmt.Errorf("render Favorites configuration comments: %w", err)
-	}
-	present := make(map[string]bool)
-	for _, line := range strings.Split(rendered.String(), "\n") {
-		present[strings.TrimSpace(line)] = true
-	}
-	for _, line := range strings.Split(string(original), "\n") {
-		line = strings.TrimSpace(line)
-		if (strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")) && !present[line] {
-			section := file.Section(ini.DefaultSection)
-			section.Comment = strings.TrimSpace(section.Comment + "\n" + line)
-			present[line] = true
+	err := config.UpdateINI(path, func(file *ini.File) error {
+		favoritesSection, sectionErr := config.GetOrCreateSection(file, "favorites")
+		if sectionErr != nil {
+			return fmt.Errorf("get favorites section: %w", sectionErr)
 		}
-	}
-	return nil
-}
-
-func getOrCreateSection(file *ini.File, name string) (*ini.Section, error) {
-	section, err := file.GetSection(name)
-	if err == nil {
-		return section, nil
-	}
-	section, err = file.NewSection(name)
-	if err != nil {
-		return nil, fmt.Errorf("create %s configuration section: %w", name, err)
-	}
-	return section, nil
-}
-
-func setKey(section *ini.Section, name, value string) {
-	section.Key(name).SetValue(value)
-}
-
-func setShadowKeys(section *ini.Section, name string, values []string) error {
-	comment := ""
-	if existing, err := section.GetKey(name); err == nil {
-		comment = existing.Comment
-	}
-	section.DeleteKey(name)
-	if len(values) == 0 {
-		// Keep notes on cleared roots without leaving an active empty key.
-		if comment != "" {
-			section.Comment = strings.TrimSpace(section.Comment + "\n" + comment)
+		config.SetKey(favoritesSection, "default_folder", settings.DefaultFolder)
+		config.SetKey(favoritesSection, "folder_name_contains", strings.Join(settings.FolderNameContains, ","))
+		config.SetKey(favoritesSection, "create_default_folder", config.FormatBool(settings.CreateDefaultFolder))
+		config.SetKey(favoritesSection, "manage_arcade_core_links", config.FormatBool(settings.ManageArcadeCoreLinks))
+		config.SetKey(favoritesSection, "hide_root_files", config.FormatBool(settings.HideRootFiles))
+		config.SetKey(favoritesSection, "external_folder", settings.ExternalFolder)
+		config.SetKey(favoritesSection, "core_prefix", settings.CorePrefix)
+		if shadowErr := config.SetShadowKeys(
+			favoritesSection, "games_folder", settings.GamesFolders,
+		); shadowErr != nil {
+			return fmt.Errorf("set games folders: %w", shadowErr)
 		}
+
+		coresSection, sectionErr := config.GetOrCreateSection(file, "cores")
+		if sectionErr != nil {
+			return fmt.Errorf("get cores section: %w", sectionErr)
+		}
+		config.SetKey(coresSection, "all", settings.AlternateCore)
+
+		tuiSection, sectionErr := config.GetOrCreateSection(file, "tui")
+		if sectionErr != nil {
+			return fmt.Errorf("get TUI section: %w", sectionErr)
+		}
+		config.SetKey(tuiSection, "theme", settings.Theme)
+		config.SetKey(tuiSection, "mouse", config.FormatBool(settings.Mouse))
+		config.SetKey(tuiSection, "crt_mode", config.FormatBool(settings.CRTMode))
+		config.SetKey(tuiSection, "on_screen_keyboard", config.FormatBool(settings.OnScreenKeyboard))
 		return nil
-	}
-	key, err := section.NewKey(name, values[0])
+	})
 	if err != nil {
-		return fmt.Errorf("create %s setting: %w", name, err)
+		return fmt.Errorf("save Favorites settings: %w", err)
 	}
-	key.Comment = comment
-	for _, value := range values[1:] {
-		if err := key.AddShadow(value); err != nil {
-			return fmt.Errorf("add %s setting: %w", name, err)
-		}
-	}
-	return nil
-}
-
-func formatBool(value bool) string {
-	if value {
-		return "true"
-	}
-	return "false"
-}
-
-func writeINIAtomically(path string, file *ini.File) error {
-	directory := filepath.Dir(path)
-	temporary, err := os.CreateTemp(directory, ".favorites-*.ini")
-	if err != nil {
-		return fmt.Errorf("create temporary Favorites configuration: %w", err)
-	}
-	temporaryPath := temporary.Name()
-	removeTemporary := true
-	defer func() {
-		_ = temporary.Close()
-		if removeTemporary {
-			_ = os.Remove(temporaryPath)
-		}
-	}()
-	if _, err := file.WriteTo(temporary); err != nil {
-		return fmt.Errorf("write temporary Favorites configuration: %w", err)
-	}
-	if err := temporary.Sync(); err != nil {
-		return fmt.Errorf("sync temporary Favorites configuration: %w", err)
-	}
-	if err := temporary.Chmod(0o644); err != nil {
-		return fmt.Errorf("set Favorites configuration permissions: %w", err)
-	}
-	if err := temporary.Close(); err != nil {
-		return fmt.Errorf("close temporary Favorites configuration: %w", err)
-	}
-	// #nosec G703 -- destination is the explicit Favorites configuration path.
-	if err := os.Rename(temporaryPath, filepath.Clean(path)); err != nil {
-		return fmt.Errorf("replace Favorites configuration: %w", err)
-	}
-	removeTemporary = false
 	return nil
 }
 

--- a/pkg/gamesmenu/cleanup.go
+++ b/pkg/gamesmenu/cleanup.go
@@ -1,0 +1,234 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/utils"
+)
+
+type CleanupProgress struct{ Checked, Removed int }
+
+type CleanupResult struct {
+	Errors                                      []error
+	Checked, Removed, Unreadable, PrunedFolders int
+	ErrorsDropped                               int
+}
+
+func (r *CleanupResult) unreadable(err error) {
+	r.Unreadable++
+	if len(r.Errors) < 10 {
+		r.Errors = append(r.Errors, err)
+	} else {
+		r.ErrorsDropped++
+	}
+}
+
+type zipContents struct {
+	members map[string]bool
+	err     error
+}
+
+// CleanUp removes only proven missing targets. Unknown paths, inaccessible
+// files and invalid archives remain untouched. System folders encode toggle
+// state and are never pruned. Symlinks in the menu are never traversed.
+func (m *Manager) CleanUp(progress func(CleanupProgress)) (CleanupResult, error) {
+	var result CleanupResult
+	root, menu, err := m.openSD()
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = root.Close() }()
+	info, err := root.Lstat(menu)
+	if errors.Is(err, fs.ErrNotExist) {
+		return result, nil
+	}
+	if err != nil {
+		return result, fmt.Errorf("stat Games menu: %w", err)
+	}
+	if !info.IsDir() {
+		return result, errors.New("games menu is not a regular directory")
+	}
+	archives := make(map[string]zipContents)
+	var dirs []string
+	err = fs.WalkDir(root.FS(), menu, func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			result.unreadable(fmt.Errorf("read menu path %s: %w", name, walkErr))
+			return nil
+		}
+		if entry.IsDir() {
+			if name != menu && path.Dir(name) != menu {
+				dirs = append(dirs, name)
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() || !strings.EqualFold(path.Ext(name), ".mgl") {
+			return nil
+		}
+		result.Checked++
+		missing, checkErr := checkShortcut(root, name, archives)
+		if checkErr != nil {
+			result.unreadable(fmt.Errorf("check shortcut %s: %w", name, checkErr))
+		} else if missing {
+			if removeErr := root.Remove(name); removeErr != nil {
+				result.unreadable(fmt.Errorf("remove shortcut %s: %w", name, removeErr))
+			} else {
+				result.Removed++
+			}
+		}
+		if progress != nil {
+			progress(CleanupProgress{Checked: result.Checked, Removed: result.Removed})
+		}
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("walk Games menu: %w", err)
+	}
+	for index := len(dirs) - 1; index >= 0; index-- {
+		children, readErr := fs.ReadDir(root.FS(), dirs[index])
+		if readErr != nil {
+			result.unreadable(fmt.Errorf("read menu folder %s: %w", dirs[index], readErr))
+			continue
+		}
+		if len(children) != 0 {
+			continue
+		}
+		if removeErr := root.Remove(dirs[index]); removeErr != nil {
+			result.unreadable(fmt.Errorf("prune menu folder %s: %w", dirs[index], removeErr))
+		} else {
+			result.PrunedFolders++
+		}
+	}
+	return result, nil
+}
+
+func checkShortcut(root *os.Root, name string, archives map[string]zipContents) (bool, error) {
+	data, err := root.ReadFile(name)
+	if err != nil {
+		return false, fmt.Errorf("read MGL: %w", err)
+	}
+	// ReadMGL only returns the first file; cleanup must validate every target.
+	// Strict=false preserves the Python writer's legacy raw ampersands.
+	type mglFile struct {
+		Path string `xml:"path,attr"`
+	}
+	var mgl struct {
+		XMLName xml.Name  `xml:"mistergamedescription"`
+		Files   []mglFile `xml:"file"`
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.Strict = false
+	if err := decoder.Decode(&mgl); err != nil {
+		return false, fmt.Errorf("decode MGL: %w", err)
+	}
+	for {
+		token, tokenErr := decoder.Token()
+		if errors.Is(tokenErr, io.EOF) {
+			break
+		}
+		if tokenErr != nil {
+			return false, fmt.Errorf("decode MGL ending: %w", tokenErr)
+		}
+		switch value := token.(type) {
+		case xml.Comment, xml.ProcInst:
+		case xml.CharData:
+			if strings.TrimSpace(string(value)) != "" {
+				return false, errors.New("unexpected text after MGL")
+			}
+		default:
+			return false, errors.New("unexpected content after MGL")
+		}
+	}
+	missing := false
+	for _, file := range mgl.Files {
+		if file.Path == "" {
+			return false, errors.New("MGL file has no target")
+		}
+		target := file.Path
+		const prefix = "../../../../.."
+		if strings.HasPrefix(target, prefix+"/") {
+			target = strings.TrimPrefix(target, prefix)
+		}
+		if !filepath.IsAbs(target) {
+			return false, fmt.Errorf("ambiguous MGL target: %q", file.Path)
+		}
+		absent, err := missingTarget(target, archives)
+		if err != nil {
+			return false, err
+		}
+		missing = missing || absent
+	}
+	return missing, nil
+}
+
+func missingTarget(target string, archives map[string]zipContents) (bool, error) {
+	if index := strings.Index(strings.ToLower(target), ".zip/"); index >= 0 {
+		archive, member := target[:index+4], target[index+5:]
+		if filepath.Clean(archive) != archive || !validZIPMember(member) {
+			return false, fmt.Errorf("ambiguous ZIP target: %q", target)
+		}
+		contents, ok := archives[archive]
+		if !ok {
+			info, err := os.Stat(archive)
+			if errors.Is(err, fs.ErrNotExist) {
+				return true, nil
+			}
+			if err != nil {
+				return false, fmt.Errorf("stat archive: %w", err)
+			}
+			if !info.Mode().IsRegular() {
+				return false, fmt.Errorf("archive is not a regular file: %s", archive)
+			}
+			names, err := utils.ListZip(archive)
+			contents = zipContents{members: make(map[string]bool, len(names)), err: err}
+			for _, name := range names {
+				contents.members[name] = true
+			}
+			archives[archive] = contents
+		}
+		if contents.err != nil {
+			return false, fmt.Errorf("read archive: %w", contents.err)
+		}
+		return !contents.members[member], nil
+	}
+	// Only ZIP member keys may contain harmless noncanonical components.
+	// Ordinary filesystem targets must stay unambiguous before deletion.
+	if filepath.Clean(target) != target {
+		return false, fmt.Errorf("ambiguous MGL target: %q", target)
+	}
+	_, err := os.Stat(target)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat target: %w", err)
+	}
+	return false, nil
+}

--- a/pkg/gamesmenu/cleanup_test.go
+++ b/pkg/gamesmenu/cleanup_test.go
@@ -1,0 +1,138 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package gamesmenu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+)
+
+func TestCleanUpLegacyGeneratedZipAndUnknownTargets(t *testing.T) {
+	m := fixture(t)
+	folder := filepath.Join(m.paths.SDRoot, "games", "NES")
+	game := filepath.Join(folder, "valid & game.nes")
+	put(t, game, "")
+	createZip(t, filepath.Join(folder, "set.zip"), "valid.nes")
+	put(t, filepath.Join(folder, "corrupt.zip"), "invalid zip")
+	generate(t, m, discover(t, m))
+	output := filepath.Join(m.paths.MenuFolder, "_NES")
+	legacy := func(name, target string) {
+		put(t, filepath.Join(output, name+".mgl"),
+			`<mistergamedescription><rbf>_Console/NES</rbf><file path="`+target+`"/></mistergamedescription>`)
+	}
+	legacy("legacy valid", game)
+	legacy("legacy missing", filepath.Join(folder, "gone & game.nes"))
+	legacy("zip missing", filepath.Join(folder, "set.zip", "gone.nes"))
+	legacy("archive missing", filepath.Join(folder, "absent.zip", "game.nes"))
+	legacy("corrupt archive", filepath.Join(folder, "corrupt.zip", "game.nes"))
+	legacy("relative", "games/NES/missing.nes")
+	legacy("empty target", "")
+	put(t, filepath.Join(output, "trailing.mgl"), `<mistergamedescription><file path="`+
+		folder+`/gone.nes"/></mistergamedescription>garbage`)
+	put(t, filepath.Join(output, "core.mgl"), `<mistergamedescription><rbf>_Console/NES</rbf></mistergamedescription>`)
+	put(t, filepath.Join(output, "malformed.mgl"), `<mistergamedescription><file`)
+	put(t, filepath.Join(output, "wrong-root.mgl"), `<other><file path="`+folder+`/gone.nes"/></other>`)
+	// If any target is ambiguous, never delete a multi-file custom launcher.
+	put(t, filepath.Join(output, "multi.mgl"), `<mistergamedescription><file path="`+folder+
+		`/gone.nes"/><file path="relative.nes"/></mistergamedescription>`)
+	entries := discover(t, m)
+	system := matchSystem(extensionRules(entries[0].Systems), "deleted.nes")
+	data, err := mister.GenerateMgl(m.cfg, system, filepath.Join(folder, "deleted.nes"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	put(t, filepath.Join(output, "_empty", "_nested", "generated.mgl"), data)
+	// Do not follow menu symlinks or remove content outside _Games.
+	outside := t.TempDir()
+	put(t, filepath.Join(outside, "keep.mgl"), data)
+	if linkErr := os.Symlink(outside, filepath.Join(output, "link")); linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	var last CleanupProgress
+	result, err := m.CleanUp(func(p CleanupProgress) { last = p })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 4 || result.PrunedFolders != 2 || result.Unreadable != 7 {
+		t.Fatalf("result: %+v", result)
+	}
+	if last.Checked != result.Checked || last.Removed != result.Removed {
+		t.Fatalf("progress: %+v, result: %+v", last, result)
+	}
+	retained := []string{
+		"valid & game", "valid", "legacy valid", "corrupt archive", "relative",
+		"core", "malformed", "wrong-root", "multi", "empty target", "trailing",
+	}
+	for _, name := range retained {
+		if _, err := os.Stat(filepath.Join(output, name+".mgl")); err != nil {
+			t.Errorf("retained %s: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(outside, "keep.mgl")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(output); err != nil {
+		t.Fatal("system folder pruned:", err)
+	}
+}
+
+func TestCleanUpKeepsAmbiguousPathsBeforeCheckingExistence(t *testing.T) {
+	m := fixture(t)
+	folder := filepath.Join(m.paths.SDRoot, "games", "NES")
+	targets := []string{
+		folder + "/missing.zip/../game.nes",
+		folder + "/missing.zip/dir/../game.nes",
+		folder + "/missing.zip//absolute.nes",
+		folder + `/missing.zip/dir\game.nes`,
+		folder + "/./missing.zip/game.nes",
+		folder + "/./missing.nes",
+	}
+	for index, target := range targets {
+		put(t, filepath.Join(m.paths.MenuFolder, "_NES", fmt.Sprintf("keep%d.mgl", index)),
+			`<mistergamedescription><file path="`+target+`"/></mistergamedescription>`)
+	}
+	result, err := m.CleanUp(nil)
+	if err != nil || result.Checked != len(targets) || result.Removed != 0 || result.Unreadable != len(targets) {
+		t.Fatalf("ambiguous shortcuts not retained: %+v, %v", result, err)
+	}
+}
+
+func TestCleanUpStatErrorsAreNotMissing(t *testing.T) {
+	m := fixture(t)
+	put(t, filepath.Join(m.paths.SDRoot, "not-directory"), "")
+	output := filepath.Join(m.paths.MenuFolder, "_NES", "keep.mgl")
+	put(t, output, `<mistergamedescription><file path="`+m.paths.SDRoot+
+		`/not-directory/game.nes"/></mistergamedescription>`)
+	result, err := m.CleanUp(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 0 || result.Unreadable != 1 {
+		t.Fatalf("result: %+v", result)
+	}
+	if _, err := os.Stat(output); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/gamesmenu/config.go
+++ b/pkg/gamesmenu/config.go
@@ -1,0 +1,93 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+// DefaultConfigFile is written beside the binary on the first interactive run
+// when no gamesmenu.ini exists. The Python script had no configuration file,
+// so every key here is optional and only affects the TUI or extra game roots.
+const DefaultConfigFile = `[tui]
+theme = default
+mouse = true
+crt_mode = true
+
+[systems]
+; Add custom game roots by repeating this key. Built-in MiSTer roots remain enabled.
+; games_folder = /media/network
+`
+
+func DefaultUserConfig() *config.UserConfig {
+	return &config.UserConfig{
+		TUI: config.TUIConfig{
+			Theme:   "default",
+			Mouse:   true,
+			CRTMode: true,
+		},
+	}
+}
+
+func LoadConfig() (*config.UserConfig, error) {
+	cfg, err := config.LoadUserConfig("gamesmenu", DefaultUserConfig())
+	return validateLoadedConfig(cfg, err)
+}
+
+func LoadConfigAt(iniPath, appPath string) (*config.UserConfig, error) {
+	cfg, err := config.LoadUserConfigAt(iniPath, appPath, DefaultUserConfig())
+	return validateLoadedConfig(cfg, err)
+}
+
+func validateLoadedConfig(cfg *config.UserConfig, err error) (*config.UserConfig, error) {
+	if err != nil {
+		return nil, fmt.Errorf("load user configuration: %w", err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// EnsureConfigFile creates the commented default configuration when missing
+// and never touches an existing file.
+func EnsureConfigFile(cfg *config.UserConfig) error {
+	if cfg == nil {
+		return errors.New("no Games Menu configuration supplied")
+	}
+	if err := config.EnsureUserConfig(cfg.IniPath, DefaultConfigFile); err != nil {
+		return fmt.Errorf("ensure Games Menu configuration: %w", err)
+	}
+	return nil
+}
+
+func ValidateConfig(cfg *config.UserConfig) error {
+	if cfg == nil {
+		return errors.New("no Games Menu configuration supplied")
+	}
+	if _, ok := tui.AvailableThemes[cfg.TUI.Theme]; !ok {
+		return fmt.Errorf("unknown tui.theme value: %s", cfg.TUI.Theme)
+	}
+	return nil
+}

--- a/pkg/gamesmenu/discover.go
+++ b/pkg/gamesmenu/discover.go
@@ -1,0 +1,180 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+// Entry is one games folder offered on the main screen. The Python script
+// keyed everything by games folder name, and so does this: Key is the catalog
+// spelling of the folder, Display its names.txt replacement, and MenuFolder
+// the _Games subfolder that receives its shortcuts.
+//
+//nolint:govet // Field order groups identity, filesystem locations and state.
+type Entry struct {
+	Key        string
+	Display    string
+	MenuFolder string
+	Systems    []games.System
+	Paths      []string
+	Existing   bool
+	Selected   bool
+}
+
+// Discover lists every catalog games folder that exists under a games root,
+// in the roots' priority order. MenuFolder reuses the spelling of a matching
+// _Games subfolder when one exists, compared case-insensitively, so existing
+// installations keep their folders. Entries are selected when their folder
+// exists, or when there is no _Games folder at all.
+func (m *Manager) Discover() ([]Entry, error) {
+	existing, err := m.menuFolders()
+	if err != nil {
+		return nil, err
+	}
+	menuExists := existing != nil
+	roots := m.resolvedRoots()
+
+	var entries []Entry
+	for _, folder := range menuSystems() {
+		paths := folderPaths(roots, folder.Key)
+		if len(paths) == 0 {
+			continue
+		}
+		entry := Entry{
+			Key:        folder.Key,
+			Display:    m.names.Replace(folder.Key),
+			MenuFolder: m.names.FolderName(folder.Key),
+			Systems:    folder.Systems,
+			Paths:      paths,
+		}
+		if name, ok := existing[strings.ToLower(entry.MenuFolder)]; ok {
+			entry.MenuFolder = name
+			entry.Existing = true
+		}
+		entry.Selected = entry.Existing || !menuExists
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+type gamesRoot struct {
+	entries map[string]string
+	path    string
+}
+
+// resolvedRoots lists the games roots that exist, each with a case-insensitive
+// index of its children, so every system folder costs one lookup instead of a
+// directory read per system.
+func (m *Manager) resolvedRoots() []gamesRoot {
+	var roots []gamesRoot
+	folders := games.GetGamesFolders(m.cfg)
+	// Relocated managers never probe the device's built-in roots. Explicit
+	// configured roots still work, including external fixture libraries.
+	if filepath.Clean(m.paths.SDRoot) != config.SdFolder {
+		folders = folders[:len(folders)-len(config.GamesFolders)]
+	}
+	for _, root := range folders {
+		path, err := games.FindFile(root)
+		if err != nil {
+			continue
+		}
+		children, err := os.ReadDir(path)
+		if err != nil {
+			continue
+		}
+		index := make(map[string]string, len(children))
+		for _, child := range children {
+			lower := strings.ToLower(child.Name())
+			if _, ok := index[lower]; !ok {
+				index[lower] = child.Name()
+			}
+		}
+		roots = append(roots, gamesRoot{path: path, entries: index})
+	}
+	return roots
+}
+
+func folderPaths(roots []gamesRoot, key string) []string {
+	var paths []string
+	seen := make(map[string]struct{})
+	lower := strings.ToLower(key)
+	for _, root := range roots {
+		name, ok := root.entries[lower]
+		if !ok {
+			continue
+		}
+		path := filepath.Join(root.path, name)
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		clean := filepath.Clean(path)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	return paths
+}
+
+// menuFolders indexes the directories directly under _Games by lower-cased
+// name. It returns a nil map when _Games does not exist.
+func (m *Manager) menuFolders() (map[string]string, error) {
+	children, err := os.ReadDir(m.paths.MenuFolder)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil //nolint:nilnil // A nil index distinguishes an absent menu from an empty one.
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read Games menu folder: %w", err)
+	}
+	folders := make(map[string]string, len(children))
+	for _, child := range children {
+		if !isDirectory(m.paths.MenuFolder, child) {
+			continue
+		}
+		lower := strings.ToLower(child.Name())
+		if _, ok := folders[lower]; !ok {
+			folders[lower] = child.Name()
+		}
+	}
+	return folders, nil
+}
+
+// isDirectory follows symlinks the way the Python script's os.path.isdir did.
+func isDirectory(parent string, entry fs.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+	if entry.Type()&fs.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(parent, entry.Name()))
+	return err == nil && info.IsDir()
+}

--- a/pkg/gamesmenu/gamesmenu_test.go
+++ b/pkg/gamesmenu/gamesmenu_test.go
@@ -1,0 +1,389 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package gamesmenu
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+)
+
+func fixture(t *testing.T) *Manager {
+	t.Helper()
+	root := t.TempDir()
+	cfg := DefaultUserConfig()
+	cfg.Systems.GamesFolder = []string{root}
+	manager, err := NewManagerWithPaths(cfg, RootedPaths(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manager
+}
+
+func put(t *testing.T, filename, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func read(t *testing.T, filename string) string {
+	t.Helper()
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func createZip(t *testing.T, filename string, members ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for _, member := range members {
+		output, err := writer.Create(member)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := output.Write([]byte("game")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func discover(t *testing.T, manager *Manager) []Entry {
+	t.Helper()
+	entries, err := manager.Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+func generate(t *testing.T, manager *Manager, entries []Entry) GenerateResult {
+	t.Helper()
+	result, err := manager.Generate(entries, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Scan.Failed != 0 {
+		t.Fatalf("scan errors: %v", result.Scan.Errors)
+	}
+	return result
+}
+
+func TestDiscoverKeysRootsCaseAndSelection(t *testing.T) {
+	m := fixture(t)
+	root := m.paths.SDRoot
+	external := filepath.Join(root, "external")
+	m.cfg.Systems.GamesFolder = append(m.cfg.Systems.GamesFolder, root, external)
+	put(t, filepath.Join(root, "games", "SNES", "a.sfc"), "")
+	put(t, filepath.Join(root, "SNES", "b.sfc"), "")
+	put(t, filepath.Join(external, "games", "SNES", "c.sfc"), "")
+	put(t, filepath.Join(root, "games", "atari2600", "a.a26"), "")
+	put(t, filepath.Join(root, "games", "NeoGeo", "a.neo"), "")
+	entries := discover(t, m)
+	if len(entries) != 3 {
+		t.Fatalf("entries: %+v", entries)
+	}
+	for _, entry := range entries {
+		if !entry.Selected {
+			t.Fatalf("missing menu should select %s", entry.Key)
+		}
+	}
+	put(t, filepath.Join(m.paths.MenuFolder, "_NeoGeo", "keep.mgl"), "custom")
+	put(t, filepath.Join(m.paths.MenuFolder, "_ATARI2600", "keep.mgl"), "custom")
+	entries = discover(t, m)
+	if entries[0].MenuFolder != "_ATARI2600" || !entries[0].Selected ||
+		entries[1].MenuFolder != "_NeoGeo" || !entries[1].Selected || entries[2].Selected {
+		t.Fatalf("case/selection: %+v", entries)
+	}
+	want := []string{
+		filepath.Join(root, "games", "SNES"), filepath.Join(root, "SNES"), filepath.Join(external, "games", "SNES"),
+	}
+	if !reflect.DeepEqual(entries[2].Paths, want) {
+		t.Fatalf("paths %v, want %v", entries[2].Paths, want)
+	}
+}
+
+func TestGenerateSharedFolderAndNeverOverwrite(t *testing.T) {
+	m := fixture(t)
+	folder := filepath.Join(m.paths.SDRoot, "games", "GAMEBOY")
+	for _, name := range []string{"Mario & Luigi.gb", "color.gbc", "duck.bin"} {
+		put(t, filepath.Join(folder, name), "")
+	}
+	entries := discover(t, m)
+	result := generate(t, m, entries)
+	if result.Scan.Created != 3 {
+		t.Fatalf("result: %+v", result)
+	}
+	output := filepath.Join(m.paths.MenuFolder, "_GAMEBOY")
+	checks := []struct{ name, fragment string }{
+		{"Mario & Luigi", "<rbf>_Console/Gameboy</rbf>"},
+		{"color", "<setname>GBC</setname>"},
+		{"duck", `index="1"`},
+	}
+	for _, check := range checks {
+		data := read(t, filepath.Join(output, check.name+".mgl"))
+		if !strings.Contains(data, check.fragment) || !strings.Contains(data, "../../../../..") {
+			t.Errorf("MGL: %s", data)
+		}
+	}
+	if !strings.Contains(read(t, filepath.Join(output, "Mario & Luigi.mgl")), "&amp;") {
+		t.Fatal("path not XML escaped")
+	}
+	custom := filepath.Join(output, "color.mgl")
+	put(t, custom, "custom bytes")
+	result = generate(t, m, entries)
+	if result.Scan.Created != 0 || result.Scan.Skipped != 3 || read(t, custom) != "custom bytes" {
+		t.Fatalf("overwrite: %+v", result)
+	}
+}
+
+func TestGenerateZipFlatteningNamesDotfilesAndOverride(t *testing.T) {
+	m := fixture(t)
+	put(t, m.paths.NamesFile, "NES:Famicom/Disk\ndir:Renamed\n")
+	var err error
+	m.names, err = LoadNames(m.paths.NamesFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.cfg.Systems.SetCore = []string{"NES:_Console/Custom"}
+	packs := filepath.Join(m.paths.SDRoot, "games", "NES", "Packs")
+	createZip(t, filepath.Join(packs, "a.zip"),
+		"dir/sub/game.nes", "top.nes", "readme.txt", ".hidden.nes", "dir/.hidden/game.nes")
+	createZip(t, filepath.Join(packs, "b.zip"), "top.nes")
+	put(t, filepath.Join(packs, "invalid.zip"), "not zip")
+	put(t, filepath.Join(packs, ".hidden.nes"), "")
+	put(t, filepath.Join(packs, ".folder", "game.nes"), "")
+	result := generate(t, m, discover(t, m))
+	if result.Scan.Created != 2 || result.Scan.Skipped != 1 {
+		t.Fatalf("result: %+v", result)
+	}
+	output := filepath.Join(m.paths.MenuFolder, "_Famicom & Disk", "_Packs")
+	data := read(t, filepath.Join(output, "_Renamed", "_sub", "game.mgl"))
+	if !strings.Contains(data, "<rbf>_Console/Custom</rbf>") || !strings.Contains(data, "a.zip/dir/sub/game.nes") {
+		t.Fatalf("MGL: %s", data)
+	}
+}
+
+func TestGenerateProcessesFilesBeforeSubfolders(t *testing.T) {
+	m := fixture(t)
+	folder := filepath.Join(m.paths.SDRoot, "games", "NES")
+	put(t, filepath.Join(folder, "A", "game.nes"), "loose game")
+	createZip(t, filepath.Join(folder, "z.zip"), "A/game.nes")
+	entries := discover(t, m)
+	result := generate(t, m, entries)
+	if result.Scan.Created != 1 || result.Scan.Skipped != 1 {
+		t.Fatalf("result: %+v", result)
+	}
+	shortcut := filepath.Join(m.paths.MenuFolder, "_NES", "_A", "game.mgl")
+	data := read(t, shortcut)
+	if !strings.Contains(data, "z.zip/A/game.nes") {
+		t.Fatalf("Python processes the parent ZIP before the loose subfolder game: %s", data)
+	}
+	result = generate(t, m, entries)
+	if result.Scan.Created != 0 || result.Scan.Skipped != 2 || read(t, shortcut) != data {
+		t.Fatalf("regeneration changed the collision winner: %+v", result)
+	}
+}
+
+func TestGenerateNoncanonicalZIPMembersAndCleanup(t *testing.T) {
+	m := fixture(t)
+	archive := filepath.Join(m.paths.SDRoot, "games", "NES", "Packs", "set.zip")
+	createZip(t, archive, "./game.nes", "Folder//second.nes", "Folder/./third.nes", "Folder//Sub/fourth.nes",
+		"./.hidden.nes", "Folder/./.hidden/game.nes")
+	result := generate(t, m, discover(t, m))
+	if result.Scan.Created != 4 {
+		t.Fatalf("result: %+v", result)
+	}
+	// Python prefixes literal dot and interior empty components before joining
+	// output paths. Preserve those menu folders and the exact ZIP member keys.
+	checks := []struct{ output, member string }{
+		{"_./game.mgl", "./game.nes"},
+		{"_Folder/second.mgl", "Folder//second.nes"},
+		{"_Folder/_./third.mgl", "Folder/./third.nes"},
+		{"_Folder/_/_Sub/fourth.mgl", "Folder//Sub/fourth.nes"},
+	}
+	for _, check := range checks {
+		data := read(t, filepath.Join(m.paths.MenuFolder, "_NES", "_Packs", check.output))
+		if !strings.Contains(data, archive+"/"+check.member) {
+			t.Fatalf("ZIP member identity changed: %s", data)
+		}
+	}
+	cleanup, err := m.CleanUp(nil)
+	if err != nil || cleanup.Checked != 4 || cleanup.Removed != 0 || cleanup.Unreadable != 0 {
+		t.Fatalf("valid members not recognized: %+v, %v", cleanup, err)
+	}
+	createZip(t, archive, "./game.nes")
+	cleanup, err = m.CleanUp(nil)
+	if err != nil || cleanup.Removed != 3 || cleanup.Unreadable != 0 {
+		t.Fatalf("missing members not removed: %+v, %v", cleanup, err)
+	}
+	if _, err := os.Stat(filepath.Join(m.paths.MenuFolder, "_NES", "_Packs", "_.", "game.mgl")); err != nil {
+		t.Fatal("cleanup removed retained dot-prefixed member:", err)
+	}
+}
+
+func TestGenerateDeselectedRemovalAndRemoveAll(t *testing.T) {
+	m := fixture(t)
+	put(t, filepath.Join(m.paths.SDRoot, "games", "GBA", "game.gba"), "")
+	put(t, filepath.Join(m.paths.MenuFolder, "_gba", "keep.mgl"), "keep")
+	put(t, filepath.Join(m.paths.MenuFolder, "_NES", "old.mgl"), "old")
+	put(t, filepath.Join(m.paths.MenuFolder, "User Folder", "note"), "old")
+	put(t, filepath.Join(m.paths.MenuFolder, "notes.txt"), "keep")
+	result := generate(t, m, discover(t, m))
+	if len(result.Removed) != 2 {
+		t.Fatalf("removed: %v", result.Removed)
+	}
+	if read(t, filepath.Join(m.paths.MenuFolder, "_gba", "keep.mgl")) != "keep" ||
+		read(t, filepath.Join(m.paths.MenuFolder, "notes.txt")) != "keep" {
+		t.Fatal("lost retained content")
+	}
+	if err := m.RemoveAll(); err != nil {
+		t.Fatal(err)
+	}
+	if m.MenuExists() {
+		t.Fatal("menu remains")
+	}
+}
+
+func TestGenerateFollowsSymlinkedFoldersOnce(t *testing.T) {
+	m := fixture(t)
+	library := filepath.Join(m.paths.SDRoot, "library")
+	put(t, filepath.Join(library, "game.sfc"), "")
+	if err := os.MkdirAll(filepath.Join(m.paths.SDRoot, "games"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(library, filepath.Join(m.paths.SDRoot, "games", "SNES")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(library, filepath.Join(library, "loop")); err != nil {
+		t.Fatal(err)
+	}
+	result := generate(t, m, discover(t, m))
+	if result.Scan.Created != 1 {
+		t.Fatalf("result: %+v", result)
+	}
+}
+
+func TestGenerateRejectsZipTraversalAndOutputSymlink(t *testing.T) {
+	m := fixture(t)
+	createZip(t, filepath.Join(m.paths.SDRoot, "games", "NES", "games.zip"),
+		"../escape.nes", "/absolute.nes", "inside/../escape2.nes", ".././escape3.nes", `inside\escape4.nes`, "safe.nes")
+	result, err := m.Generate(discover(t, m), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Scan.Failed != 5 || result.Scan.Created != 1 {
+		t.Fatalf("result: %+v", result)
+	}
+	outside := t.TempDir()
+	if removeErr := os.RemoveAll(filepath.Join(m.paths.MenuFolder, "_NES")); removeErr != nil {
+		t.Fatal(removeErr)
+	}
+	if linkErr := os.Symlink(outside, filepath.Join(m.paths.MenuFolder, "_NES")); linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	result, err = m.Generate(discover(t, m), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Scan.Failed == 0 {
+		t.Fatal("escaped output root")
+	}
+	children, err := os.ReadDir(outside)
+	if err != nil || len(children) != 0 {
+		t.Fatalf("outside files: %v, %v", children, err)
+	}
+}
+
+func TestGenerateConcurrentNeverOverwrites(t *testing.T) {
+	m := fixture(t)
+	put(t, filepath.Join(m.paths.SDRoot, "games", "NES", "game.nes"), "")
+	entries := discover(t, m)
+	var wg sync.WaitGroup
+	results := make(chan GenerateResult, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Go(func() { result, err := m.Generate(entries, nil); results <- result; errs <- err })
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	created, skipped := 0, 0
+	for result := range results {
+		if result.Scan.Failed != 0 {
+			t.Fatal(result.Scan.Errors)
+		}
+		created += result.Scan.Created
+		skipped += result.Scan.Skipped
+	}
+	if created != 1 || skipped != 1 {
+		t.Fatalf("created=%d skipped=%d", created, skipped)
+	}
+	if _, err := mister.ReadMGL(filepath.Join(m.paths.MenuFolder, "_NES", "game.mgl")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateProgress(t *testing.T) {
+	m := fixture(t)
+	for _, system := range []string{"NES", "SNES", "GBA"} {
+		put(t, filepath.Join(m.paths.SDRoot, "games", system, "readme.txt"), "")
+	}
+	var percentages []int
+	_, err := m.Generate(discover(t, m), func(p Progress) {
+		percentages = append(percentages, (p.Index*100+p.Total-1)/p.Total)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(percentages, []int{0, 34, 67, 100}) {
+		t.Fatalf("progress: %v", percentages)
+	}
+}

--- a/pkg/gamesmenu/generate.go
+++ b/pkg/gamesmenu/generate.go
@@ -1,0 +1,358 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+	"github.com/wizzomafizzo/mrext/pkg/utils"
+)
+
+type Progress struct {
+	Entry                 *Entry
+	Folder                string
+	Index, Total, Created int
+}
+
+type ScanResult struct {
+	Errors                                  []error
+	Created, Skipped, Failed, ErrorsDropped int
+}
+
+func (r *ScanResult) fail(err error) {
+	r.Failed++
+	if len(r.Errors) < 10 {
+		r.Errors = append(r.Errors, err)
+	} else {
+		r.ErrorsDropped++
+	}
+}
+
+type GenerateResult struct {
+	Removed []string
+	Scan    ScanResult
+}
+
+// openSD confines every menu mutation, including symlinks, to the SD root.
+func (m *Manager) openSD() (*os.Root, string, error) {
+	relative, err := filepath.Rel(m.paths.SDRoot, m.paths.MenuFolder)
+	if err != nil || !filepath.IsLocal(relative) || relative == "." {
+		return nil, "", errors.New("games menu must be below the SD root")
+	}
+	root, err := os.OpenRoot(m.paths.SDRoot)
+	if err != nil {
+		return nil, "", fmt.Errorf("open SD root: %w", err)
+	}
+	return root, relative, nil
+}
+
+func (m *Manager) DeselectedFolders(selected []Entry) ([]string, error) {
+	folders, err := m.menuFolders()
+	if err != nil {
+		return nil, err
+	}
+	keep := make(map[string]bool, len(selected))
+	for _, entry := range selected {
+		keep[strings.ToLower(entry.MenuFolder)] = true
+	}
+	var removed []string
+	for lower, name := range folders {
+		if !keep[lower] {
+			removed = append(removed, name)
+		}
+	}
+	sort.Strings(removed)
+	return removed, nil
+}
+
+func (m *Manager) RemoveAll() error {
+	root, menu, err := m.openSD()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.RemoveAll(menu); err != nil {
+		return fmt.Errorf("remove Games menu: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) Generate(selected []Entry, progress func(Progress)) (GenerateResult, error) {
+	var result GenerateResult
+	for _, entry := range selected {
+		if !filepath.IsLocal(entry.MenuFolder) || filepath.Base(entry.MenuFolder) != entry.MenuFolder ||
+			entry.MenuFolder == "." {
+			return result, fmt.Errorf("invalid menu folder: %q", entry.MenuFolder)
+		}
+	}
+	removed, err := m.DeselectedFolders(selected)
+	if err != nil {
+		return result, err
+	}
+	root, menu, err := m.openSD()
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = root.Close() }()
+	// #nosec G301 -- MiSTer menu folders are shared filesystem data.
+	if err := root.MkdirAll(menu, 0o755); err != nil {
+		return result, fmt.Errorf("create Games menu: %w", err)
+	}
+	for _, name := range removed {
+		if err := root.RemoveAll(filepath.Join(menu, name)); err != nil {
+			return result, fmt.Errorf("remove deselected folder %s: %w", name, err)
+		}
+		result.Removed = append(result.Removed, name)
+	}
+	scan := menuScanner{
+		manager: m, root: root, menu: menu, result: &result.Scan,
+		directories: make(map[string]map[string]bool),
+	}
+	for index := range selected {
+		entry := &selected[index]
+		scan.entry, scan.rules = entry, extensionRules(entry.Systems)
+		scan.visited = make(map[string]bool)
+		for _, folder := range entry.Paths {
+			scan.folder = folder
+			scan.notify = func() {
+				if progress != nil {
+					progress(Progress{
+						Entry: entry, Folder: folder, Index: index, Total: len(selected), Created: result.Scan.Created,
+					})
+				}
+			}
+			scan.notify()
+			scan.walk(folder)
+		}
+	}
+	if progress != nil {
+		progress(Progress{Index: len(selected), Total: len(selected), Created: result.Scan.Created})
+	}
+	return result, nil
+}
+
+//nolint:govet // Groups scan state and filesystem caches.
+type menuScanner struct {
+	manager     *Manager
+	root        *os.Root
+	menu        string
+	result      *ScanResult
+	entry       *Entry
+	rules       []extensionRule
+	folder      string
+	visited     map[string]bool
+	directories map[string]map[string]bool
+	notify      func()
+	processed   int
+}
+
+func (s *menuScanner) walk(dir string) {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		s.result.fail(fmt.Errorf("resolve games folder %s: %w", dir, err))
+		return
+	}
+	if s.visited[resolved] {
+		return
+	}
+	s.visited[resolved] = true
+	children, err := os.ReadDir(dir)
+	if err != nil {
+		s.result.fail(fmt.Errorf("read games folder %s: %w", dir, err))
+		return
+	}
+	var directories []string
+	for _, child := range children {
+		if strings.HasPrefix(child.Name(), ".") {
+			continue
+		}
+		full := filepath.Join(dir, child.Name())
+		info, err := os.Stat(full)
+		if err != nil {
+			s.result.fail(fmt.Errorf("stat game %s: %w", full, err))
+			continue
+		}
+		if info.IsDir() {
+			directories = append(directories, full)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		relative, err := filepath.Rel(s.folder, dir)
+		if err != nil {
+			s.result.fail(fmt.Errorf("resolve game folder: %w", err))
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(full), ".zip") {
+			s.archive(full, relative)
+		} else {
+			s.write(full, relativeFolders(relative), child.Name())
+		}
+	}
+	// Python's os.walk yields current-directory files before its subfolders.
+	// Parent ZIP members must keep priority over colliding loose files below.
+	for _, directory := range directories {
+		s.walk(directory)
+	}
+}
+
+func relativeFolders(relative string) []string {
+	if relative == "." || relative == "" {
+		return nil
+	}
+	return strings.Split(filepath.ToSlash(relative), "/")
+}
+
+// ZIP member names are archive keys, not filesystem paths. Allow harmless dot
+// and empty components, but reject traversal before any path normalization.
+func validZIPMember(member string) bool {
+	if member == "" || strings.HasPrefix(member, "/") ||
+		strings.Contains(member, "\\") || strings.ContainsRune(member, 0) {
+		return false
+	}
+	for _, component := range strings.Split(member, "/") {
+		if component == ".." {
+			return false
+		}
+	}
+	clean := path.Clean(member)
+	return clean != "." && fs.ValidPath(clean)
+}
+
+func hiddenMember(member string) bool {
+	for _, component := range strings.Split(member, "/") {
+		if component != "." && strings.HasPrefix(component, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *menuScanner) archive(filename, relative string) {
+	members, err := utils.ListZip(filename)
+	if err != nil {
+		return
+	} // Python silently ignored invalid ZIPs.
+	for _, member := range members {
+		if strings.HasSuffix(member, "/") {
+			continue
+		}
+		if !validZIPMember(member) {
+			s.result.fail(fmt.Errorf("unsafe ZIP member in %s: %q", filename, member))
+			continue
+		}
+		if hiddenMember(member) {
+			continue
+		}
+		folders := relativeFolders(relative)
+		if index := strings.LastIndex(member, "/"); index >= 0 {
+			// Match Python's dirname: trim trailing separators, but preserve
+			// interior empty/dot components until names.txt prefixes them.
+			directory := strings.TrimRight(member[:index], "/")
+			if directory != "" {
+				folders = append(folders, strings.Split(directory, "/")...)
+			}
+		}
+		s.write(filename+"/"+member, folders, path.Base(member))
+	}
+}
+
+func (s *menuScanner) write(full string, folders []string, name string) {
+	system := matchSystem(s.rules, name)
+	if system == nil {
+		return
+	}
+	s.processed++
+	if s.processed%250 == 0 {
+		s.notify()
+	}
+	components := []string{s.menu, s.entry.MenuFolder}
+	for _, component := range folders {
+		components = append(components, s.manager.names.FolderName(component))
+	}
+	dir := filepath.Join(components...)
+	existing, err := s.outputDirectory(dir)
+	if err != nil {
+		s.result.fail(err)
+		return
+	}
+	filename := strings.TrimSuffix(name, filepath.Ext(name)) + ".mgl"
+	key := strings.ToLower(filename)
+	if existing[key] {
+		s.result.Skipped++
+		return
+	}
+	data, err := mister.GenerateMgl(s.manager.cfg, system, full, "")
+	if err != nil {
+		s.result.fail(fmt.Errorf("generate shortcut for %s: %w", full, err))
+		return
+	}
+	target := filepath.Join(dir, filename)
+	// O_EXCL also protects against another writer or a dangling symlink.
+	// #nosec G302 -- shortcuts are shared MiSTer menu data.
+	file, err := s.root.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, fs.ErrExist) {
+		existing[key] = true
+		s.result.Skipped++
+		return
+	}
+	if err != nil {
+		s.result.fail(fmt.Errorf("create shortcut %s: %w", target, err))
+		return
+	}
+	_, writeErr := file.WriteString(data)
+	closeErr := file.Close()
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		_ = s.root.Remove(target)
+		s.result.fail(fmt.Errorf("write shortcut %s: %w", target, err))
+		return
+	}
+	existing[key] = true
+	s.result.Created++
+}
+
+func (s *menuScanner) outputDirectory(dir string) (map[string]bool, error) {
+	if existing, ok := s.directories[dir]; ok {
+		return existing, nil
+	}
+	// #nosec G301 -- MiSTer menu folders are shared filesystem data.
+	if err := s.root.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create shortcut folder %s: %w", dir, err)
+	}
+	children, err := fs.ReadDir(s.root.FS(), dir)
+	if err != nil {
+		return nil, fmt.Errorf("read shortcut folder %s: %w", dir, err)
+	}
+	existing := make(map[string]bool, len(children))
+	for _, child := range children {
+		existing[strings.ToLower(child.Name())] = true
+	}
+	s.directories[dir] = existing
+	return existing, nil
+}

--- a/pkg/gamesmenu/manager.go
+++ b/pkg/gamesmenu/manager.go
@@ -1,0 +1,61 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"os"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// Manager discovers games folders and maintains the _Games shortcut tree.
+type Manager struct {
+	cfg   *config.UserConfig
+	names *Names
+	paths Paths
+}
+
+// NewManager targets the real MiSTer filesystem.
+func NewManager(cfg *config.UserConfig) (*Manager, error) {
+	return NewManagerWithPaths(cfg, DefaultPaths())
+}
+
+// NewManagerWithPaths targets a relocated root and loads its names.txt once.
+func NewManagerWithPaths(cfg *config.UserConfig, paths Paths) (*Manager, error) {
+	names, err := LoadNames(paths.NamesFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{cfg: cfg, names: names, paths: paths}, nil
+}
+
+func (m *Manager) Paths() Paths {
+	return m.paths
+}
+
+func (m *Manager) Names() *Names {
+	return m.names
+}
+
+// MenuExists reports whether the _Games folder is present.
+func (m *Manager) MenuExists() bool {
+	info, err := os.Stat(m.paths.MenuFolder)
+	return err == nil && info.IsDir()
+}

--- a/pkg/gamesmenu/names.go
+++ b/pkg/gamesmenu/names.go
@@ -1,0 +1,116 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// illegalNameChars are removed from names.txt replacements before they are
+// used as folder names, exactly as the Python script did.
+const illegalNameChars = `<>:"/\|?*`
+
+type nameEntry struct {
+	key         string
+	replacement string
+}
+
+// Names is MiSTer's names.txt display-name mapping with the Python script's
+// lookup rules: the key before the first colon is compared case-insensitively
+// after trimming, the first matching line wins, and the replacement has "/"
+// turned into " & " and other filename-illegal characters turned into spaces.
+type Names struct {
+	entries []nameEntry
+}
+
+// LoadNames reads names.txt from path. A missing file yields an empty mapping
+// that returns every name unchanged.
+func LoadNames(path string) (*Names, error) {
+	// #nosec G304 -- path is the configured names.txt location.
+	file, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &Names{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open names file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	names := &Names{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, replacement, ok := strings.Cut(scanner.Text(), ":")
+		if !ok {
+			continue
+		}
+		names.entries = append(names.entries, nameEntry{
+			key:         strings.ToLower(strings.TrimSpace(key)),
+			replacement: sanitizeName(strings.TrimSpace(replacement)),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read names file: %w", err)
+	}
+	return names, nil
+}
+
+func sanitizeName(replacement string) string {
+	replacement = strings.ReplaceAll(replacement, "/", " & ")
+	return strings.Map(func(r rune) rune {
+		if strings.ContainsRune(illegalNameChars, r) {
+			return ' '
+		}
+		return r
+	}, replacement)
+}
+
+// Replace returns the names.txt display name for name, or name itself.
+func (n *Names) Replace(name string) string {
+	if n == nil {
+		return name
+	}
+	lower := strings.ToLower(name)
+	for _, entry := range n.entries {
+		if entry.key == lower {
+			return entry.replacement
+		}
+	}
+	return name
+}
+
+// FolderName is the stock-menu folder name for name: an underscore so the
+// MiSTer menu descends into it, then the display name.
+func (n *Names) FolderName(name string) string {
+	return "_" + n.Replace(name)
+}
+
+// MenuPath joins the menu folder name of every component with slashes.
+func (n *Names) MenuPath(components ...string) string {
+	folders := make([]string, 0, len(components))
+	for _, component := range components {
+		folders = append(folders, n.FolderName(component))
+	}
+	return strings.Join(folders, "/")
+}

--- a/pkg/gamesmenu/names_test.go
+++ b/pkg/gamesmenu/names_test.go
@@ -1,0 +1,67 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNamesPythonRules(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "names.txt")
+	names, err := LoadNames(filename)
+	if err != nil || names.Replace("NES") != "NES" {
+		t.Fatalf("missing: %v, %v", names, err)
+	}
+	put(t, filename, "ignored\n NES : First/Name\nnes: second\nempty: \nchars: <>:\"\\|?*\n")
+	names, err = LoadNames(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := []struct{ input, want string }{
+		{"nEs", "First & Name"},
+		{"empty", ""},
+		{"chars", "        "},
+		{"unknown", "unknown"},
+		{" NES ", " NES "},
+	}
+	for _, check := range checks {
+		if got := names.Replace(check.input); got != check.want {
+			t.Errorf("Replace(%q)=%q want %q", check.input, got, check.want)
+		}
+	}
+	if got := names.MenuPath("NES", "empty", "unknown"); got != "_First & Name/_/_unknown" {
+		t.Fatalf("menu path: %q", got)
+	}
+}
+
+func TestExtensionRulesUseCatalogMGLSlots(t *testing.T) {
+	for _, folder := range menuSystems() {
+		if folder.Key == "Arcade" {
+			t.Fatal("Arcade has no MGL slot")
+		}
+		if matchSystem(extensionRules(folder.Systems), "custom.mgl") != nil {
+			t.Fatalf("MGL accepted for %s", folder.Key)
+		}
+		if folder.Key == "Pico8" && matchSystem(extensionRules(folder.Systems), "game.P8.PNG") == nil {
+			t.Fatal("multi-dot catalog suffix not accepted")
+		}
+	}
+}

--- a/pkg/gamesmenu/paths.go
+++ b/pkg/gamesmenu/paths.go
@@ -1,0 +1,68 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Package gamesmenu mirrors MiSTer game libraries into stock-menu MGL shortcut
+// folders. It is the Go port of scripts/gamesmenu.sh and keeps that script's
+// on-disk contract: a _Games folder at the SD root, one _<name> folder per
+// games folder, names.txt renaming of every folder component, and shortcuts
+// that are created once and never rewritten.
+package gamesmenu
+
+import (
+	"path/filepath"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+const (
+	// AppFilename is the installed binary name; the .sh suffix is load-bearing
+	// for MiSTer's Scripts menu and Downloader entries.
+	AppFilename = "gamesmenu.sh"
+	// IniFilename sits beside the binary in the Scripts folder.
+	IniFilename = "gamesmenu.ini"
+	// MenuFolderName is the stock-menu folder that receives the shortcuts.
+	MenuFolderName = "_Games"
+	namesFilename  = "names.txt"
+)
+
+// Paths holds every filesystem location GamesMenu reads or writes outside the
+// games folders, so tests and the --root development mode can relocate it.
+type Paths struct {
+	SDRoot     string
+	MenuFolder string
+	NamesFile  string
+}
+
+// DefaultPaths returns the locations used on a real MiSTer.
+func DefaultPaths() Paths {
+	return Paths{
+		SDRoot:     config.SdFolder,
+		MenuFolder: config.GamesMenuFolder,
+		NamesFile:  config.NamesFile,
+	}
+}
+
+// RootedPaths relocates every location under root, mirroring the SD layout.
+func RootedPaths(root string) Paths {
+	return Paths{
+		SDRoot:     root,
+		MenuFolder: filepath.Join(root, MenuFolderName),
+		NamesFile:  filepath.Join(root, namesFilename),
+	}
+}

--- a/pkg/gamesmenu/settings.go
+++ b/pkg/gamesmenu/settings.go
@@ -1,0 +1,80 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"fmt"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"gopkg.in/ini.v1"
+)
+
+// Settings is the staged copy of the values the Settings page edits.
+type Settings struct {
+	Theme   string
+	Mouse   bool
+	CRTMode bool
+}
+
+func SettingsFromConfig(cfg *config.UserConfig) Settings {
+	return Settings{
+		Theme:   cfg.TUI.Theme,
+		Mouse:   cfg.TUI.Mouse,
+		CRTMode: cfg.TUI.CRTMode,
+	}
+}
+
+func (s *Settings) ApplyTo(cfg *config.UserConfig) {
+	cfg.TUI.Theme = s.Theme
+	cfg.TUI.Mouse = s.Mouse
+	cfg.TUI.CRTMode = s.CRTMode
+}
+
+func (s *Settings) Validate() error {
+	cfg := DefaultUserConfig()
+	s.ApplyTo(cfg)
+	return ValidateConfig(cfg)
+}
+
+func (s *Settings) Equal(other *Settings) bool {
+	return s.Theme == other.Theme && s.Mouse == other.Mouse && s.CRTMode == other.CRTMode
+}
+
+// SaveSettings writes only the managed [tui] keys, keeping every other
+// section, key and comment in the file.
+func SaveSettings(path string, settings *Settings) error {
+	if err := settings.Validate(); err != nil {
+		return err
+	}
+	err := config.UpdateINI(path, func(file *ini.File) error {
+		section, sectionErr := config.GetOrCreateSection(file, "tui")
+		if sectionErr != nil {
+			return fmt.Errorf("get TUI section: %w", sectionErr)
+		}
+		config.SetKey(section, "theme", settings.Theme)
+		config.SetKey(section, "mouse", config.FormatBool(settings.Mouse))
+		config.SetKey(section, "crt_mode", config.FormatBool(settings.CRTMode))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("save Games Menu settings: %w", err)
+	}
+	return nil
+}

--- a/pkg/gamesmenu/settings_test.go
+++ b/pkg/gamesmenu/settings_test.go
@@ -1,0 +1,74 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSettingsPreserveExistingConfig(t *testing.T) {
+	root := t.TempDir()
+	filename := filepath.Join(root, IniFilename)
+	cfg, err := LoadConfigAt(filename, filepath.Join(root, AppFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configErr := EnsureConfigFile(cfg); configErr != nil {
+		t.Fatal(configErr)
+	}
+	original := read(t, filename) + "games_folder = " + root + "\n\n[custom]\n; retained comment\nunknown = retained\n"
+	put(t, filename, original)
+	if configErr := EnsureConfigFile(cfg); configErr != nil {
+		t.Fatal(configErr)
+	}
+	if read(t, filename) != original {
+		t.Fatal("EnsureConfigFile overwrote configuration")
+	}
+	settings := SettingsFromConfig(cfg)
+	settings.Mouse = false
+	settings.Theme = "dracula"
+	if saveErr := SaveSettings(filename, &settings); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	data := read(t, filename)
+	retained := []string{"; games_folder = /media/network", "[systems]", "[custom]", "; retained comment", "retained"}
+	for _, text := range retained {
+		if !strings.Contains(data, text) {
+			t.Errorf("lost %q: %s", text, data)
+		}
+	}
+	loaded, err := LoadConfigAt(filename, filepath.Join(root, AppFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.TUI.Mouse || loaded.TUI.Theme != "dracula" ||
+		len(loaded.Systems.GamesFolder) != 1 || loaded.Systems.GamesFolder[0] != root {
+		t.Fatalf("reload: %+v", loaded)
+	}
+	settings.Theme = "unknown theme"
+	if err := SaveSettings(filename, &settings); err == nil {
+		t.Fatal("invalid settings accepted")
+	}
+	if read(t, filename) != data {
+		t.Fatal("invalid settings modified file")
+	}
+}

--- a/pkg/gamesmenu/systems.go
+++ b/pkg/gamesmenu/systems.go
@@ -1,0 +1,133 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+// folderSystems lists the catalog systems that can launch files found in one
+// games folder. Several systems share folders (GAMEBOY, SMS, NES, TGFX16 and
+// so on), so the systems are ordered for deterministic extension matching:
+// systems that list the folder earlier in their own folder list come first,
+// then by ID.
+type folderSystems struct {
+	Key     string
+	Systems []games.System
+}
+
+type candidate struct {
+	system      games.System
+	folderIndex int
+}
+
+// menuSystems returns every catalog games folder that at least one system can
+// generate MGL shortcuts for, sorted case-insensitively by folder name.
+func menuSystems() []folderSystems {
+	byKey := make(map[string]*folderSystems)
+	candidates := make(map[string][]candidate)
+	systems := games.AllSystems()
+	for index := range systems {
+		system := &systems[index]
+		if !hasMglSlot(system) {
+			continue
+		}
+		for index, folder := range system.Folder {
+			lower := strings.ToLower(folder)
+			if _, ok := byKey[lower]; !ok {
+				byKey[lower] = &folderSystems{Key: folder}
+			}
+			candidates[lower] = append(candidates[lower], candidate{system: *system, folderIndex: index})
+		}
+	}
+
+	result := make([]folderSystems, 0, len(byKey))
+	for lower, entry := range byKey {
+		matches := candidates[lower]
+		sort.Slice(matches, func(i, j int) bool {
+			if matches[i].folderIndex != matches[j].folderIndex {
+				return matches[i].folderIndex < matches[j].folderIndex
+			}
+			return matches[i].system.Id < matches[j].system.Id
+		})
+		entry.Systems = make([]games.System, 0, len(matches))
+		for index := range matches {
+			entry.Systems = append(entry.Systems, matches[index].system)
+		}
+		result = append(result, *entry)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := strings.ToLower(result[i].Key), strings.ToLower(result[j].Key)
+		if left != right {
+			return left < right
+		}
+		return result[i].Key < result[j].Key
+	})
+	return result
+}
+
+func hasMglSlot(system *games.System) bool {
+	for _, slot := range system.Slots {
+		if slot.Mgl != nil && len(slot.Exts) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// extensionRule maps one lower-cased file suffix to the system that launches
+// it. Rules are ordered longest suffix first so ".p8.png" beats ".png".
+type extensionRule struct {
+	system *games.System
+	suffix string
+}
+
+func extensionRules(candidates []games.System) []extensionRule {
+	var rules []extensionRule
+	for index := range candidates {
+		system := &candidates[index]
+		for _, slot := range system.Slots {
+			if slot.Mgl == nil {
+				continue
+			}
+			for _, ext := range slot.Exts {
+				rules = append(rules, extensionRule{system: system, suffix: strings.ToLower(ext)})
+			}
+		}
+	}
+	sort.SliceStable(rules, func(i, j int) bool { return len(rules[i].suffix) > len(rules[j].suffix) })
+	return rules
+}
+
+// matchSystem returns the system that launches name, or nil when no MGL slot
+// accepts its extension. Matching is a case-insensitive suffix test, the same
+// rule the catalog uses to pick an MGL slot.
+func matchSystem(rules []extensionRule, name string) *games.System {
+	lower := strings.ToLower(name)
+	for _, rule := range rules {
+		if strings.HasSuffix(lower, rule.suffix) {
+			return rule.system
+		}
+	}
+	return nil
+}

--- a/pkg/tui/dialog.go
+++ b/pkg/tui/dialog.go
@@ -41,6 +41,7 @@ type Dialog struct {
 	done     func(int)
 	text     string
 	buttons  []string
+	overflow bool
 }
 
 func NewDialog() *Dialog {
@@ -77,7 +78,7 @@ func NewDialog() *Dialog {
 
 func (d *Dialog) SetText(text string) *Dialog {
 	d.text = text
-	d.textView.SetText(text)
+	d.textView.SetText(text).ScrollToBeginning()
 	return d
 }
 
@@ -107,6 +108,16 @@ func (d *Dialog) AddButtons(labels []string) *Dialog {
 		})
 		button := d.form.GetButton(d.form.GetButtonCount() - 1)
 		button.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			// Keep scrolling separate from button selection and activation.
+			if d.overflow {
+				switch event.Key() {
+				case tcell.KeyUp, tcell.KeyDown, tcell.KeyPgUp, tcell.KeyPgDn, tcell.KeyHome, tcell.KeyEnd:
+					d.textView.InputHandler()(event, func(tview.Primitive) {})
+					return nil
+				default:
+					// Confirmation keys must still reach the focused button.
+				}
+			}
 			switch event.Key() {
 			case tcell.KeyDown, tcell.KeyRight:
 				return tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
@@ -152,15 +163,25 @@ func (d *Dialog) Draw(screen tcell.Screen) {
 	if len(d.buttons) > 0 {
 		buttonRows = 2
 	}
-	dialogHeight := min(len(tview.WordWrap(d.text, textWidth))+buttonRows+2, height)
+	textLines := len(tview.WordWrap(d.text, textWidth))
+	d.overflow = textLines+buttonRows+2 > height
+	hintRows := 0
+	if d.overflow && len(d.buttons) > 0 {
+		hintRows = 1
+	}
+	dialogHeight := min(textLines+buttonRows+hintRows+2, height)
 
 	d.frame.SetRect(x+(width-dialogWidth)/2, y+(height-dialogHeight)/2, dialogWidth, dialogHeight)
 	d.frame.Draw(screen)
 
 	innerX, innerY, innerWidth, innerHeight := d.frame.GetInnerRect()
-	if textHeight := innerHeight - buttonRows; textHeight > 0 {
+	if textHeight := innerHeight - buttonRows - hintRows; textHeight > 0 {
 		d.textView.SetRect(innerX+1, innerY, max(innerWidth-2, 1), textHeight)
 		d.textView.Draw(screen)
+	}
+	if hintRows > 0 && innerHeight > buttonRows {
+		tview.Print(screen, "Up/Down: scroll  Left/Right: buttons", innerX, innerY+innerHeight-buttonRows-1,
+			innerWidth, tview.AlignCenter, CurrentTheme().SecondaryTextColor)
 	}
 	if buttonRows > 0 && innerHeight > 0 {
 		d.form.SetRect(innerX, innerY+innerHeight-1, innerWidth, 1)

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -299,6 +299,64 @@ func TestButtonBarNavigationAndActivation(t *testing.T) {
 	}
 }
 
+func TestLongDialogScrollsWhileKeepingButtonsIndependent(t *testing.T) {
+	for _, size := range [][2]int{{75, 15}, {100, 30}} {
+		screen := tcell.NewSimulationScreen("UTF-8")
+		if err := screen.Init(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(screen.Fini)
+		screen.SetSize(size[0], size[1])
+		app := tview.NewApplication()
+		selected := -1
+		dialog := NewDialog().SetText("First line\n" + strings.Repeat("Summary detail\n", 50) + "Last line").
+			AddButtons([]string{"Yes", "No"}).SetDoneFunc(func(index int) { selected = index })
+		app.SetRoot(dialog, true)
+		dialog.SetRect(0, 0, size[0], size[1])
+		draw := func() string {
+			screen.Clear()
+			dialog.Draw(screen)
+			var text strings.Builder
+			for y := range size[1] {
+				for x := range size[0] {
+					value, _, _ := screen.Get(x, y)
+					_, _ = text.WriteString(value)
+				}
+			}
+			return text.String()
+		}
+		press := func(key tcell.Key) {
+			dialog.InputHandler()(tcell.NewEventKey(key, 0, tcell.ModNone), func(p tview.Primitive) { app.SetFocus(p) })
+		}
+		if text := draw(); !strings.Contains(text, "First line") || !strings.Contains(text, "scroll") {
+			t.Fatalf("missing initial message/help at %v: %s", size, text)
+		}
+		press(tcell.KeyEnd)
+		if text := draw(); !strings.Contains(text, "Last line") || selected != -1 {
+			t.Fatalf("could not scroll summary safely at %v: %s", size, text)
+		}
+		press(tcell.KeyHome)
+		if text := draw(); !strings.Contains(text, "First line") {
+			t.Fatalf("could not scroll back at %v: %s", size, text)
+		}
+		press(tcell.KeyRight)
+		press(tcell.KeyEnter)
+		if selected != 1 {
+			t.Fatalf("button selection changed while scrolling: %d", selected)
+		}
+		// Short dialogs retain the original Up/Down button navigation.
+		dialog.SetText("Short message")
+		if text := draw(); strings.Contains(text, "scroll") {
+			t.Fatalf("short dialog still shows scrolling help: %s", text)
+		}
+		press(tcell.KeyUp)
+		press(tcell.KeyEnter)
+		if selected != 0 {
+			t.Fatalf("short dialog navigation changed: %d", selected)
+		}
+	}
+}
+
 func TestModalDismissalRestoresPageFocus(t *testing.T) {
 	type harness struct {
 		app   *tview.Application

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -1,0 +1,177 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+const (
+	progressModalPage       = "tui_progress_modal"
+	progressModalWidth      = 60
+	progressModalHeight     = 7
+	progressBarWidth        = 50
+	defaultProgressThrottle = 150 * time.Millisecond
+)
+
+// ProgressOptions configures ShowProgressModal. Throttle bounds how often the
+// task goroutine may redraw the modal; zero selects a 150ms minimum interval.
+type ProgressOptions struct {
+	Title    string
+	Initial  ProgressUpdate
+	Throttle time.Duration
+}
+
+// Progress is a bordered message box with an optional bar. It swallows all
+// keys so a running task cannot be interrupted by the controller.
+type Progress struct {
+	*tview.Box
+	update ProgressUpdate
+}
+
+func NewProgress(title string) *Progress {
+	theme := CurrentTheme()
+	progress := &Progress{Box: tview.NewBox()}
+	progress.SetBackgroundColor(tview.Styles.ContrastBackgroundColor).
+		SetBorder(true).
+		SetBorderColor(theme.BorderColor).
+		SetTitleColor(theme.BorderColor).
+		SetTitleAlign(tview.AlignCenter).
+		SetTitle(" " + title + " ")
+	return progress
+}
+
+// SetUpdate replaces the displayed text and bar. Call it on the UI goroutine.
+func (p *Progress) SetUpdate(update ProgressUpdate) *Progress {
+	p.update = update
+	return p
+}
+
+// Update returns the most recently displayed state.
+func (p *Progress) Update() ProgressUpdate {
+	return p.update
+}
+
+func (p *Progress) Draw(screen tcell.Screen) {
+	p.DrawForSubclass(screen, p)
+	x, y, width, height := p.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+	theme := CurrentTheme()
+	textRows := height
+	if p.update.Total > 0 {
+		textRows = max(height-2, 1)
+	}
+	lines := tview.WordWrap(p.update.Text, width)
+	if len(lines) > textRows {
+		lines = lines[:textRows]
+	}
+	for index, line := range lines {
+		tview.Print(screen, tview.Escape(line), x, y+index, width, tview.AlignCenter, theme.PrimaryTextColor)
+	}
+	if p.update.Total <= 0 || height < 2 {
+		return
+	}
+	barWidth := min(width, progressBarWidth)
+	barX := x + (width-barWidth)/2
+	barY := y + height - 1
+	current := min(max(p.update.Current, 0), p.update.Total)
+	filled := current * barWidth / p.update.Total
+	fill := tcell.StyleDefault.Foreground(theme.ProgressFillColor).Background(tview.Styles.ContrastBackgroundColor)
+	empty := tcell.StyleDefault.Foreground(theme.ProgressEmptyColor).Background(tview.Styles.ContrastBackgroundColor)
+	for index := range barWidth {
+		if index < filled {
+			screen.SetContent(barX+index, barY, '#', nil, fill)
+		} else {
+			screen.SetContent(barX+index, barY, '-', nil, empty)
+		}
+	}
+}
+
+func (p *Progress) InputHandler() func(*tcell.EventKey, func(tview.Primitive)) {
+	return p.WrapInputHandler(func(*tcell.EventKey, func(tview.Primitive)) {})
+}
+
+// Cover the entire page, not just the centered box, so mouse clicks cannot
+// activate underlying actions while a filesystem operation is running.
+type progressOverlay struct{ tview.Primitive }
+
+func (*progressOverlay) MouseHandler() func(
+	tview.MouseAction, *tcell.EventMouse, func(tview.Primitive),
+) (bool, tview.Primitive) {
+	return func(tview.MouseAction, *tcell.EventMouse, func(tview.Primitive)) (bool, tview.Primitive) {
+		return true, nil
+	}
+}
+
+// ShowProgressModal overlays a progress box on pages and runs task on a new
+// goroutine. The update callback handed to task may be called from that
+// goroutine as often as wanted; redraws are throttled and delivered with
+// app.QueueUpdateDraw, so the application must be running. When task returns
+// the modal is removed and onDone runs on the UI goroutine with its error.
+// update must not be called after task returns.
+func ShowProgressModal(
+	pages *tview.Pages,
+	app *tview.Application,
+	options ProgressOptions,
+	task func(update func(ProgressUpdate)) error,
+	onDone func(error),
+) *Progress {
+	throttle := options.Throttle
+	if throttle <= 0 {
+		throttle = defaultProgressThrottle
+	}
+	previousFocus := app.GetFocus()
+	progress := NewProgress(options.Title).SetUpdate(options.Initial)
+	overlay := &progressOverlay{Primitive: Centered(progressModalWidth, progressModalHeight, progress)}
+	pages.AddPage(progressModalPage, overlay, true, true)
+	app.SetFocus(progress)
+
+	var mu sync.Mutex
+	var last time.Time
+	update := func(update ProgressUpdate) {
+		mu.Lock()
+		now := time.Now()
+		if !last.IsZero() && now.Sub(last) < throttle {
+			mu.Unlock()
+			return
+		}
+		last = now
+		mu.Unlock()
+		app.QueueUpdateDraw(func() { progress.SetUpdate(update) })
+	}
+
+	go func() {
+		err := task(update)
+		app.QueueUpdateDraw(func() {
+			pages.RemovePage(progressModalPage)
+			app.SetFocus(previousFocus)
+			if onDone != nil {
+				onDone(err)
+			}
+		})
+	}()
+	return progress
+}

--- a/pkg/tui/progress_test.go
+++ b/pkg/tui/progress_test.go
@@ -1,0 +1,136 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestProgressDrawsTextAndHalfFilledBar(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(60, 7)
+	progress := NewProgress("Creating MGL files...").
+		SetUpdate(ProgressUpdate{Text: "Scanning SNES (/media/fat/games/SNES)", Current: 5, Total: 10})
+	progress.SetRect(0, 0, 60, 7)
+	progress.Draw(screen)
+	var text strings.Builder
+	for x := range 60 {
+		value, _, _ := screen.Get(x, 1)
+		_, _ = text.WriteString(value)
+	}
+	if !strings.Contains(text.String(), "Scanning SNES") {
+		t.Fatalf("progress text missing: %q", text.String())
+	}
+	filled, empty := 0, 0
+	for x := range 60 {
+		value, _, _ := screen.Get(x, 5)
+		switch value {
+		case "#":
+			filled++
+		case "-":
+			empty++
+		}
+	}
+	if filled != 25 || empty != 25 {
+		t.Fatalf("bar filled=%d empty=%d", filled, empty)
+	}
+	progress.InputHandler()(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone), func(tview.Primitive) {
+		t.Fatal("progress box delegated focus")
+	})
+}
+
+func TestShowProgressModalRunsTaskAndThrottlesUpdates(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	app := tview.NewApplication().SetScreen(screen)
+	base := tview.NewBox()
+	pages := tview.NewPages().AddPage("base", base, true, true)
+	app.SetRoot(pages, true).SetFocus(base)
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run() }()
+	t.Cleanup(func() {
+		app.Stop()
+		select {
+		case <-runErr:
+		case <-time.After(5 * time.Second):
+			t.Error("application did not stop")
+		}
+	})
+
+	sentinel := errors.New("task finished")
+	done := make(chan error, 1)
+	var progress *Progress
+	app.QueueUpdate(func() {
+		progress = ShowProgressModal(pages, app, ProgressOptions{Title: "Working", Throttle: time.Second},
+			func(update func(ProgressUpdate)) error {
+				for index := range 50 {
+					update(ProgressUpdate{Text: "step", Current: index, Total: 50})
+				}
+				return sentinel
+			}, func(err error) { done <- err })
+	})
+	select {
+	case err := <-done:
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("onDone error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("progress task did not complete")
+	}
+	var hasPage bool
+	var shown ProgressUpdate
+	app.QueueUpdate(func() {
+		hasPage = pages.HasPage(progressModalPage)
+		shown = progress.Update()
+		if app.GetFocus() != base {
+			t.Error("progress did not restore focus")
+		}
+	})
+	if hasPage {
+		t.Fatal("progress modal was not removed")
+	}
+	if shown.Current != 0 {
+		t.Fatalf("updates were not throttled: %+v", shown)
+	}
+}
+
+func TestProgressOverlayConsumesMouseOutsideBox(t *testing.T) {
+	overlay := &progressOverlay{Primitive: Centered(60, 7, NewProgress("Working"))}
+	overlay.SetRect(0, 0, 100, 30)
+	consumed, capture := overlay.MouseHandler()(
+		tview.MouseLeftClick, tcell.NewEventMouse(0, 0, tcell.Button1, tcell.ModNone),
+		func(tview.Primitive) { t.Error("mouse changed focus") },
+	)
+	if !consumed || capture != nil {
+		t.Fatal("progress overlay leaked mouse input")
+	}
+}

--- a/scripts/generate_repo.py
+++ b/scripts/generate_repo.py
@@ -9,10 +9,11 @@ from pathlib import Path
 from zipfile import ZipFile
 from typing import TypedDict, Union, Optional, List
 
-APPS = ["bgm", "favorites", "lastplayed", "launchsync", "playlog", "random", "remote", "search"]
+APPS = ["bgm", "favorites", "gamesmenu", "lastplayed", "launchsync", "playlog", "random", "remote", "search"]
 FILES = {
     "bgm": ["bgm.sh"],
     "favorites": ["favorites.sh"],
+    "gamesmenu": ["gamesmenu.sh"],
     "lastplayed": ["lastplayed.sh"],
     "launchsync": ["launchsync.sh"],
     "playlog": ["playlog.sh"],
@@ -21,15 +22,11 @@ FILES = {
     "search": ["search.sh"],
 }
 REBOOT = ["remote"]
-SCRIPT_FILES = [
-    "scripts/gamesmenu.sh",
-]
 
 DB_ID = "mrext/{}"
 RELEASES_FOLDER = "releases"
 DL_FOLDER = "_bin/releases"
 DL_URL = "https://github.com/wizzomafizzo/mrext/releases/download/{}"
-SCRIPT_URL = "https://github.com/wizzomafizzo/mrext/raw/main/scripts/{}"
 
 
 class RepoDbFilesItem(TypedDict):
@@ -121,19 +118,6 @@ def create_all_db(tag: str) -> RepoDb:
             )
 
             files[key] = file_entry
-
-    for file in SCRIPT_FILES:
-        url = SCRIPT_URL.format(os.path.basename(file))
-        local_path = file
-        key = "Scripts/{}".format(os.path.basename(local_path))
-        size = os.stat(local_path).st_size
-        md5 = hashlib.md5(open(local_path, "rb").read()).hexdigest()
-
-        file_entry = RepoDbFilesItem(
-            hash=md5, size=size, url=url, overwrite=None, reboot=False, tags=[Path(local_path).stem]
-        )
-
-        files[key] = file_entry
 
     return RepoDb(
         db_id=DB_ID.format("all"),

--- a/scripts/test_generate_repo.py
+++ b/scripts/test_generate_repo.py
@@ -1,0 +1,31 @@
+"""Downloader compatibility tests; never write release databases."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
+
+from scripts import generate_repo
+
+
+class GamesMenuReleaseTests(unittest.TestCase):
+    def test_gamesmenu_binary_keeps_installed_key(self):
+        with patch("builtins.open", mock_open(read_data=b"ELF fixture")), patch(
+            "scripts.generate_repo.os.stat", return_value=SimpleNamespace(st_size=11)
+        ):
+            individual = generate_repo.create_app_db("gamesmenu", "v-test")
+            combined = generate_repo.create_all_db("v-test")
+
+        key = "Scripts/gamesmenu.sh"
+        self.assertEqual(individual["db_id"], "mrext/gamesmenu")
+        self.assertEqual(list(individual["files"]), [key])
+        self.assertEqual(individual["files"][key], combined["files"][key])
+        self.assertEqual(
+            combined["files"][key]["url"],
+            "https://github.com/wizzomafizzo/mrext/releases/download/v-test/gamesmenu.sh",
+        )
+        self.assertEqual(combined["files"][key]["tags"], ["gamesmenu"])
+        self.assertFalse(combined["files"][key]["reboot"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Port GamesMenu to Go with controller-first TUI, staged Settings, catalog-backed generation and explicit Clean Up; preserve existing shortcuts and Downloader install path.
- Add shared INI helpers, progress overlays and scrollable dialogs; fix verified Python parity regressions with fixture and simulation tests.
- Wire native releases and document compatibility differences, including legacy extension losses.
- Include all repo changes: refreshed AGENTS.md, redundant Copilot guidance removal and local CLAUDE.md ignore.

## Validation
- `mage test` and `mage lint` (zero issues)
- 52 focused race-tested tests; Python/Go differential parity fixtures
- `mage mister all`
- Workflow actionlint, Downloader Python unittest and `git diff --check`

Live-device testing not performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the GamesMenu application for discovering games, generating shortcuts, cleaning up missing entries, and removing unwanted menu items.
  * Added settings for themes, mouse support, and CRT mode, with save/discard confirmation.
  * Added progress indicators and scrolling support for longer confirmation dialogs.
* **Documentation**
  * Added comprehensive GamesMenu installation, usage, configuration, and compatibility guidance.
  * Updated download links to use the latest released GamesMenu asset.
* **Bug Fixes**
  * Improved preservation of existing configuration comments and unrelated settings when saving changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->