### PR TITLE
test(favorites): cover arcade core updates

### DIFF
--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -24,12 +24,14 @@ Run `favorites` from MiSTer's Scripts menu.
 - Preserve NeoGeo ZIP naming from `romsets.xml` and relative NeoGeo launcher paths.
 - Create, rename, move, and remove Favorites folders and entries.
 - Refresh broken dated core symlinks after core updates.
-- Maintain arcade `cores` links needed by MRA favorites.
+- Maintain arcade `cores` links needed by MRA favorites. These link directly to `/media/fat/_Arcade/cores`, so newly downloaded cores are available without refreshing Favorites.
 - Operate with a controller through an on-screen keyboard.
 
 ## Compatibility notes
 
 The Go version preserves Python Favorites' folder discovery, top-level destinations, nested folder management, startup refresh hook, LLAPI/YC selection, root filtering, external-drive shortcut, ZIP traversal, NeoGeo names and relative paths, dated-core repair, and safe link-based core favorites. Symlinked game directories remain browsable.
+
+Arcade link management creates missing `cores` links when the interactive app opens and when it creates a Favorites folder. Existing files, directories, and symlinks named `cores` are preserved, not repaired or replaced. If an older Favorites folder uses a copied `cores` directory or an incorrect link, back it up and move it aside before reopening Favorites. MRAs that require a custom cores directory rather than `_Arcade/cores` are not automatically supported; Favorites does not merge multiple core directories.
 
 Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog.
 

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -834,6 +834,47 @@ func TestAlternateCoreAndCorePrefix(t *testing.T) {
 	}
 }
 
+func TestArcadeLinksExposeNewCoresWithoutRefresh(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	nested := filepath.Join(folder, "_Arcade Picks")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetupArcadeLinks(); err != nil {
+		t.Fatal(err)
+	}
+	created, err := manager.CreateFolder(folder, "_New Picks")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Downloader adds cores after Favorites has already prepared its menu folders.
+	const coreName = "RTypeII_20220918.rbf"
+	const coreData = "new arcade core"
+	corePath := filepath.Join(manager.paths.ArcadeCoresFolder, coreName)
+	if err := os.WriteFile(corePath, []byte(coreData), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, destination := range []string{root, folder, nested, created} {
+		link := filepath.Join(destination, "cores")
+		target, readErr := os.Readlink(link)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if target != manager.paths.ArcadeCoresFolder {
+			t.Fatalf("%s target = %q, want %q", link, target, manager.paths.ArcadeCoresFolder)
+		}
+		data, readErr := os.ReadFile(filepath.Join(link, coreName))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(data) != coreData {
+			t.Fatalf("new core unavailable through %s: %q", link, data)
+		}
+	}
+}
+
 func TestArcadeLinksDoNotReplaceExistingContent(t *testing.T) {
 	manager, _, root := newTestManager(t)
 	folder := filepath.Join(root, "_@Favorites")


### PR DESCRIPTION
## Summary
- Verify existing Go directory symlinks expose newly downloaded arcade cores without refreshing Favorites.
- Cover root, existing nested folders, and newly created Favorites folders.
- Document legacy cores-path recovery and unsupported custom core directories; no runtime behavior changes.

Closes #156

## Validation
- `mage test`
- `mage lint`
- `mage mister favorites`
- `git diff --check`
- No device testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favorites now automatically keeps arcade core links up to date when the app opens or new Favorites folders are created.
  * Newly added arcade cores appear in existing and newly created Favorites folders without requiring a refresh.
* **Documentation**
  * Documented preservation of existing files and links, along with manual cleanup requirements for incorrect copied folders or links.
  * Custom MRA core directories are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->