### PR TITLE
feat(bgm): add generic core boot sound fallback

### DIFF
--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -41,6 +41,7 @@ Intentional differences:
 - A socket file left behind by a crashed service is removed automatically instead of blocking BGM until reboot. `restart` waits for the old service to exit before starting the new one.
 - Stopping a playlist waits for the running track to be killed, so a stopped playlist can never start one more track. Unknown command-line arguments print usage instead of opening the menu.
 - Playlist folders are listed alphabetically in the menu.
+- Optional `music/boot/default/` tracks provide a generic core boot sound when no core-specific boot directory exists. Existing empty core-specific directories remain silent.
 
 ## Music folder
 
@@ -54,7 +55,10 @@ Intentional differences:
   Radio/station.pls    an internet radio playlist
   boot/                global boot sounds, no prefix needed
   boot/SNES/           boot sounds played when the SNES core launches
+  boot/default/        optional fallback for cores without their own boot folder
 ```
+
+Core boot folders are matched case-insensitively. BGM chooses a random supported track from the matching folder's top level and applies `corebootdelay`. If no core-specific directory exists, it uses `boot/default/` with the same selection and delay rules. A core-specific folder with no supported tracks suppresses the fallback. Missing or empty fallback folders remain silent; startup tracks directly inside `boot/` are not reused for core launches. No INI changes are needed to enable this: add tracks to `boot/default/`.
 
 ### Supported files
 

--- a/pkg/bgm/player.go
+++ b/pkg/bgm/player.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
 )
 
 // HistorySize is the ratio of total tracks kept in the recently-played list.
@@ -576,14 +578,26 @@ func (p *Player) PlayBoot() {
 	p.Play(track)
 }
 
-// PlayCoreBoot mirrors play_core_boot(): a case-insensitive folder match in
-// music/boot plays one random track after the configured delay. An empty
-// matching folder ends the search; a played one lets it continue.
+// PlayCoreBoot plays a random core-specific boot track after the configured
+// delay. The default folder is used only when no core-specific directory exists;
+// an empty core-specific directory deliberately suppresses the fallback.
 func (p *Player) PlayCoreBoot(core string) {
+	if core == "" {
+		return
+	}
 	entries, err := os.ReadDir(p.paths.BootFolder)
 	if err != nil {
 		return
 	}
+	if !p.playCoreBootFolder(entries, core) {
+		p.playCoreBootFolder(entries, config.BGMDefaultBootFolder)
+	}
+}
+
+// playCoreBootFolder preserves case-insensitive matching, including multiple
+// matching directories. Its result reports directory presence, not playback.
+func (p *Player) playCoreBootFolder(entries []fs.DirEntry, core string) bool {
+	found := false
 	for _, entry := range entries {
 		if !strings.EqualFold(entry.Name(), core) {
 			continue
@@ -593,6 +607,7 @@ func (p *Player) PlayCoreBoot(core string) {
 		if statErr != nil || !info.IsDir() {
 			continue
 		}
+		found = true
 		files, readErr := os.ReadDir(folder)
 		if readErr != nil {
 			continue
@@ -604,11 +619,12 @@ func (p *Player) PlayCoreBoot(core string) {
 			}
 		}
 		if len(tracks) == 0 {
-			return
+			return true
 		}
 		cfg, _ := LoadConfig(&p.paths)
 		p.sleep(time.Duration(cfg.CoreBootDelay * float64(time.Second)))
 		p.logger.Log("Playing core boot track...")
 		p.Play(tracks[p.randIndex(len(tracks))])
 	}
+	return found
 }

--- a/pkg/bgm/player_test.go
+++ b/pkg/bgm/player_test.go
@@ -473,6 +473,49 @@ func TestPlayCoreBoot(t *testing.T) {
 	}
 }
 
+func TestPlayCoreBootDefaultFallback(t *testing.T) {
+	paths := newTestPaths(t)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	writeINI(t, &paths, "[bgm]\ncorebootdelay = 1.5\n")
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	var slept time.Duration
+	player.sleep = func(duration time.Duration) { slept += duration }
+	touchTracks(t, filepath.Join(paths.BootFolder, "DeFaUlT"), "fallback.wav")
+	touchTracks(t, filepath.Join(paths.BootFolder, "Genesis"), "specific.wav")
+	touchTracks(t, filepath.Join(paths.BootFolder, "Empty"), "notes.txt")
+	touchTracks(t, paths.BootFolder, "startup.wav")
+
+	player.PlayCoreBoot("SNES")
+	got := stubInvocations(t, logPath)
+	if len(got) != 1 || !strings.HasSuffix(got[0], "fallback.wav") {
+		t.Fatalf("missing core folder must use fallback: %v", got)
+	}
+	if slept != 1500*time.Millisecond {
+		t.Fatalf("fallback delay = %v", slept)
+	}
+	player.PlayCoreBoot("genesis")
+	got = stubInvocations(t, logPath)
+	if len(got) != 2 || !strings.HasSuffix(got[1], "specific.wav") {
+		t.Fatalf("core-specific track must take priority: %v", got)
+	}
+	player.PlayCoreBoot("empty")
+	player.PlayCoreBoot("")
+	if got := stubInvocations(t, logPath); len(got) != 2 {
+		t.Fatalf("empty core folders and unknown core state must remain silent: %v", got)
+	}
+	if slept != 3*time.Second {
+		t.Fatalf("silent core boots must not delay: %v", slept)
+	}
+	if err := os.Remove(filepath.Join(paths.BootFolder, "DeFaUlT", "fallback.wav")); err != nil {
+		t.Fatal(err)
+	}
+	player.PlayCoreBoot("SNES")
+	if got := stubInvocations(t, logPath); len(got) != 2 {
+		t.Fatalf("empty fallback must not reuse startup tracks: %v", got)
+	}
+}
+
 func TestPlaylistTrackStartedAfterStopIsKilledImmediately(t *testing.T) {
 	paths := newTestPaths(t)
 	logPath := installStubPlayers(t)

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -48,3 +48,6 @@ const (
 const GamesDB = ScriptsConfigFolder + "/mrext/games.db"
 
 const LastLaunchFile = SdFolder + "/.LASTLAUNCH.mgl"
+
+// BGMDefaultBootFolder holds opt-in core boot sounds under BGM's boot directory.
+const BGMDefaultBootFolder = "default"


### PR DESCRIPTION
## Summary
- Add opt-in `music/boot/default/` fallback for cores without a dedicated boot directory.
- Preserve core-specific priority, empty-folder silence, case-insensitive matching, and `corebootdelay`.
- Add regression coverage and document setup and compatibility.

Closes #142

## Validation
- Regression failed before implementation and passed afterward.
- `mage test`
- `mage lint`
- `mage mister bgm`
- `git diff --check`
- No device testing.