### PR TITLE
feat(gamesmenu): support Darksoft NeoGeo ROM sets

### DIFF
--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -31,7 +31,7 @@ Run `favorites` from MiSTer's Scripts menu.
 
 The Go version preserves Python Favorites' folder discovery, top-level destinations, nested folder management, startup refresh hook, LLAPI/YC selection, root filtering, external-drive shortcut, ZIP traversal, NeoGeo names and relative paths, dated-core repair, and safe link-based core favorites. Symlinked game directories remain browsable.
 
-Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog.
+Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog. ZIP and `.neo` launchers use the same catalog ROM-slot parameters and retain Favorites' relative NeoGeo paths.
 
 ## Settings screen
 

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -37,9 +37,17 @@ The ZIP filename adds no folder level. Duplicate game basenames in the same outp
 
 Progress shows the current source folder and shortcut count. Completion reports created, skipped and failed shortcuts, removed folders, and up to ten error details. Long summaries and errors also scroll with Up/Down. Leave GamesMenu running until it finishes; progress is not cancellable.
 
+### NeoGeo Darksoft sets
+
+GamesMenu recognizes extracted NeoGeo set folders and whole-set ZIPs by their names in `romsets.xml`, including comma-separated aliases and case differences. Place the XML file at the top of a discovered `NEOGEO` games folder; its filename is also matched case-insensitively. Definitions are shared across discovered NeoGeo roots, so an SD mapping can describe sets on USB or network storage. Earlier roots win when definitions conflict.
+
+A matching folder or ZIP produces one shortcut named from its `altname`, with unsafe filename characters sanitized using the same rules as `names.txt`. Parent folders remain mirrored, but the set's individual ROM components are not added. Ordinary `.neo` files keep their filenames; ZIPs not identified as sets retain normal collection scanning. A missing mapping is allowed; malformed mappings are reported and never used partially. An entry needs a nonempty `altname` to be recognized. Recognition does not verify that every required ROM component is present.
+
+For example, a `romset` with `name="mslug" altname="Metal Slug"` recognizes `/media/usb0/games/NEOGEO/mslug/` and creates `_Games/_NEOGEO/Metal Slug.mgl` on SD. No ROM conversion or Zaparoo Core installation is required. Newly generated set shortcuts use the catalog's NeoGeo ROM slot and honor `set_core`; runtime hooks are not executed.
+
 ## Clean Up
 
-Clean Up asks for confirmation, then checks `.mgl` targets. It removes shortcuts when the referenced file or ZIP member is missing, and prunes empty nested menu folders. System-level folders remain so toggle state is preserved. Both Go-generated shortcuts and legacy Python shortcuts with absolute paths and raw ampersands are understood.
+Clean Up asks for confirmation, then checks `.mgl` targets. It removes shortcuts when the referenced file, NeoGeo set directory, or ZIP member is missing, and prunes empty nested menu folders. System-level folders remain so toggle state is preserved. Both Go-generated shortcuts and legacy Python shortcuts with absolute paths and raw ampersands are understood.
 
 Malformed, unreadable or ambiguous shortcuts, invalid/unreadable archives, and core-only launchers are kept. Cleanup checks every file target in custom multi-file MGLs; an unknown target prevents deletion. Menu symlinks are not traversed. The summary reports checked and removed shortcuts, pruned folders and unreadable paths.
 
@@ -93,6 +101,7 @@ Intentional differences:
 - Existing `_NeoGeo` and `_ATARI2600` folder spelling survives catalog casing differences. Source directory symlinks are followed with loop protection. Additional network and configured roots are supported.
 - Dotfiles, AppleDouble files and hidden ZIP members are skipped. Absolute and parent-traversing ZIP paths are rejected, but harmless `./` and repeated separators are accepted. Exact ZIP member names and Python's `_.`/`_` menu-folder quirks are preserved (for example, `./game.nes` creates `_./game.mgl`). Output writes are confined to the SD root; symlinks escaping it fail rather than writing elsewhere. Exclusive file creation protects existing shortcuts against concurrent writers.
 - Optional `gamesmenu.ini` and explicit, conservative Clean Up are new. Errors are reported rather than silently discarded (invalid source ZIPs are still silently ignored).
+- NeoGeo Darksoft set folders and ZIPs mapped by `romsets.xml` are now supported as single games. This is a stock-MiSTer compatibility extension using the catalog's existing NeoGeo mount parameters, not a separate system catalog. Recognized set folders are treated as game entries in their parent directory's name order.
 
 ## Local development
 

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -48,3 +48,5 @@ const (
 const GamesDB = ScriptsConfigFolder + "/mrext/games.db"
 
 const LastLaunchFile = SdFolder + "/.LASTLAUNCH.mgl"
+
+const NeoGeoRomsetsFile = "romsets.xml"

--- a/pkg/favorites/launcher.go
+++ b/pkg/favorites/launcher.go
@@ -166,40 +166,19 @@ func (m *Manager) generateMGL(system *games.System, mediaPath string) (string, e
 		return "", fmt.Errorf("resolve NeoGeo favorite path: %w", err)
 	}
 	core := games.CatalogCore(system)
-	params, err := catalog.PathToMGLDef(&core, mediaPath)
-	if err != nil {
-		if !strings.EqualFold(filepath.Ext(mediaPath), ".zip") {
-			return "", fmt.Errorf("resolve NeoGeo MGL parameters: %w", err)
-		}
-		// NeoGeo ZIP sets are supported by Favorites but are not yet present in
-		// the published standalone catalog module.
-		params = &catalog.MGLParams{Delay: 1, Method: "f", Index: 1}
+	if _, slotErr := catalog.PathToMGLDef(&core, mediaPath); slotErr != nil &&
+		!strings.EqualFold(filepath.Ext(mediaPath), ".zip") {
+		return "", fmt.Errorf("resolve NeoGeo MGL parameters: %w", slotErr)
 	}
-	//nolint:gocritic // Explicit XML quoting is required after attribute escaping.
-	override := fmt.Sprintf(
-		"\t<file delay=\"%d\" type=%q index=\"%d\" path=\"%s\"/>\n",
-		params.Delay,
-		params.Method,
-		params.Index,
-		escapeAttribute(filepath.ToSlash(relativePath)),
-	)
-	if params.ResetDelay > 0 {
-		override += fmt.Sprintf("\t<reset delay=\"%d\" hold=\"%d\"/>\n", params.ResetDelay, params.ResetHold)
+	override, err := games.NeoGeoMGLOverride(system, filepath.ToSlash(relativePath))
+	if err != nil {
+		return "", fmt.Errorf("generate NeoGeo favorite mount: %w", err)
 	}
 	launcher, err := mglgen.Generate(&core, core.RBF, mediaPath, override)
 	if err != nil {
 		return "", fmt.Errorf("generate relative NeoGeo favorite MGL: %w", err)
 	}
 	return launcher, nil
-}
-
-func escapeAttribute(value string) string {
-	return strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-		`"`, "&quot;",
-	).Replace(value)
 }
 
 func (m *Manager) resolveCore(system *games.System) string {

--- a/pkg/favorites/neogeo.go
+++ b/pkg/favorites/neogeo.go
@@ -21,13 +21,11 @@ package favorites
 
 import (
 	"bytes"
-	"encoding/xml"
-	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/games"
 )
 
@@ -41,7 +39,7 @@ func (m *Manager) NeoGeoTitle(path string) string {
 	}
 	folder := filepath.Dir(path)
 	for {
-		xmlPath := filepath.Join(folder, "romsets.xml")
+		xmlPath := filepath.Join(folder, config.NeoGeoRomsetsFile)
 		if info, err := os.Stat(xmlPath); err == nil && !info.IsDir() {
 			names := m.loadNeoGeoNames(xmlPath)
 			return names[strings.ToLower(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))]
@@ -108,38 +106,6 @@ func (m *Manager) loadNeoGeoNames(path string) map[string]string {
 	if err != nil {
 		return names
 	}
-	decoder := xml.NewDecoder(bytes.NewReader(data))
-	for {
-		token, tokenErr := decoder.Token()
-		if errors.Is(tokenErr, io.EOF) {
-			break
-		}
-		if tokenErr != nil {
-			clear(names)
-			return names
-		}
-		start, ok := token.(xml.StartElement)
-		if !ok || start.Name.Local != "romset" {
-			continue
-		}
-		var rawNames, title string
-		for _, attribute := range start.Attr {
-			switch attribute.Name.Local {
-			case "name":
-				rawNames = attribute.Value
-			case "altname":
-				title = strings.TrimSpace(attribute.Value)
-			}
-		}
-		if rawNames == "" || title == "" {
-			continue
-		}
-		for _, rawName := range strings.Split(rawNames, ",") {
-			name := strings.ToLower(strings.TrimSpace(rawName))
-			if name != "" {
-				names[name] = title
-			}
-		}
-	}
+	names, _ = games.ReadNeoGeoNames(bytes.NewReader(data))
 	return names
 }

--- a/pkg/games/neogeo.go
+++ b/pkg/games/neogeo.go
@@ -1,0 +1,95 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/mister/catalog"
+)
+
+// ReadNeoGeoNames reads MiSTer's romsets.xml aliases and display titles.
+// Malformed XML never returns a partial mapping. Empty aliases and titles are
+// ignored, preserving Favorites' naming rules.
+func ReadNeoGeoNames(reader io.Reader) (map[string]string, error) {
+	names := make(map[string]string)
+	decoder := xml.NewDecoder(reader)
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return names, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode NeoGeo ROM sets: %w", err)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Local != "romset" {
+			continue
+		}
+		var rawNames, title string
+		for _, attribute := range start.Attr {
+			switch attribute.Name.Local {
+			case "name":
+				rawNames = attribute.Value
+			case "altname":
+				title = strings.TrimSpace(attribute.Value)
+			}
+		}
+		if rawNames == "" || title == "" {
+			continue
+		}
+		for _, rawName := range strings.Split(rawNames, ",") {
+			name := strings.ToLower(strings.TrimSpace(rawName))
+			if name != "" {
+				names[name] = title
+			}
+		}
+	}
+}
+
+// NeoGeoMGLOverride mounts a NeoGeo ROM set using the catalog's .neo slot.
+// The caller supplies the MGL-relative path and is responsible for identifying
+// directory/ZIP sets. Unlike runtime system hooks, this performs no file writes.
+func NeoGeoMGLOverride(system *System, mountPath string) (string, error) {
+	if system == nil || system.Id != "NeoGeo" {
+		return "", errors.New("NeoGeo MGL override requires a NeoGeo system")
+	}
+	core := CatalogCore(system)
+	// ZIPs and extracted sets use the same slot as .neo, but are not scan
+	// extensions in the pinned catalog. Do not duplicate its mount parameters.
+	params, err := catalog.PathToMGLDef(&core, ".neo")
+	if err != nil {
+		return "", fmt.Errorf("resolve NeoGeo ROM-set slot: %w", err)
+	}
+	escaped := strings.NewReplacer(
+		"&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;",
+	).Replace(mountPath)
+	//nolint:gocritic // XML attributes need XML escaping, not Go string quoting.
+	override := fmt.Sprintf("\t<file delay=\"%d\" type=%q index=\"%d\" path=\"%s\"/>\n",
+		params.Delay, params.Method, params.Index, escaped)
+	if params.ResetDelay > 0 {
+		override += fmt.Sprintf("\t<reset delay=\"%d\" hold=\"%d\"/>\n", params.ResetDelay, params.ResetHold)
+	}
+	return override, nil
+}

--- a/pkg/games/neogeo_test.go
+++ b/pkg/games/neogeo_test.go
@@ -1,0 +1,87 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestReadNeoGeoNames(t *testing.T) {
+	names, err := ReadNeoGeoNames(strings.NewReader(`<romsets>
+		<romset name="MSLUG, ms1, ," altname=" Metal &amp; Slug "/>
+		<romset name="ignored" altname=" "/>
+		<romset name="" altname="Ignored"/>
+		<romset name="ms1" altname="Alias title"/>
+	</romsets>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"mslug": "Metal & Slug", "ms1": "Alias title"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("names = %v, want %v", names, want)
+	}
+	names, err = ReadNeoGeoNames(strings.NewReader(`<romsets><romset name="partial" altname="Not valid"/>`))
+	if err == nil || len(names) != 0 {
+		t.Fatalf("malformed XML must not return partial names: %v, %v", names, err)
+	}
+}
+
+func TestNeoGeoMGLOverrideUsesCatalogSlot(t *testing.T) {
+	// Nonstandard parameters prove ZIP/folder support does not hardcode a
+	// second copy of NeoGeo's catalog data.
+	system := &System{Id: "NeoGeo", Slots: []Slot{{
+		Exts: []string{".neo"},
+		Mgl:  &MglParams{Delay: 3, Method: "s", Index: 2, resetDelay: 4, resetHold: 5},
+	}}}
+	override, err := NeoGeoMGLOverride(system, `Picks/A & B "Special" <set>.zip`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "\t<file delay=\"3\" type=\"s\" index=\"2\" " +
+		"path=\"Picks/A &amp; B &quot;Special&quot; &lt;set&gt;.zip\"/>\n" +
+		"\t<reset delay=\"4\" hold=\"5\"/>\n"
+	if override != want {
+		t.Fatalf("override = %q, want %q", override, want)
+	}
+	for _, invalid := range []*System{nil, {Id: "NES"}, {Id: "NeoGeo"}} {
+		if _, err := NeoGeoMGLOverride(invalid, "set"); err == nil {
+			t.Fatalf("expected invalid system or missing-slot error: %+v", invalid)
+		}
+	}
+}
+
+func FuzzReadNeoGeoNames(f *testing.F) {
+	f.Add(`<romsets><romset name="mslug,ms1" altname="Metal Slug"/></romsets>`)
+	f.Add(`<romsets><romset name="partial" altname="Title"/>`)
+	f.Add("")
+	f.Fuzz(func(t *testing.T, data string) {
+		names, err := ReadNeoGeoNames(strings.NewReader(data))
+		if err != nil && len(names) != 0 {
+			t.Fatal("invalid XML returned a partial mapping")
+		}
+		for name, title := range names {
+			if name == "" || name != strings.ToLower(strings.TrimSpace(name)) || strings.TrimSpace(title) == "" {
+				t.Fatalf("invalid mapping: %q => %q", name, title)
+			}
+		}
+	})
+}

--- a/pkg/gamesmenu/generate.go
+++ b/pkg/gamesmenu/generate.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/wizzomafizzo/mrext/pkg/games"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
 )
@@ -136,6 +137,7 @@ func (m *Manager) Generate(selected []Entry, progress func(Progress)) (GenerateR
 	for index := range selected {
 		entry := &selected[index]
 		scan.entry, scan.rules = entry, extensionRules(entry.Systems)
+		scan.prepareNeoGeo()
 		scan.visited = make(map[string]bool)
 		for _, folder := range entry.Paths {
 			scan.folder = folder
@@ -163,6 +165,8 @@ type menuScanner struct {
 	menu        string
 	result      *ScanResult
 	entry       *Entry
+	neoGeo      *games.System
+	neoGeoNames map[string]string
 	rules       []extensionRule
 	folder      string
 	visited     map[string]bool
@@ -197,16 +201,19 @@ func (s *menuScanner) walk(dir string) {
 			s.result.fail(fmt.Errorf("stat game %s: %w", full, err))
 			continue
 		}
-		if info.IsDir() {
-			directories = append(directories, full)
-			continue
-		}
-		if !info.Mode().IsRegular() {
+		if !info.IsDir() && !info.Mode().IsRegular() {
 			continue
 		}
 		relative, err := filepath.Rel(s.folder, dir)
 		if err != nil {
 			s.result.fail(fmt.Errorf("resolve game folder: %w", err))
+			continue
+		}
+		if s.writeNeoGeoSet(full, relative, info.IsDir()) {
+			continue
+		}
+		if info.IsDir() {
+			directories = append(directories, full)
 			continue
 		}
 		if strings.EqualFold(filepath.Ext(full), ".zip") {
@@ -288,11 +295,18 @@ func (s *menuScanner) write(full string, folders []string, name string) {
 	if system == nil {
 		return
 	}
+	s.writeShortcut(full, folders, strings.TrimSuffix(name, filepath.Ext(name))+".mgl", system, "")
+}
+
+func (s *menuScanner) writeShortcut(
+	full string, folders []string, filename string, system *games.System, override string,
+) {
 	s.processed++
 	if s.processed%250 == 0 {
 		s.notify()
 	}
-	components := []string{s.menu, s.entry.MenuFolder}
+	components := make([]string, 0, 2+len(folders))
+	components = append(components, s.menu, s.entry.MenuFolder)
 	for _, component := range folders {
 		components = append(components, s.manager.names.FolderName(component))
 	}
@@ -302,13 +316,12 @@ func (s *menuScanner) write(full string, folders []string, name string) {
 		s.result.fail(err)
 		return
 	}
-	filename := strings.TrimSuffix(name, filepath.Ext(name)) + ".mgl"
 	key := strings.ToLower(filename)
 	if existing[key] {
 		s.result.Skipped++
 		return
 	}
-	data, err := mister.GenerateMgl(s.manager.cfg, system, full, "")
+	data, err := mister.GenerateMgl(s.manager.cfg, system, full, override)
 	if err != nil {
 		s.result.fail(fmt.Errorf("generate shortcut for %s: %w", full, err))
 		return

--- a/pkg/gamesmenu/neogeo.go
+++ b/pkg/gamesmenu/neogeo.go
@@ -1,0 +1,109 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesmenu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+// Definitions are shared across the entry's roots so an SD romsets.xml can
+// describe external-drive sets. Earlier roots retain naming priority.
+func (s *menuScanner) prepareNeoGeo() {
+	s.neoGeo, s.neoGeoNames = nil, nil
+	for index := range s.entry.Systems {
+		if s.entry.Systems[index].Id == "NeoGeo" {
+			s.neoGeo = &s.entry.Systems[index]
+			break
+		}
+	}
+	if s.neoGeo == nil {
+		return
+	}
+	s.neoGeoNames = make(map[string]string)
+	for _, folder := range s.entry.Paths {
+		filename, err := games.FindFile(filepath.Join(folder, config.NeoGeoRomsetsFile))
+		if err != nil {
+			continue // A mapping is optional; ordinary .neo files still work.
+		}
+		names, err := readNeoGeoNames(filename)
+		if err != nil {
+			s.result.fail(fmt.Errorf("read %s: %w", filename, err))
+			continue
+		}
+		for name, title := range names {
+			if _, exists := s.neoGeoNames[name]; !exists {
+				s.neoGeoNames[name] = title
+			}
+		}
+	}
+}
+
+func readNeoGeoNames(filename string) (map[string]string, error) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return nil, fmt.Errorf("stat ROM-set mapping: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("ROM-set mapping is not a regular file: %s", filename)
+	}
+	// #nosec G304 -- mapping is discovered under a selected games root.
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("open ROM-set mapping: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	names, err := games.ReadNeoGeoNames(file)
+	if err != nil {
+		return nil, fmt.Errorf("read ROM-set mapping: %w", err)
+	}
+	return names, nil
+}
+
+// A mapped set is one launch target. Never descend into its component ROMs or
+// expand its ZIP as an ordinary collection, even when shortcut creation fails.
+func (s *menuScanner) writeNeoGeoSet(full, relative string, isDirectory bool) bool {
+	if s.neoGeo == nil {
+		return false
+	}
+	name := strings.ToLower(filepath.Base(full))
+	if !isDirectory {
+		if filepath.Ext(name) != ".zip" {
+			return false
+		}
+		name = strings.TrimSuffix(name, ".zip")
+	}
+	title, ok := s.neoGeoNames[name]
+	if !ok {
+		return false
+	}
+	override, err := games.NeoGeoMGLOverride(s.neoGeo, "../../../../.."+filepath.ToSlash(full))
+	if err != nil {
+		s.result.fail(fmt.Errorf("generate NeoGeo set %s: %w", full, err))
+		return true
+	}
+	s.writeShortcut(full, relativeFolders(relative), sanitizeName(title)+".mgl", s.neoGeo, override)
+	return true
+}

--- a/pkg/gamesmenu/neogeo_test.go
+++ b/pkg/gamesmenu/neogeo_test.go
@@ -1,0 +1,162 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package gamesmenu
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateNeoGeoDarksoftSets(t *testing.T) {
+	m := fixture(t)
+	external := t.TempDir()
+	m.cfg.Systems.GamesFolder = append(m.cfg.Systems.GamesFolder, external)
+	m.cfg.Systems.SetCore = []string{"NeoGeo:_Console/CustomNeoGeo"}
+	// A definition on SD also describes sets stored on USB or network roots.
+	put(t, filepath.Join(m.paths.SDRoot, "games", "NEOGEO", "ROMSETS.XML"),
+		`<romsets><romset name="mslug, MS1" altname="Metal Slug"/>`+
+			`<romset name="samsho" altname="Samurai/Shodown: Special"/></romsets>`)
+	base := filepath.Join(external, "games", "NEOGEO")
+	set := filepath.Join(base, `Picks & "More"`, "MS1")
+	put(t, filepath.Join(set, "crom0"), "rom")
+	put(t, filepath.Join(set, "prom.bin"), "component, not a NeoGeoCD game")
+	put(t, filepath.Join(set, "nested", "wrong.neo"), "not a separate game")
+	createZip(t, filepath.Join(base, "SAMSHO.ZIP"), "crom0", "prom.bin", "wrong.neo")
+	createZip(t, filepath.Join(base, "collection.zip"), "loose.neo")
+	put(t, filepath.Join(base, "ordinary.neo"), "rom")
+	put(t, filepath.Join(base, "unknown", "crom0"), "rom")
+	entries := discover(t, m)
+	if len(entries) != 1 {
+		t.Fatalf("entries: %+v", entries)
+	}
+	result := generate(t, m, entries)
+	if result.Scan.Created != 4 {
+		t.Fatalf("expected two sets and two ordinary games: %+v", result)
+	}
+	output := filepath.Join(m.paths.MenuFolder, entries[0].MenuFolder)
+	checks := []struct{ shortcut, target string }{
+		{filepath.Join(`_Picks & "More"`, "Metal Slug.mgl"), set},
+		{"Samurai & Shodown  Special.mgl", filepath.Join(base, "SAMSHO.ZIP")},
+		{"loose.mgl", filepath.Join(base, "collection.zip") + "/loose.neo"},
+		{"ordinary.mgl", filepath.Join(base, "ordinary.neo")},
+	}
+	type mglFile struct {
+		Path  string `xml:"path,attr"`
+		Type  string `xml:"type,attr"`
+		Index int    `xml:"index,attr"`
+		Delay int    `xml:"delay,attr"`
+	}
+	for _, check := range checks {
+		data := read(t, filepath.Join(output, check.shortcut))
+		var doc struct {
+			RBF  string  `xml:"rbf"`
+			File mglFile `xml:"file"`
+		}
+		if err := xml.Unmarshal([]byte(data), &doc); err != nil {
+			t.Fatalf("invalid MGL: %s: %v", data, err)
+		}
+		if doc.RBF != "_Console/CustomNeoGeo" || doc.File.Path != "../../../../.."+check.target ||
+			doc.File.Type != "f" || doc.File.Index != 1 || doc.File.Delay != 1 {
+			t.Fatalf("unexpected MGL: %s", data)
+		}
+	}
+	result = generate(t, m, entries)
+	if result.Scan.Created != 0 || result.Scan.Skipped != 4 {
+		t.Fatalf("regeneration: %+v", result)
+	}
+	cleaned, err := m.CleanUp(nil)
+	if err != nil || cleaned.Checked != 4 || cleaned.Removed != 0 || cleaned.Unreadable != 0 {
+		t.Fatalf("existing sets must survive cleanup: %+v, %v", cleaned, err)
+	}
+	if removeErr := os.RemoveAll(set); removeErr != nil {
+		t.Fatal(removeErr)
+	}
+	if removeErr := os.Remove(filepath.Join(base, "SAMSHO.ZIP")); removeErr != nil {
+		t.Fatal(removeErr)
+	}
+	cleaned, err = m.CleanUp(nil)
+	if err != nil || cleaned.Removed != 2 || cleaned.Unreadable != 0 {
+		t.Fatalf("missing sets must be removed: %+v, %v", cleaned, err)
+	}
+}
+
+func TestGenerateNeoGeoSymlinksCollisionsAndRootPriority(t *testing.T) {
+	m := fixture(t)
+	external := t.TempDir()
+	m.cfg.Systems.GamesFolder = append(m.cfg.Systems.GamesFolder, external)
+	base := filepath.Join(m.paths.SDRoot, "games", "NEOGEO")
+	put(t, filepath.Join(base, "romsets.xml"),
+		`<romsets><romset name="set,link.with.dot" altname="Game v1.0"/></romsets>`)
+	put(t, filepath.Join(external, "games", "NEOGEO", "romsets.xml"),
+		`<romsets><romset name="set" altname="Wrong title"/></romsets>`)
+	put(t, filepath.Join(external, "games", "NEOGEO", "set", "crom0"), "rom")
+	target := filepath.Join(external, "ROM data")
+	put(t, filepath.Join(target, "crom0"), "rom")
+	if err := os.Symlink(target, filepath.Join(base, "link.with.dot")); err != nil {
+		t.Fatal(err)
+	}
+	createZip(t, filepath.Join(base, "set.zip"), "crom0")
+	createZip(t, filepath.Join(base, ".hidden.zip"), "ignored.neo")
+	entries := discover(t, m)
+	result := generate(t, m, entries)
+	if result.Scan.Created != 1 || result.Scan.Skipped != 2 {
+		t.Fatalf("mapped aliases must collide without exposing components: %+v", result)
+	}
+	shortcut := filepath.Join(m.paths.MenuFolder, entries[0].MenuFolder, "Game v1.0.mgl")
+	original := read(t, shortcut)
+	if !strings.Contains(original, "link.with.dot") {
+		t.Fatalf("expected linked directory mount, got %s", original)
+	}
+	put(t, shortcut, "user content")
+	result = generate(t, m, entries)
+	if result.Scan.Created != 0 || result.Scan.Skipped != 3 || read(t, shortcut) != "user content" {
+		t.Fatalf("custom set shortcut must not be replaced: %+v", result)
+	}
+}
+
+func TestGenerateNeoGeoWithoutValidMapping(t *testing.T) {
+	for _, metadata := range []string{"", `<romsets><romset name="set" altname="Partial"/>`} {
+		t.Run(metadata, func(t *testing.T) {
+			m := fixture(t)
+			base := filepath.Join(m.paths.SDRoot, "games", "NEOGEO")
+			put(t, filepath.Join(base, "set", "crom0"), "rom")
+			createZip(t, filepath.Join(base, "set.zip"), "crom0")
+			put(t, filepath.Join(base, "ordinary.neo"), "rom")
+			if metadata != "" {
+				put(t, filepath.Join(base, "romsets.xml"), metadata)
+			}
+			result, err := m.Generate(discover(t, m), nil)
+			if err != nil || result.Scan.Created != 1 {
+				t.Fatalf("ordinary .neo must still work: %+v, %v", result, err)
+			}
+			if metadata == "" && result.Scan.Failed != 0 {
+				t.Fatalf("missing optional mapping: %+v", result)
+			}
+			if metadata != "" && (result.Scan.Failed != 1 ||
+				!strings.Contains(result.Scan.Errors[0].Error(), "romsets.xml")) {
+				t.Fatalf("invalid mapping must be reported without partial set recognition: %+v", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Recognize Darksoft folders and whole-set ZIPs through `romsets.xml`, including aliases and external storage, without exposing individual ROM components.
- Share existing Favorites parsing and catalog-based NeoGeo mount generation within mrext; preserve Favorites relative paths and ordinary `.neo` behavior.
- Add regression coverage for naming, escaping, collisions, symlinks, malformed mappings, and cleanup; document compatibility and setup.
- No Zaparoo Core changes or runtime hook execution during menu generation.

Closes #175

## Validation
- `mage test`
- `mage lint`
- `mage mister gamesmenu`
- `mage mister favorites`
- Shared XML parser fuzzing (5 seconds)
- `git diff --check`
- No device testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for NeoGeo Darksoft ROM sets defined through `romsets.xml`.
  - Generates named launch shortcuts for recognized NeoGeo sets stored in folders or ZIP files.
  - Supports custom catalog launch parameters, including reset behavior.

- **Bug Fixes**
  - Improved Favorites compatibility for ZIP and `.neo` launchers while preserving relative NeoGeo paths.
  - Cleanup now removes shortcuts for missing NeoGeo sets or ZIP contents.

- **Documentation**
  - Added guidance covering NeoGeo set recognition, naming, storage, validation, and shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->