### PR TITLE
fix(favorites): preserve renamed core favorites across updates

### DIFF
--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -31,6 +31,8 @@ Run `favorites` from MiSTer's Scripts menu.
 
 The Go version preserves Python Favorites' folder discovery, top-level destinations, nested folder management, startup refresh hook, LLAPI/YC selection, root filtering, external-drive shortcut, ZIP traversal, NeoGeo names and relative paths, dated-core repair, and safe link-based core favorites. Symlinked game directories remain browsable.
 
+Core-update repair now recognizes the date in the symlink target rather than requiring it in the favorite's name. Renaming a core favorite no longer prevents its repair after an update.
+
 Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog.
 
 ## Settings screen
@@ -142,7 +144,7 @@ Favorites preserves non-interactive startup behavior:
 /media/fat/Scripts/favorites.sh refresh
 ```
 
-This removes broken unversioned core shortcuts and relinks broken dated shortcuts when an updated matching core exists. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
+Refresh repairs shortcuts whose target is a dated core (such as `NES_20260101.rbf`), even when the favorite has a custom name such as `Nintendo.rbf`. Custom names are preserved; dated favorite names follow the replacement core's date. Both absolute and relative symlink targets are supported. Broken shortcuts without a replacement are removed. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
 
 ## Safety
 

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -486,6 +486,40 @@ func TestRefreshUpdatesVersionedCoreSymlink(t *testing.T) {
 	}
 }
 
+func TestRefreshPreservesCustomCoreFavoriteName(t *testing.T) {
+	for _, relative := range []bool{false, true} {
+		t.Run(fmt.Sprintf("relative=%t", relative), func(t *testing.T) {
+			manager, _, root := newTestManager(t)
+			folder := filepath.Join(root, "_@Favorites")
+			coreFolder := filepath.Join(root, "_Console")
+			for _, path := range []string{folder, coreFolder} {
+				if err := os.MkdirAll(path, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			oldCore := filepath.Join(coreFolder, "NES_20250101.rbf")
+			newCore := filepath.Join(coreFolder, "NES_20260101.rbf")
+			if err := os.WriteFile(newCore, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if relative {
+				oldCore = filepath.Join("..", "_Console", filepath.Base(oldCore))
+			}
+			link := filepath.Join(folder, "My_Nintendo.rbf")
+			if err := os.Symlink(oldCore, link); err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.Refresh(); err != nil {
+				t.Fatal(err)
+			}
+			target, err := os.Readlink(link)
+			if err != nil || target != newCore {
+				t.Fatalf("custom favorite lost: target=%q, err=%v", target, err)
+			}
+		})
+	}
+}
+
 func TestRefreshUpdatesRelativeVersionedCoreSymlink(t *testing.T) {
 	manager, _, root := newTestManager(t)
 	folder := filepath.Join(root, "_@Favorites")

--- a/pkg/favorites/manager.go
+++ b/pkg/favorites/manager.go
@@ -553,13 +553,12 @@ func (m *Manager) Refresh() error {
 		if err := os.Remove(favorite.Path); err != nil {
 			return fmt.Errorf("remove broken favorite: %w", err)
 		}
-		if !versionedCorePattern.MatchString(favorite.Path) {
+		// Users can rename a core favorite without retaining its date suffix.
+		// The target identifies the installed core, not the display name.
+		if !versionedCorePattern.MatchString(filepath.Base(resolvedTarget)) {
 			continue
 		}
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(favorite.Path), target)
-		}
-		if err := refreshVersionedCore(favorite.Path, target); err != nil {
+		if err := refreshVersionedCore(favorite.Path, resolvedTarget); err != nil {
 			return err
 		}
 	}
@@ -567,10 +566,6 @@ func (m *Manager) Refresh() error {
 }
 
 func refreshVersionedCore(linkPath, oldTarget string) error {
-	linkPrefix := strings.TrimSuffix(linkPath, filepath.Ext(linkPath))
-	if underscore := strings.LastIndex(linkPrefix, "_"); underscore >= 0 {
-		linkPrefix = linkPrefix[:underscore]
-	}
 	targetPrefix := oldTarget
 	if underscore := strings.LastIndex(targetPrefix, "_"); underscore >= 0 {
 		targetPrefix = targetPrefix[:underscore]
@@ -588,7 +583,12 @@ func refreshVersionedCore(linkPath, oldTarget string) error {
 	if underscore < 0 {
 		return nil
 	}
-	newLink := linkPrefix + newTarget[underscore:]
+	newLink := linkPath
+	if versionedCorePattern.MatchString(filepath.Base(linkPath)) {
+		linkPrefix := strings.TrimSuffix(linkPath, filepath.Ext(linkPath))
+		linkPrefix = linkPrefix[:strings.LastIndex(linkPrefix, "_")]
+		newLink = linkPrefix + newTarget[underscore:]
+	}
 	if err := os.Symlink(newTarget, newLink); err != nil {
 		return fmt.Errorf("link updated core: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Detect dated cores from symlink targets rather than favorite display names.
- Preserve custom names during repair while retaining date updates for dated favorite names.
- Add absolute/relative-target regressions and document refresh behavior.

Closes #160

## Validation
- Regression failed before fix and passed afterward.
- `mage test`
- `mage lint`
- `mage mister favorites`
- `git diff --check`
- No device testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed core shortcut repair when favorites use custom names.
  - Refresh now recognizes dated cores from their target, including absolute and relative shortcut targets.
  - Custom favorite names are preserved while links are updated to the newest core.
  - Dated favorite names continue to reflect the replacement core’s date.

- **Documentation**
  - Updated refresh guidance to describe custom-name preservation and dated core repair behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->