### PR TITLE
docs: add per-app uninstall instructions

### DIFF
--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -184,6 +184,17 @@ Commands are processed one at a time and wait while a core boot sound plays, exa
 
 With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players.
 
+## Uninstall
+
+Remove BGM's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Close the control screen, then run `/media/fat/Scripts/bgm.sh stop` and wait for the service and audio player to exit. Do not reopen the screen afterward: it can start the service again.
+2. Remove the `# Startup BGM` comment and its `bgm.sh $1` command from `/media/fat/linux/user-startup.sh`. Preserve all other startup entries.
+3. Delete `/media/fat/Scripts/bgm.sh`. Optionally back up and remove `/media/fat/music/bgm.ini` to discard BGM settings.
+4. Keep `/media/fat/music/`: tracks, playlists, `.pls` subscriptions, and `boot/` sounds are user content. BGM has no separate persistent database or generated menu tree to remove.
+
+After shutdown, leftover `/tmp/bgm.sock`, `/tmp/bgm.log`, and `/tmp/bgm.sh` can be removed or left until reboot. Keep MiSTer's audio players installed.
+
 ## Local development
 
 Run BGM against a temporary MiSTer root without touching `/media/fat`:

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -144,6 +144,17 @@ Favorites preserves non-interactive startup behavior:
 
 This removes broken unversioned core shortcuts and relinks broken dated shortcuts when an updated matching core exists. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
 
+## Uninstall
+
+Remove Favorites' Downloader subscription if configured, so updates do not reinstall it.
+
+1. Exit Favorites and let any refresh finish. There is no persistent Favorites service to stop.
+2. Remove the `# Startup favorites` comment and its `favorites.sh refresh` command from `/media/fat/linux/user-startup.sh`.
+3. Delete `/media/fat/Scripts/favorites.sh`. Optionally back up and remove `/media/fat/Scripts/favorites.ini` to discard settings, respecting any shared `MREXT_CONFIG` override.
+4. Keep `/media/fat/_@Favorites` and other favorite folders unless you want to remove your curated shortcuts. The folder can be renamed through `default_folder`, and favorites may also be at the SD root or in other menu folders. There is no Favorites database to delete.
+
+If discarding generated entries, remove only selected `.mgl` files and symlinks after inspecting their contents and ownership. Favorites can create `cores` symlinks in the SD root and favorite subfolders. Leave these if other MRA shortcuts use them; otherwise remove only the links, never their `_Arcade/cores` target. Remove symlinks themselves, not their destinations. Keep real core files and custom content.
+
 ## Safety
 
 Favorites never recursively deletes a folder containing user files. Folder deletion succeeds only when folder is empty or contains only managed `cores` symlink. Existing configuration files, non-symlink `cores` entries, and unrelated menu content are left untouched.

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -94,6 +94,16 @@ Intentional differences:
 - Dotfiles, AppleDouble files and hidden ZIP members are skipped. Absolute and parent-traversing ZIP paths are rejected, but harmless `./` and repeated separators are accepted. Exact ZIP member names and Python's `_.`/`_` menu-folder quirks are preserved (for example, `./game.nes` creates `_./game.mgl`). Output writes are confined to the SD root; symlinks escaping it fail rather than writing elsewhere. Exclusive file creation protects existing shortcuts against concurrent writers.
 - Optional `gamesmenu.ini` and explicit, conservative Clean Up are new. Errors are reported rather than silently discarded (invalid source ZIPs are still silently ignored).
 
+## Uninstall
+
+Remove GamesMenu's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Let generation or cleanup finish, then exit GamesMenu. It installs no startup service; remove any launch commands you added manually.
+2. Delete `/media/fat/Scripts/gamesmenu.sh`. Optionally back up and remove `/media/fat/Scripts/gamesmenu.ini` to discard settings, respecting any shared `MREXT_CONFIG` override.
+3. Keep `/media/fat/_Games` if you still want its shortcuts: they do not need GamesMenu to launch. If removing the menu, inspect and back up the folder first, then remove only entries you no longer want. It may contain hand-edited shortcuts or unrelated user files. Do not use Generate with everything deselected as an uninstall shortcut unless you intend to delete the whole tree.
+
+GamesMenu has no persistent database. Keep `names.txt`, original games, ZIP archives, BIOS files, and shared mrext state. Removing shortcuts does not require deleting their targets.
+
 ## Local development
 
 Use a disposable filesystem, not a mounted live MiSTer:

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -26,6 +26,17 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/last
 
 Once installed, run `lastplayed` from the MiSTer `Scripts` menu, and a prompt will offer to enable LastPlayed as a startup service.
 
+## Uninstall
+
+Remove LastPlayed's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Run `/media/fat/Scripts/lastplayed.sh -service stop` and wait for shutdown. Remove the `# mrext/lastplayed` block and its `lastplayed.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
+2. If `bootcore` in any MiSTer INI points at the Last Played shortcut, disable or change that setting before removing the shortcut. Do not delete the INI or disable `recents` just to uninstall LastPlayed; other apps may use it.
+3. Delete `/media/fat/Scripts/lastplayed.sh`. Optionally back up and remove `/media/fat/Scripts/lastplayed.ini` to discard settings.
+4. Optionally remove `/media/fat/Last Played.mgl` and generated entries in `/media/fat/_Recently Played/`. Use the actual configured names (`last_played_name`, legacy `name`, and `recent_folder_name`) if customized. Inspect the folder for user-added files before deleting anything. Keeping the shortcuts is allowed; they will stop updating.
+
+LastPlayed has no separate database. Keep MiSTer's recents files under `config/` and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/lastplayed.pid`, `/tmp/lastplayed.log`, and `/tmp/lastplayed.sh` are optional cleanup.
+
 ## Configuration
 
 LastPlayed can be configured by creating a `lastplayed.ini` file in the `/media/fat/Scripts` folder where you put `lastplayed.sh`. For example:

--- a/docs/launchsync.md
+++ b/docs/launchsync.md
@@ -33,6 +33,17 @@ LaunchSync must be run manually whenever you want to update subscribed files or 
 
 LaunchSync requires sync files to actually do anything. These are text files ending in `.sync` which define the name of a playlist, the games in it and how to find them on your own system. You can create your own or find sync files other people have created. An example is the [Discord Game of the Month](https://raw.githubusercontent.com/wizzomafizzo/mrext/main/cmd/launchsync/examples/Discord%20Game%20of%20the%20Month.sync) playlist hosted here.
 
+## Uninstall
+
+Remove LaunchSync's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Let any update finish and exit LaunchSync. It installs no startup service; remove any scheduled or startup invocations you added yourself.
+2. Delete `/media/fat/Scripts/launchsync.sh`. Optionally back up and remove `/media/fat/Scripts/launchsync.ini` if present, respecting any shared configuration override.
+3. Preserve your `.sync` files by default: they contain subscriptions or authored game lists. To unsubscribe permanently, remove only the `.sync` files you no longer want from their actual locations.
+4. Generated folders live beside each `.sync` file, named from its top-level `name` field with an underscore prefix. Keep them to retain static shortcuts, or inspect and remove their generated `.mgl` files, arcade `.mra` links, and `[NOT FOUND].mgl` placeholders. Do not remove unrelated files or follow `cores` symlinks into the real arcade cores directory. Removing a `.sync` file does not by itself remove its generated folder.
+
+The game index at `/media/fat/Scripts/.config/mrext/games.db` is shared with Search and Remote; leave it in place when either remains installed. Keep original games, arcade MRAs, and shared metadata. There is no separate LaunchSync service database to delete.
+
 ## Creating Sync Files
 
 *NOTE: Check the [Systems](https://github.com/wizzomafizzo/mrext/blob/main/docs/systems.md) page to see what cores are supported. Most consoles are, most computers aren't. Use the ID or Alias listed on that page for the `system` field.*

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -31,6 +31,16 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/play
 
 From this point, PlayLog will always run on boot and silently track game playing stats in the background. At any point you can run `playlog` again and see a summary report of the stats.
 
+## Uninstall
+
+Remove PlayLog's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Run `/media/fat/Scripts/playlog.sh -service stop` and wait for shutdown and database writes to finish. Remove the `# mrext/playlog` block and its `playlog.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
+2. Delete `/media/fat/Scripts/playlog.sh`. Optionally back up and remove `/media/fat/Scripts/playlog.ini` to discard settings and hook configuration.
+3. **Preserve `/media/fat/playlog.db` unless you intend to erase your play history and totals.** After the service stops, back up the database together with any `playlog.db-wal`, `playlog.db-shm`, or `playlog.db-journal` sidecars present. Keep that set together; do not delete sidecars independently. Only discard the database and remaining sidecars when intentionally removing all history.
+
+PlayLog generates no menu folder. Custom scripts referenced by its state hooks belong to you and may be shared; removing PlayLog does not require deleting them. Keep MiSTer recents/configuration and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/playlog.pid`, `/tmp/playlog.log`, and `/tmp/playlog.sh` are optional cleanup.
+
 ## Configuration
 
 PlayLog can be configured by creating a `playlog.ini` file in the `/media/fat/Scripts` folder where you put `playlog.sh`. For example:

--- a/docs/random.md
+++ b/docs/random.md
@@ -36,6 +36,16 @@ Example of Commodore 64 being ignored: `random.sh -filter all -ignore c64`
 
 A `-noscan` flag is also available which will use a slightly faster but less random method to pick a game. It instead traverses folders at random until it finds a game, meaning results will be weighted by folder depth.
 
+## Uninstall
+
+Remove Random's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Let any Random invocation finish. It installs no startup service; remove custom startup, scheduled, or wrapper-script invocations you added yourself.
+2. Delete `/media/fat/Scripts/random.sh`. Optionally back up and remove `/media/fat/Scripts/random.ini` if present, respecting any shared configuration override.
+3. Remove only custom Random wrapper scripts you created and no longer need. Random has no dedicated persistent game database or generated menu tree to delete; keep original games and other apps' shortcuts.
+
+Keep shared `.LASTLAUNCH.mgl` and `Scripts/.config/mrext/` files for other mrext apps. Removing Random does not stop a core it already launched.
+
 ## Custom Launchers
 
 Random can be customised by creating your own shell scripts which call `random.sh` with the above arguments.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -51,20 +51,28 @@ From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The 
 
 ## Uninstall
 
-After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.
+Remove Remote's Downloader subscription if configured, so updates do not reinstall it.
 
-### Manual
+### Built-in uninstall
 
-To manually uninstall Remote from your MiSTer, delete these files from the SD card:
+The Scripts-menu interface offers **Uninstall**. The console equivalent is `/media/fat/Scripts/remote.sh -uninstall`.
 
-* `Scripts/remote.sh`
-* `Scripts/remote.ini` (if present)
-* `search.db` (this file is also used by Search if you have it installed)
+This requests service shutdown, removes the `mrext/remote` startup entry, deletes legacy `/media/fat/search.db` if present, and removes `menu.jpg`/`menu.png` **when they are symlinks**. It does not check who created those links. Back up the legacy database if older apps still use it; choose manual uninstall below if you want to retain the active wallpaper links. Original wallpaper images are not removed.
 
-If you have an active wallpaper set by Remote, you will also need to remove `menu.png` or `menu.jpg`. These are just links to the actual file in the `wallpapers` folder.
+The command leaves `Scripts/remote.sh`, `Scripts/remote.ini`, and the current shared `Scripts/.config/mrext/games.db` in place. Check reported errors and confirm the service has stopped, then remove the binary yourself and optionally preserve or delete its INI. Keep any INI selected through `MREXT_CONFIG` if another app uses it.
 
-Finally, remove the following lines from `linux/user-startup.sh`:
-```
-# mrext/remote
-[[ -e /media/fat/Scripts/remote.sh ]] && /media/fat/Scripts/remote.sh -service $1
-```
+### Manual uninstall
+
+1. Run `/media/fat/Scripts/remote.sh -service stop` and wait for shutdown. Close Remote's browser interface.
+2. Back up `/media/fat/linux/user-startup.sh`, then remove only this block (paths may be quoted or customized):
+
+   ```sh
+   # mrext/remote
+   [[ -e /media/fat/Scripts/remote.sh ]] && /media/fat/Scripts/remote.sh -service $1
+   ```
+
+3. Delete `/media/fat/Scripts/remote.sh`. Optionally back up and remove `/media/fat/Scripts/remote.ini` to discard settings, respecting any shared configuration override.
+4. Keep `/media/fat/Scripts/.config/mrext/games.db` for Search or LaunchSync. The legacy `/media/fat/search.db` is optional cleanup only when no older app needs it. Do not delete the shared `.config/mrext` directory.
+5. Keep wallpaper images, screenshots, and menu shortcuts you created through Remote. If you no longer want the active wallpaper, remove only verified `menu.png`/`menu.jpg` symlinks, not their targets or regular files at those paths. Check `cores` links before removing any generated MRA shortcuts; other menu entries may still need them.
+
+After shutdown, `/tmp/remote.pid`, `/tmp/remote.log`, and `/tmp/remote.sh` are optional cleanup. Uninstall does not reset MiSTer settings, network settings, or SSH authorization; keep shared INIs and `authorized_keys` files.

--- a/docs/search.md
+++ b/docs/search.md
@@ -29,8 +29,14 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/sear
 
 ## Updating the Index
 
-At the moment, re-indexing of games must be triggered manually. You might need to do this if you've made changes to the games on your MiSTer.
+To force a rebuild, first exit Search and LaunchSync and stop Remote if it is running. After all users have stopped, remove the current shared index at `/media/fat/Scripts/.config/mrext/games.db`, then launch Search to rebuild it. This affects Search, Remote, and LaunchSync, not your game files. `/media/fat/search.db` is a legacy index, not the current database.
 
-Just delete this file: `/media/fat/search.db`
+## Uninstall
 
-Search will create a new database next time you launch it.
+Remove Search's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Finish any indexing operation and exit Search. It installs no startup service; remove launch commands you added manually, if any.
+2. Delete `/media/fat/Scripts/search.sh`. Optionally back up and remove `/media/fat/Scripts/search.ini` if present, respecting any shared configuration override.
+3. Keep `/media/fat/Scripts/.config/mrext/games.db` while Remote or LaunchSync uses it. If none of those apps remain, the index can be removed after they have stopped; it contains rebuildable game names and paths, not ROMs. Older releases may still use `/media/fat/search.db`, so check before deleting that legacy file.
+
+Search creates no dedicated menu tree or history database. Preserve your games, existing shortcuts, shared `.LASTLAUNCH.mgl`, and `Scripts/.config/mrext/ArcadeDatabase.csv`.


### PR DESCRIPTION
## Summary
- Add self-contained uninstall instructions for all nine retained apps.
- Cover service shutdown, startup entries, binaries, optional settings removal, and relevant shared/user-data precautions.
- Correct Remote uninstall behavior and Search shared-index path.
- No separate uninstall guide.

Closes #18

## Validation
- Checked commands and file ownership against implementation.
- `git diff --check`; no dangling standalone-guide references.
- Go tests/builds skipped: documentation only.