### PR TITLE
fix(remote): rebuild shared index safely with bounded batches

### DIFF
--- a/cmd/launchsync/index_test.go
+++ b/cmd/launchsync/index_test.go
@@ -1,0 +1,48 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+func TestRequiredSystemsDeduplicatesLargePlaylist(t *testing.T) {
+	nes, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snes, err := games.GetSystem("SNES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	playlist := syncFile{games: make([]syncFileGame, 20000)}
+	for index := range playlist.games {
+		playlist.games[index].system = nes
+	}
+	systems := requiredSystems([]syncFile{playlist, playlist, {games: []syncFileGame{{system: snes}}}})
+	if len(systems) != 2 || systems[0].Id != "NES" || systems[1].Id != "SNES" {
+		t.Fatalf("repeated playlist entries expanded system list: %+v", systems)
+	}
+	if len(requiredSystems(nil)) != 0 {
+		t.Fatal("empty playlist should not request indexing")
+	}
+}

--- a/cmd/launchsync/syncfiles.go
+++ b/cmd/launchsync/syncfiles.go
@@ -228,17 +228,24 @@ func updateSyncFile(sync *syncFile) (syncFile, bool, error) {
 	return newSync, true, nil
 }
 
-func makeIndex(cfg *config.UserConfig, syncs []syncFile) error {
-	// restrict index to necessary systems
+func requiredSystems(syncs []syncFile) []games.System {
 	var systems []games.System
+	seen := make(map[string]bool)
 	for syncIndex := range syncs {
 		sync := &syncs[syncIndex]
 		for gameIndex := range sync.games {
 			game := &sync.games[gameIndex]
-			systems = append(systems, *game.system)
+			if !seen[game.system.Id] {
+				seen[game.system.Id] = true
+				systems = append(systems, *game.system)
+			}
 		}
 	}
+	return systems
+}
 
+func makeIndex(cfg *config.UserConfig, syncs []syncFile) error {
+	systems := requiredSystems(syncs)
 	if len(systems) == 0 {
 		return nil
 	}

--- a/cmd/remote/games/games.go
+++ b/cmd/remote/games/games.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/wizzomafizzo/mrext/cmd/remote/menu"
@@ -59,15 +60,21 @@ type Index struct {
 }
 
 func GetIndexingStatus() string {
+	return IndexInstance.status(gamesdb.DBExists())
+}
+
+func (s *Index) status(exists bool) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	status := "indexStatus:"
 
-	if gamesdb.DBExists() {
+	if exists {
 		status += "y,"
 	} else {
 		status += "n,"
 	}
 
-	if IndexInstance.Indexing {
+	if s.Indexing {
 		status += "y,"
 	} else {
 		status += "n,"
@@ -75,28 +82,38 @@ func GetIndexingStatus() string {
 
 	status += fmt.Sprintf(
 		"%d,%d,%s",
-		IndexInstance.TotalSteps,
-		IndexInstance.CurrentStep,
-		IndexInstance.CurrentDesc,
+		s.TotalSteps,
+		s.CurrentStep,
+		strings.NewReplacer(",", ";", "\n", " ", "\r", " ").Replace(s.CurrentDesc),
 	)
 
 	return status
 }
 
 func (s *Index) GenerateIndex(logger *service.Logger, cfg *config.UserConfig) {
-	if s.Indexing {
-		return
-	}
+	s.start(func(update func(gamesdb.IndexStatus)) (int, error) {
+		return gamesdb.RebuildNamesIndex(cfg, games.AllSystems(), update)
+	}, func() {
+		websocket.Broadcast(logger, s.status(gamesdb.DBExists()))
+	}, func(err error) {
+		logger.Error("generate index: indexing: %s", err)
+	})
+}
 
+func (s *Index) start(build func(func(gamesdb.IndexStatus)) (int, error), publish func(), failed func(error)) bool {
 	s.mu.Lock()
+	if s.Indexing {
+		s.mu.Unlock()
+		return false
+	}
 	s.Indexing = true
-
-	websocket.Broadcast(logger, GetIndexingStatus())
-
+	s.TotalSteps, s.CurrentStep = 0, 0
+	s.CurrentDesc = "Finding games folders..."
+	s.mu.Unlock()
+	publish()
 	go func() {
-		defer s.mu.Unlock()
-
-		_, err := gamesdb.NewNamesIndex(cfg, games.AllSystems(), func(status gamesdb.IndexStatus) {
+		_, err := build(func(status gamesdb.IndexStatus) {
+			s.mu.Lock()
 			s.TotalSteps = status.Total
 			s.CurrentStep = status.Step
 			switch status.Step {
@@ -105,25 +122,30 @@ func (s *Index) GenerateIndex(logger *service.Logger, cfg *config.UserConfig) {
 			case status.Total:
 				s.CurrentDesc = "Writing database... (" + strconv.Itoa(status.Files) + " games)"
 			default:
-				system, err := games.GetSystem(status.SystemID)
-				if err != nil {
+				system, lookupErr := games.GetSystem(status.SystemID)
+				if lookupErr != nil {
 					s.CurrentDesc = "Indexing " + status.SystemID + "..."
 				} else {
 					s.CurrentDesc = "Indexing " + system.Name + "..."
 				}
 			}
-			websocket.Broadcast(logger, GetIndexingStatus())
+			s.mu.Unlock()
+			publish()
 		})
 		if err != nil {
-			logger.Error("generate index: indexing: %s", err)
+			failed(err)
 		}
-
+		s.mu.Lock()
 		s.Indexing = false
-		s.TotalSteps = 0
-		s.CurrentStep = 0
+		s.TotalSteps, s.CurrentStep = 0, 0
 		s.CurrentDesc = ""
-		websocket.Broadcast(logger, GetIndexingStatus())
+		if err != nil {
+			s.CurrentDesc = "Index failed: " + err.Error()
+		}
+		s.mu.Unlock()
+		publish()
 	}()
+	return true
 }
 
 func NewIndex() *Index {

--- a/cmd/remote/games/index_test.go
+++ b/cmd/remote/games/index_test.go
@@ -1,0 +1,91 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/gamesdb"
+)
+
+func nextIndexStatus(t *testing.T, updates <-chan string) string {
+	t.Helper()
+	select {
+	case status := <-updates:
+		return status
+	case <-time.After(5 * time.Second):
+		t.Fatal("index status was not published")
+		return ""
+	}
+}
+
+func TestIndexReportsFailureAndRejectsOverlappingBuild(t *testing.T) {
+	index := NewIndex()
+	updates := make(chan string, 10)
+	release := make(chan struct{})
+	failure := errors.New("fixture, scan\nfailed")
+	logged := make(chan error, 1)
+	publish := func() { updates <- index.status(true) }
+	if !index.start(func(update func(gamesdb.IndexStatus)) (int, error) {
+		update(gamesdb.IndexStatus{Total: 3, Step: 2, SystemID: "NES"})
+		<-release
+		return 0, failure
+	}, publish, func(err error) { logged <- err }) {
+		t.Fatal("first build did not start")
+	}
+	if got := nextIndexStatus(t, updates); !strings.HasPrefix(got, "indexStatus:y,y,") {
+		t.Fatalf("initial status = %q", got)
+	}
+	if got := nextIndexStatus(t, updates); !strings.Contains(got, ",3,2,Indexing ") {
+		t.Fatalf("progress status = %q", got)
+	}
+	if index.start(nil, publish, nil) {
+		t.Fatal("overlapping build was accepted")
+	}
+	close(release)
+	want := "indexStatus:y,n,0,0,Index failed: fixture; scan failed"
+	if got := nextIndexStatus(t, updates); got != want {
+		t.Fatalf("failure status = %q, want %q", got, want)
+	}
+	if err := <-logged; !errors.Is(err, failure) {
+		t.Fatalf("logged error = %v", err)
+	}
+	if got := index.status(true); got != want {
+		t.Fatalf("reconnecting client lost failure: %q", got)
+	}
+	if !index.start(func(update func(gamesdb.IndexStatus)) (int, error) {
+		update(gamesdb.IndexStatus{Total: 2, Step: 2, Files: 4})
+		return 4, nil
+	}, publish, func(err error) { logged <- err }) {
+		t.Fatal("retry did not start")
+	}
+	if got := nextIndexStatus(t, updates); strings.Contains(got, "failed") {
+		t.Fatalf("retry retained previous error: %q", got)
+	}
+	if got := nextIndexStatus(t, updates); !strings.Contains(got, "Writing database... (4 games)") {
+		t.Fatalf("writing status = %q", got)
+	}
+	if got := nextIndexStatus(t, updates); got != "indexStatus:y,n,0,0," {
+		t.Fatalf("success status = %q", got)
+	}
+}

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -40,7 +40,7 @@ func generateIndexWindow(cfg *config.UserConfig) error {
 		Current: 1,
 		Total:   100,
 	}, func(update func(tui.ProgressUpdate)) error {
-		_, err := gamesdb.NewNamesIndex(cfg, games.AllSystems(), func(status gamesdb.IndexStatus) {
+		_, err := gamesdb.RebuildNamesIndex(cfg, games.AllSystems(), func(status gamesdb.IndexStatus) {
 			systemName := status.SystemID
 			if system, systemErr := games.GetSystem(status.SystemID); systemErr == nil {
 				systemName = system.Name

--- a/docs/launchsync.md
+++ b/docs/launchsync.md
@@ -33,6 +33,12 @@ LaunchSync must be run manually whenever you want to update subscribed files or 
 
 LaunchSync requires sync files to actually do anything. These are text files ending in `.sync` which define the name of a playlist, the games in it and how to find them on your own system. You can create your own or find sync files other people have created. An example is the [Discord Game of the Month](https://raw.githubusercontent.com/wizzomafizzo/mrext/main/cmd/launchsync/examples/Discord%20Game%20of%20the%20Month.sync) playlist hosted here.
 
+## Indexing large playlists
+
+LaunchSync indexes each required system once, regardless of how many playlist entries use it. Repeated or symlinked references to the same system root are scanned once. Matches stream into bounded batches in a temporary database on SD; they are not accumulated as a whole-library filename list or buffered in `/tmp`. The scanner still needs memory for individual directory/ZIP listings and visited-directory tracking.
+
+Only requested systems are refreshed in the shared `/media/fat/Scripts/.config/mrext/games.db`; unrelated Search/Remote entries are retained. A successful refresh removes stale entries for the requested systems. Failed scans or writes leave the previous index intact. Allow free SD space for a replacement index and do not remove `games.db.lock` while an app is indexing. Playlist matching rules and generated shortcut formats are unchanged.
+
 ## Creating Sync Files
 
 *NOTE: Check the [Systems](https://github.com/wizzomafizzo/mrext/blob/main/docs/systems.md) page to see what cores are supported. Most consoles are, most computers aren't. Use the ID or Alias listed on that page for the `system` field.*

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1790,7 +1790,7 @@ Format: `indexStatus:{exists},{inProgress},{totalSteps},{currentStep},{currentSt
 | `currentStep`            | number  | Current step in the index generation process. Split by system.            |
 | `currentStepDescription` | string  | Description of current step in the index generation process. System name. |
 
-Steps are used for displaying detailed indexing status to the user.
+Steps are used for displaying detailed indexing status to the user. On failure, `inProgress` becomes `n`, step counters reset to zero, and `currentStepDescription` retains an `Index failed: ...` message until the next indexing attempt. Commas and line breaks in descriptions are replaced to preserve the existing five-field format. `exists` continues to describe the published index: a failed regeneration preserves the previous working index, while a failed first build leaves it absent. Successful completion clears the description. An indexing request received while Remote is already indexing does not start a second build.
 
 #### Core status
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,14 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## Rebuilding the search index
+
+Use the regenerate button in Search after moving, renaming, or deleting games. A successful rebuild replaces all names and system metadata in `/media/fat/Scripts/.config/mrext/games.db`, shared with Search and LaunchSync. The legacy root-level `search.db` is not the current index.
+
+Progress and failures appear in the existing indexing status flow. If regeneration fails, the previous index remains usable and the error stays visible until another attempt. Rebuilds stream game matches into bounded database batches on SD rather than keeping a whole-library list in RAM. Directory/ZIP listings and directory-cycle tracking still use memory.
+
+A rebuild needs space beside `games.db` for a replacement index. Do not delete the adjacent `games.db.lock` while any app is indexing; it serializes writers across index replacement. Failed attempts normally clean up their temporary `.games-index-*` files. After a hard interruption, leftover files with that prefix can be removed only when no indexer is running. Mount the libraries you want included before regenerating: absent libraries are omitted from a successful full rebuild.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/docs/search.md
+++ b/docs/search.md
@@ -29,8 +29,6 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/sear
 
 ## Updating the Index
 
-At the moment, re-indexing of games must be triggered manually. You might need to do this if you've made changes to the games on your MiSTer.
+The current shared index is `/media/fat/Scripts/.config/mrext/games.db`, not the legacy `/media/fat/search.db`. If Remote is installed, use its Search regenerate button to rebuild without first deleting the working index. Otherwise, exit Search and LaunchSync, stop Remote if running, then remove `games.db` and reopen Search to create a fresh index. Manual deletion gives up the previous-index fallback, so keep a backup if needed.
 
-Just delete this file: `/media/fat/search.db`
-
-Search will create a new database next time you launch it.
+Full rebuilds remove stale game names and system metadata only after a successful scan. They stage bounded batches on SD before publishing the replacement, leaving an existing working index intact if regeneration fails. Mount all desired game libraries first and allow enough free space for a second index. Leave the adjacent `games.db.lock` in place while any app is indexing; it is shared writer-coordination state.

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -47,4 +47,7 @@ const (
 
 const GamesDB = ScriptsConfigFolder + "/mrext/games.db"
 
+// GamesDBLockSuffix names the persistent writer lock beside the shared index.
+const GamesDBLockSuffix = ".lock"
+
 const LastLaunchFile = SdFolder + "/.LASTLAUNCH.mgl"

--- a/pkg/games/walk.go
+++ b/pkg/games/walk.go
@@ -1,0 +1,108 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/utils"
+)
+
+// WalkFiles emits matching game paths without retaining a whole-library list
+// or changing the process working directory. Directory order and ZIP member
+// matching follow GetFiles; symlink paths remain usable through their aliases.
+func WalkFiles(systemID, root string, visit func(string) error) error {
+	system, err := GetSystem(systemID)
+	if err != nil {
+		return err
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolve game root: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return fmt.Errorf("stat game root: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("game root is not a directory: %s", root)
+	}
+	visited := make(map[string]bool)
+	var walk func(string, string) error
+	walk = func(realRoot, displayRoot string) error {
+		err := filepath.WalkDir(realRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return fmt.Errorf("scan game path: %w", walkErr)
+			}
+			relative, relErr := filepath.Rel(realRoot, path)
+			if relErr != nil {
+				return fmt.Errorf("resolve game path: %w", relErr)
+			}
+			display := filepath.Join(displayRoot, relative)
+			if entry.IsDir() {
+				if visited[path] {
+					return filepath.SkipDir
+				}
+				visited[path] = true
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				target, resolveErr := filepath.EvalSymlinks(path)
+				if resolveErr != nil {
+					return fmt.Errorf("resolve game symlink: %w", resolveErr)
+				}
+				targetInfo, statErr := os.Stat(target)
+				if statErr != nil {
+					return fmt.Errorf("stat game symlink: %w", statErr)
+				}
+				if targetInfo.IsDir() {
+					return walk(target, display)
+				}
+			}
+			if strings.HasSuffix(strings.ToLower(path), ".zip") {
+				members, zipErr := utils.ListZip(path)
+				if zipErr != nil {
+					return nil //nolint:nilerr // GetFiles also ignores invalid archives.
+				}
+				for _, member := range members {
+					if MatchSystemFile(system, member) {
+						if err := visit(filepath.Join(display, member)); err != nil {
+							return err
+						}
+					}
+				}
+				return nil
+			}
+			if MatchSystemFile(system, path) {
+				return visit(display)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("walk games: %w", err)
+		}
+		return nil
+	}
+	return walk(resolved, root)
+}

--- a/pkg/games/walk_test.go
+++ b/pkg/games/walk_test.go
@@ -1,0 +1,89 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"archive/zip"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestWalkFilesMatchesLegacyScanner(t *testing.T) {
+	root, external := t.TempDir(), t.TempDir()
+	for _, path := range []string{filepath.Join(root, "game.nes"), filepath.Join(external, "linked.nes")} {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(external, filepath.Join(root, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(external, "cycle")); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- archive is created only beneath t.TempDir.
+	file, err := os.Create(filepath.Join(root, "pack.zip"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := zip.NewWriter(file)
+	for _, name := range []string{"nested/zip.nes", "ignored.sfc"} {
+		if _, createErr := archive.Create(name); createErr != nil {
+			t.Fatal(createErr)
+		}
+	}
+	if closeErr := archive.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	want, err := GetFiles("NES", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	walkErr := WalkFiles("NES", root, func(path string) error { got = append(got, path); return nil })
+	if walkErr != nil {
+		t.Fatal(walkErr)
+	}
+	slices.Sort(got)
+	slices.Sort(want)
+	if !reflect.DeepEqual(got, want) || len(got) != 3 {
+		t.Fatalf("streamed paths = %v, legacy = %v", got, want)
+	}
+	if after, cwdErr := os.Getwd(); cwdErr != nil || after != cwd {
+		t.Fatalf("scanner changed working directory: %q, %v", after, cwdErr)
+	}
+	failure := errors.New("stop scan")
+	calls := 0
+	err = WalkFiles("NES", root, func(string) error { calls++; return failure })
+	if !errors.Is(err, failure) || calls != 1 {
+		t.Fatalf("callback failure not propagated immediately: %v, calls=%d", err, calls)
+	}
+}

--- a/pkg/gamesdb/gamesdb.go
+++ b/pkg/gamesdb/gamesdb.go
@@ -30,9 +30,7 @@ import (
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/games"
-	"github.com/wizzomafizzo/mrext/pkg/utils"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -54,13 +52,33 @@ func DBExists() bool {
 // Open the gamesdb with the given options. If the database does not exist it
 // will be created and the buckets will be initialized.
 func open(options *bolt.Options) (*bolt.DB, error) {
-	if err := os.MkdirAll(filepath.Dir(config.GamesDB), 0o750); err != nil {
-		return nil, fmt.Errorf("create games database directory: %w", err)
+	return openAt(config.GamesDB, options)
+}
+
+func openAt(path string, options *bolt.Options) (*bolt.DB, error) {
+	readOnly := options != nil && options.ReadOnly
+	if !readOnly {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			return nil, fmt.Errorf("create games database directory: %w", err)
+		}
 	}
 
-	db, err := bolt.Open(config.GamesDB, 0o600, options)
+	db, err := bolt.Open(path, 0o600, options)
 	if err != nil {
 		return nil, fmt.Errorf("open games database: %w", err)
+	}
+
+	if readOnly {
+		if err := db.View(func(tx *bolt.Tx) error {
+			if tx.Bucket([]byte(BucketNames)) == nil {
+				return errors.New("games database has no names index")
+			}
+			return nil
+		}); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("validate games database: %w", err)
+		}
+		return db, nil
 	}
 
 	if err := db.Update(func(txn *bolt.Tx) error {
@@ -78,21 +96,13 @@ func open(options *bolt.Options) (*bolt.DB, error) {
 	return db, nil
 }
 
-// Open the gamesdb with default options for generating names index.
-func openNames() (*bolt.DB, error) {
-	return open(&bolt.Options{
-		NoSync:         true,
-		NoFreelistSync: true,
-	})
-}
-
 func readIndexedSystems(db *bolt.DB) ([]string, error) {
 	var systems []string
 
 	err := db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(BucketNames))
 		v := b.Get([]byte(indexedSystemsKey))
-		if v != nil {
+		if len(v) != 0 {
 			systems = strings.Split(string(v), ",")
 		}
 		return nil
@@ -103,154 +113,11 @@ func readIndexedSystems(db *bolt.DB) ([]string, error) {
 	return systems, nil
 }
 
-func writeIndexedSystems(db *bolt.DB, systems []string) error {
-	if err := db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(BucketNames))
-		v := b.Get([]byte(indexedSystemsKey))
-		if v == nil {
-			v = []byte(strings.Join(systems, ","))
-			if err := b.Put([]byte(indexedSystemsKey), v); err != nil {
-				return fmt.Errorf("write indexed systems: %w", err)
-			}
-			return nil
-		}
-
-		existing := strings.Split(string(v), ",")
-		for _, system := range systems {
-			if !utils.Contains(existing, system) {
-				existing = append(existing, system)
-			}
-		}
-		if err := b.Put([]byte(indexedSystemsKey), []byte(strings.Join(existing, ","))); err != nil {
-			return fmt.Errorf("update indexed systems: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("update indexed systems transaction: %w", err)
-	}
-	return nil
-}
-
-type fileInfo struct {
-	SystemID string
-	Path     string
-}
-
-// Update the names index with the given files.
-func updateNames(db *bolt.DB, files []fileInfo) error {
-	if err := db.Batch(func(tx *bolt.Tx) error {
-		bns := tx.Bucket([]byte(BucketNames))
-
-		for _, file := range files {
-			base := filepath.Base(file.Path)
-			name := strings.TrimSuffix(base, filepath.Ext(base))
-
-			nk := NameKey(file.SystemID, name)
-			if err := bns.Put([]byte(nk), []byte(file.Path)); err != nil {
-				return fmt.Errorf("index game name: %w", err)
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return fmt.Errorf("update names transaction: %w", err)
-	}
-	return nil
-}
-
 type IndexStatus struct {
 	SystemID string
 	Total    int
 	Step     int
 	Files    int
-}
-
-// Given a list of systems, index all valid game files on disk and write a
-// names index to the DB. Overwrites any existing names index, but does not
-// clean up old missing files.
-//
-// Takes a function which will be called with the current status of the index
-// during key steps.
-//
-// Returns the total number of files indexed.
-func NewNamesIndex(
-	cfg *config.UserConfig,
-	systems []games.System,
-	update func(IndexStatus),
-) (int, error) {
-	status := IndexStatus{
-		Total: len(systems) + 1,
-		Step:  1,
-	}
-
-	db, err := openNames()
-	if err != nil {
-		return status.Files, fmt.Errorf("error opening gamesdb: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	update(status)
-	systemPaths := make(map[string][]string, 0)
-	paths := games.GetSystemPaths(cfg, systems)
-	for i := range paths {
-		systemPaths[paths[i].System.Id] = append(systemPaths[paths[i].System.Id], paths[i].Path)
-	}
-
-	g := new(errgroup.Group)
-
-	for _, k := range utils.AlphaMapKeys(systemPaths) {
-		status.SystemID = k
-		status.Step++
-		update(status)
-
-		files := make([]fileInfo, 0)
-
-		for _, path := range systemPaths[k] {
-			pathFiles, filesErr := games.GetFiles(k, path)
-			if filesErr != nil {
-				return status.Files, fmt.Errorf("error getting files: %w", filesErr)
-			}
-
-			if len(pathFiles) == 0 {
-				continue
-			}
-
-			for pf := range pathFiles {
-				files = append(files, fileInfo{SystemID: k, Path: pathFiles[pf]})
-			}
-		}
-
-		if len(files) == 0 {
-			continue
-		}
-
-		status.Files += len(files)
-
-		g.Go(func() error {
-			return updateNames(db, files)
-		})
-	}
-
-	status.Step++
-	status.SystemID = ""
-	update(status)
-
-	err = g.Wait()
-	if err != nil {
-		return status.Files, fmt.Errorf("error updating names index: %w", err)
-	}
-
-	err = writeIndexedSystems(db, utils.AlphaMapKeys(systemPaths))
-	if err != nil {
-		return status.Files, fmt.Errorf("error writing indexed systems: %w", err)
-	}
-
-	err = db.Sync()
-	if err != nil {
-		return status.Files, fmt.Errorf("error syncing database: %w", err)
-	}
-
-	return status.Files, nil
 }
 
 type SearchResult struct {
@@ -265,11 +132,13 @@ func searchNamesGeneric(
 	query string,
 	test func(string, string) bool,
 ) ([]SearchResult, error) {
-	if !DBExists() {
-		return nil, errors.New("gamesdb does not exist")
-	}
+	return searchNamesAt(config.GamesDB, systems, query, test)
+}
 
-	db, err := open(&bolt.Options{ReadOnly: true})
+func searchNamesAt(
+	path string, systems []games.System, query string, test func(string, string) bool,
+) ([]SearchResult, error) {
+	db, err := openAt(path, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return nil, fmt.Errorf("open games database for search: %w", err)
 	}

--- a/pkg/gamesdb/gamesdb_test.go
+++ b/pkg/gamesdb/gamesdb_test.go
@@ -1,0 +1,329 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+	bolt "go.etcd.io/bbolt"
+)
+
+func indexFixture(t *testing.T) (string, []games.System, []games.PathResult) {
+	t.Helper()
+	root := t.TempDir()
+	db := filepath.Join(root, "games.db")
+	systems := make([]games.System, 0, 2)
+	paths := make([]games.PathResult, 0, 2)
+	for _, id := range []string{"NES", "SNES"} {
+		system, lookupErr := games.GetSystem(id)
+		if lookupErr != nil {
+			t.Fatal(lookupErr)
+		}
+		folder := filepath.Join(root, id)
+		if mkdirErr := os.Mkdir(folder, 0o750); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+		ext := ".nes"
+		if id == "SNES" {
+			ext = ".sfc"
+		}
+		for _, name := range []string{"deleted", "renamed"} {
+			if writeErr := os.WriteFile(filepath.Join(folder, name+ext), nil, 0o600); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+		}
+		systems = append(systems, *system)
+		paths = append(paths, games.PathResult{System: *system, Path: folder})
+	}
+	if _, err := indexNames(db, systems, paths, games.WalkFiles, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	return db, systems, paths
+}
+
+func namesSnapshot(t *testing.T, path string) map[string]string {
+	t.Helper()
+	db, err := openAt(path, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	result := make(map[string]string)
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(BucketNames)).ForEach(func(key, value []byte) error {
+			result[string(key)] = string(value)
+			return nil
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestRebuildRemovesDeletedRenamedAndMissingSystems(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	if err := os.Remove(filepath.Join(paths[0].Path, "deleted.nes")); err != nil {
+		t.Fatal(err)
+	}
+	oldName, newName := filepath.Join(paths[0].Path, "renamed.nes"), filepath.Join(paths[0].Path, "new.nes")
+	if err := os.Rename(oldName, newName); err != nil {
+		t.Fatal(err)
+	}
+	var progress []IndexStatus
+	count, err := indexNames(db, systems, paths[:1], games.WalkFiles, func(status IndexStatus) {
+		progress = append(progress, status)
+	}, true)
+	if err != nil || count != 1 {
+		t.Fatalf("rebuild = %d, %v", count, err)
+	}
+	want := map[string]string{indexedSystemsKey: "NES", "NES:new": filepath.Join(paths[0].Path, "new.nes")}
+	if got := namesSnapshot(t, db); !reflect.DeepEqual(got, want) {
+		t.Fatalf("stale names or metadata: %v", got)
+	}
+	last := progress[len(progress)-1]
+	if last.Step != last.Total || last.SystemID != "" || last.Files != 1 {
+		t.Fatalf("final progress = %+v", last)
+	}
+	for _, status := range progress {
+		if status.Step > status.Total {
+			t.Fatalf("progress overflow: %+v", status)
+		}
+	}
+}
+
+func TestPartialIndexPreservesOtherSystems(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	before := namesSnapshot(t, db)
+	if _, err := indexNames(db, systems[:1], nil, games.WalkFiles, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		indexedSystemsKey: "SNES", "SNES:deleted": before["SNES:deleted"], "SNES:renamed": before["SNES:renamed"],
+	}
+	if got := namesSnapshot(t, db); !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial refresh damaged unrelated names or retained missing system: %v", got)
+	}
+	if _, err := indexNames(db, systems[:1], paths[:1], games.WalkFiles, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := namesSnapshot(t, db); !reflect.DeepEqual(got, before) {
+		t.Fatalf("partial refresh failed to restore selected system: %v", got)
+	}
+}
+
+func TestFailedRebuildRollsBackNamesAndMetadata(t *testing.T) {
+	for _, replaceAll := range []bool{false, true} {
+		db, systems, paths := indexFixture(t)
+		before := namesSnapshot(t, db)
+		failure := errors.New("fixture scan failed")
+		scan := func(id, path string, visit func(string) error) error {
+			if id == "SNES" {
+				return failure
+			}
+			return visit(filepath.Join(path, "new.nes"))
+		}
+		if _, err := indexNames(db, systems, paths, scan, nil, replaceAll); !errors.Is(err, failure) {
+			t.Fatalf("scan failure was hidden: %v", err)
+		}
+		if got := namesSnapshot(t, db); !reflect.DeepEqual(got, before) {
+			t.Fatalf("failed scan changed working index: %v", got)
+		}
+		writeFailure := func(_, path string, visit func(string) error) error {
+			return visit(filepath.Join(path, strings.Repeat("x", bolt.MaxKeySize+1)+".nes"))
+		}
+		_, writeErr := indexNames(db, systems, paths, writeFailure, nil, replaceAll)
+		if !errors.Is(writeErr, bolt.ErrKeyTooLarge) {
+			t.Fatalf("write failure was hidden: %v", writeErr)
+		}
+		if got := namesSnapshot(t, db); !reflect.DeepEqual(got, before) {
+			t.Fatalf("failed write changed working index: %v", got)
+		}
+	}
+}
+
+func TestRebuiltIndexSupportsReadOnlySearchAndMetadata(t *testing.T) {
+	path, systems, _ := indexFixture(t)
+	results, err := searchNamesAt(path, systems, "renamed", strings.Contains)
+	if err != nil || len(results) != 2 {
+		t.Fatalf("read-only search = %v, %v", results, err)
+	}
+	reader, err := openAt(path, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	indexed, err := readIndexedSystems(reader)
+	if err != nil || !reflect.DeepEqual(indexed, []string{"NES", "SNES"}) {
+		t.Fatalf("read-only metadata = %v, %v", indexed, err)
+	}
+}
+
+func TestIndexDeduplicatesResolvedSystemPaths(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	alias := filepath.Join(filepath.Dir(db), "alias")
+	if err := os.Symlink(paths[0].Path, alias); err != nil {
+		t.Fatal(err)
+	}
+	repeated := make([]games.PathResult, 0, 20001)
+	for range 20000 {
+		repeated = append(repeated, paths[0])
+	}
+	repeated = append(repeated, games.PathResult{System: systems[0], Path: alias})
+	calls := 0
+	count, err := indexNames(db, systems[:1], repeated, func(_, path string, visit func(string) error) error {
+		calls++
+		for i := range 10000 {
+			if err := visit(filepath.Join(path, fmt.Sprintf("game-%05d.nes", i))); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, nil, true)
+	if err != nil || count != 10000 || calls != 1 {
+		t.Fatalf("duplicate scan: count=%d calls=%d err=%v", count, calls, err)
+	}
+}
+
+func TestIndexWriterBoundsPendingBatch(t *testing.T) {
+	db, err := openAt(filepath.Join(t.TempDir(), "stage.db"), &bolt.Options{NoSync: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	writer := indexWriter{db: db}
+	for i := range 2000 {
+		if err := writer.put(fmt.Sprintf("NES:%d", i), strings.Repeat("x", 2000)); err != nil {
+			t.Fatal(err)
+		}
+		if len(writer.batch) > indexBatchEntries || writer.bytes > indexBatchBytes {
+			t.Fatalf("unbounded pending batch: entries=%d bytes=%d", len(writer.batch), writer.bytes)
+		}
+	}
+	if err := writer.flush(); err != nil {
+		t.Fatal(err)
+	}
+	if len(writer.batch) != 0 || writer.bytes != 0 {
+		t.Fatal("flushed batch retained pending data")
+	}
+	if err := writer.put("NES:oversized", strings.Repeat("x", indexBatchBytes)); err == nil {
+		t.Fatal("oversized entry exceeded batch bound")
+	}
+}
+
+func TestPreviousIndexReadableDuringRebuild(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	before := namesSnapshot(t, db)
+	_, err := indexNames(db, systems, paths, func(_, path string, visit func(string) error) error {
+		if got := namesSnapshot(t, db); !reflect.DeepEqual(got, before) {
+			t.Fatalf("live index changed before publication: %v", got)
+		}
+		return visit(filepath.Join(path, "new.nes"))
+	}, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFailedInitialBuildLeavesNoIndexOrStagedFiles(t *testing.T) {
+	root := t.TempDir()
+	db := filepath.Join(root, "games.db")
+	failure := errors.New("fixture failure")
+	_, err := indexNames(db, nil, []games.PathResult{{System: games.System{Id: "NES"}, Path: root}},
+		func(string, string, func(string) error) error { return failure }, nil, true)
+	if !errors.Is(err, failure) {
+		t.Fatalf("scan error = %v", err)
+	}
+	if _, statErr := os.Stat(db); !os.IsNotExist(statErr) {
+		t.Fatalf("failed initial build left an index: %v", statErr)
+	}
+	matches, err := filepath.Glob(filepath.Join(root, ".games-index-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("staged files leaked: %v, %v", matches, err)
+	}
+}
+
+func TestRebuildHoldsStableWriterLock(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	ctx, release := context.WithCancel(context.Background())
+	defer release()
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := indexNames(db, systems[:1], paths[:1], func(_, path string, visit func(string) error) error {
+			close(started)
+			<-ctx.Done()
+			return visit(filepath.Join(path, "new.nes"))
+		}, nil, true)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer did not start")
+	}
+	lock, err := bolt.Open(db+config.GamesDBLockSuffix, 0o600, &bolt.Options{Timeout: time.Millisecond})
+	if lock != nil {
+		_ = lock.Close()
+	}
+	release()
+	if !errors.Is(err, bolt.ErrTimeout) {
+		t.Fatalf("concurrent writer was not excluded: %v", err)
+	}
+	select {
+	case buildErr := <-done:
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer did not finish")
+	}
+	if _, statErr := os.Stat(db + config.GamesDBLockSuffix); statErr != nil {
+		t.Fatalf("publication removed stable lock file: %v", statErr)
+	}
+}
+
+func TestEmptyFullRebuildClearsIndex(t *testing.T) {
+	db, systems, _ := indexFixture(t)
+	if _, err := indexNames(db, systems, nil, games.WalkFiles, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := namesSnapshot(t, db); !reflect.DeepEqual(got, map[string]string{indexedSystemsKey: ""}) {
+		t.Fatalf("empty rebuild retained names: %v", got)
+	}
+	reader, err := openAt(db, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	indexed, err := readIndexedSystems(reader)
+	if err != nil || len(indexed) != 0 {
+		t.Fatalf("empty metadata = %v, %v", indexed, err)
+	}
+}

--- a/pkg/gamesdb/index.go
+++ b/pkg/gamesdb/index.go
@@ -1,0 +1,251 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package gamesdb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+	"github.com/wizzomafizzo/mrext/pkg/utils"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	indexBatchEntries = 256
+	indexBatchBytes   = 256 * 1024
+)
+
+// NewNamesIndex refreshes requested systems without discarding unrelated
+// systems needed by Search or Remote when LaunchSync indexes a playlist.
+func NewNamesIndex(cfg *config.UserConfig, systems []games.System, update func(IndexStatus)) (int, error) {
+	return generateNamesIndex(cfg, systems, update, false)
+}
+
+// RebuildNamesIndex replaces all names and system metadata after a successful
+// scan. Failed regeneration leaves the previous index available to readers.
+func RebuildNamesIndex(cfg *config.UserConfig, systems []games.System, update func(IndexStatus)) (int, error) {
+	return generateNamesIndex(cfg, systems, update, true)
+}
+
+func generateNamesIndex(
+	cfg *config.UserConfig, systems []games.System, update func(IndexStatus), replaceAll bool,
+) (int, error) {
+	unique := make([]games.System, 0)
+	seen := make(map[string]bool)
+	for i := range systems {
+		system := &systems[i]
+		if !seen[system.Id] {
+			seen[system.Id] = true
+			unique = append(unique, *system)
+		}
+	}
+	if update != nil {
+		update(IndexStatus{Step: 1, Total: len(unique) + 2})
+	}
+	return indexNames(config.GamesDB, unique, games.GetSystemPaths(cfg, unique), games.WalkFiles, update, replaceAll)
+}
+
+// indexNames stages bounded batches beside the live database, never in /tmp.
+// A separate persistent lock serializes writers across atomic file replacement;
+// readers keep using the previous inode until they close their connection.
+func indexNames(
+	filename string, systems []games.System, paths []games.PathResult,
+	scan func(string, string, func(string) error) error, update func(IndexStatus), replaceAll bool,
+) (int, error) {
+	if update == nil {
+		update = func(IndexStatus) {}
+	}
+	if err := os.MkdirAll(filepath.Dir(filename), 0o750); err != nil {
+		return 0, fmt.Errorf("create index directory: %w", err)
+	}
+	lock, err := bolt.Open(filename+config.GamesDBLockSuffix, 0o600, nil)
+	if err != nil {
+		return 0, fmt.Errorf("lock index writer: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+	systemPaths, err := uniquePaths(paths)
+	if err != nil {
+		return 0, err
+	}
+	status := IndexStatus{Total: len(systemPaths) + 2, Step: 1}
+	update(status)
+	temporary, err := os.CreateTemp(filepath.Dir(filename), ".games-index-*")
+	if err != nil {
+		return 0, fmt.Errorf("create staged index: %w", err)
+	}
+	stagedPath := temporary.Name()
+	defer func() { _ = os.Remove(stagedPath) }()
+	if closeErr := temporary.Close(); closeErr != nil {
+		return 0, fmt.Errorf("close staged index file: %w", closeErr)
+	}
+	db, err := openAt(stagedPath, &bolt.Options{NoSync: true, NoFreelistSync: true})
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = db.Close() }()
+	writer := indexWriter{db: db}
+	indexed := make(map[string]bool)
+	if !replaceAll {
+		if err := copyUnselected(filename, systems, &writer, indexed); err != nil {
+			return 0, err
+		}
+	}
+	for _, id := range utils.AlphaMapKeys(systemPaths) {
+		status.SystemID = id
+		status.Step++
+		update(status)
+		for _, path := range systemPaths[id] {
+			if err := scan(id, path, func(file string) error {
+				base := filepath.Base(file)
+				name := strings.TrimSuffix(base, filepath.Ext(base))
+				if err := writer.put(NameKey(id, name), file); err != nil {
+					return err
+				}
+				status.Files++
+				return nil
+			}); err != nil {
+				return status.Files, fmt.Errorf("scan %s: %w", path, err)
+			}
+		}
+		indexed[id] = true
+	}
+	status.Step, status.SystemID = status.Total, ""
+	update(status)
+	if err := writer.put(indexedSystemsKey, strings.Join(utils.AlphaMapKeys(indexed), ",")); err != nil {
+		return status.Files, err
+	}
+	if err := writer.flush(); err != nil {
+		return status.Files, err
+	}
+	if err := db.Sync(); err != nil {
+		return status.Files, fmt.Errorf("sync staged index: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		return status.Files, fmt.Errorf("close staged index: %w", err)
+	}
+	if err := os.Rename(stagedPath, filename); err != nil {
+		return status.Files, fmt.Errorf("publish staged index: %w", err)
+	}
+	return status.Files, nil
+}
+
+func uniquePaths(paths []games.PathResult) (map[string][]string, error) {
+	result := make(map[string][]string)
+	seen := make(map[string]bool)
+	for i := range paths {
+		path := &paths[i]
+		resolved, err := filepath.EvalSymlinks(path.Path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve index root %s: %w", path.Path, err)
+		}
+		key := path.System.Id + ":" + resolved
+		if !seen[key] {
+			seen[key] = true
+			result[path.System.Id] = append(result[path.System.Id], path.Path)
+		}
+	}
+	return result, nil
+}
+
+func copyUnselected(filename string, systems []games.System, writer *indexWriter, indexed map[string]bool) error {
+	db, err := openAt(filename, &bolt.Options{ReadOnly: true})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read previous index: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	selected := make(map[string]bool, len(systems))
+	for i := range systems {
+		selected[systems[i].Id] = true
+	}
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketNames))
+		for _, id := range strings.Split(string(bucket.Get([]byte(indexedSystemsKey))), ",") {
+			if id != "" && !selected[id] {
+				indexed[id] = true
+			}
+		}
+		return bucket.ForEach(func(key, value []byte) error {
+			name := string(key)
+			id, _, _ := strings.Cut(name, ":")
+			if name == indexedSystemsKey || selected[id] {
+				return nil
+			}
+			return writer.put(name, string(value))
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("copy retained index entries: %w", err)
+	}
+	return nil
+}
+
+type indexEntry struct{ key, value string }
+
+type indexWriter struct {
+	db    *bolt.DB
+	batch []indexEntry
+	bytes int
+}
+
+func (w *indexWriter) put(key, value string) error {
+	if len(key) > bolt.MaxKeySize {
+		return fmt.Errorf("index key: %w", bolt.ErrKeyTooLarge)
+	}
+	size := len(key) + len(value)
+	if size > indexBatchBytes {
+		return fmt.Errorf("index entry exceeds batch limit: %d bytes", size)
+	}
+	if len(w.batch) >= indexBatchEntries || w.bytes+size > indexBatchBytes {
+		if err := w.flush(); err != nil {
+			return err
+		}
+	}
+	w.batch = append(w.batch, indexEntry{key: key, value: value})
+	w.bytes += size
+	return nil
+}
+
+func (w *indexWriter) flush() error {
+	if len(w.batch) == 0 {
+		return nil
+	}
+	if err := w.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(BucketNames))
+		for _, entry := range w.batch {
+			if err := bucket.Put([]byte(entry.key), []byte(entry.value)); err != nil {
+				return fmt.Errorf("index game name: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("write index batch: %w", err)
+	}
+	clear(w.batch)
+	w.batch, w.bytes = w.batch[:0], 0
+	return nil
+}

--- a/web/remote/src/components/Search.test.tsx
+++ b/web/remote/src/components/Search.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Search from "./Search";
+
+const mocks = vi.hoisted(() => ({
+  search: {
+    ready: true,
+    indexing: false,
+    totalSteps: 0,
+    currentStep: 0,
+    currentDesc: "",
+  },
+  reset: vi.fn(),
+  refetch: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("../lib/store", () => ({
+  useServerStateStore: () => ({ search: mocks.search }),
+}));
+vi.mock("../lib/queries", () => ({
+  useIndexedSystems: () => ({ data: { systems: [] }, refetch: mocks.refetch }),
+}));
+vi.mock("./WebSocket", () => ({
+  default: () => ({ readyState: 1, sendMessage: mocks.sendMessage }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    mutate: vi.fn(),
+    reset: mocks.reset,
+    isLoading: false,
+  }),
+}));
+vi.mock("./ScrollToTop", () => ({ default: () => null }));
+vi.mock("./Shortcuts", () => ({ SingleShortcut: () => null }));
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(mocks.search, {
+    ready: true,
+    indexing: false,
+    totalSteps: 0,
+    currentStep: 0,
+    currentDesc: "",
+  });
+});
+
+describe("index regeneration", () => {
+  it("shows failed regeneration while keeping the previous index searchable", () => {
+    mocks.search.currentDesc = "Index failed: disk full";
+    render(<Search />);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Index failed: disk full",
+    );
+    expect(screen.getByPlaceholderText("Search")).toBeTruthy();
+  });
+
+  it("shows first-build failure with a retry button", () => {
+    mocks.search.ready = false;
+    mocks.search.currentDesc = "Index failed: unreadable game folder";
+    render(<Search />);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "unreadable game folder",
+    );
+    expect(screen.getByRole("button", { name: "Generate Index" })).toBeTruthy();
+  });
+
+  it("invalidates old results and system choices only after success", () => {
+    mocks.search.indexing = true;
+    const view = render(<Search />);
+    mocks.search.indexing = false;
+    view.rerender(<Search />);
+    expect(mocks.reset).toHaveBeenCalledOnce();
+    expect(mocks.refetch).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps cached results when regeneration fails", () => {
+    mocks.search.indexing = true;
+    const view = render(<Search />);
+    mocks.search.indexing = false;
+    mocks.search.currentDesc = "Index failed: scan interrupted";
+    view.rerender(<Search />);
+    expect(mocks.reset).not.toHaveBeenCalled();
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/remote/src/components/Search.tsx
+++ b/web/remote/src/components/Search.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
 
 import Button from "@mui/material/Button";
+import Alert from "@mui/material/Alert";
 
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -227,6 +228,26 @@ export default function Search() {
     );
   }, [searchGames.data, selectedGame]);
 
+  const wasIndexing = useRef(false);
+  useEffect(() => {
+    if (
+      wasIndexing.current &&
+      !serverState.search.indexing &&
+      !serverState.search.currentDesc
+    ) {
+      searchGames.reset();
+      setSearchSystem("all");
+      void systems.refetch();
+    }
+    wasIndexing.current = serverState.search.indexing;
+  }, [serverState.search.indexing, serverState.search.currentDesc]);
+
+  const indexError = serverState.search.currentDesc ? (
+    <Alert severity="error" sx={{ mb: 2 }}>
+      {serverState.search.currentDesc}
+    </Alert>
+  ) : null;
+
   if (ws.readyState !== WebSocket.OPEN) {
     return <></>;
   }
@@ -254,6 +275,7 @@ export default function Search() {
   if (!serverState.search.ready) {
     return (
       <Box m={2} sx={{ textAlign: "center" }}>
+        {indexError}
         <Typography sx={{ marginBottom: 2 }}>
           Searching needs an index of game files to be created. This is only
           required on first setup, or if the games on disk have changed.
@@ -281,6 +303,7 @@ export default function Search() {
 
   return (
     <Box m={2}>
+      {indexError}
       <Grid
         container
         sx={{ alignItems: "center" }}


### PR DESCRIPTION
## Summary
- Replace stale names and metadata through staged, synced index publication; failures preserve the previous working index.
- Stream matches into bounded batches and deduplicate LaunchSync systems and resolved roots, preserving unrelated systems during partial refresh.
- Fix read-only index opening and expose rebuild failures through existing Remote status/UI; refresh cached results after success.
- Add regression coverage and update Remote, Search, LaunchSync, and API docs.

Closes #20
Closes #24

## Validation
- `mage test` and `mage lint`
- Targeted race tests for gamesdb, games, Remote indexing, and LaunchSync
- Remote web tests and production build
- `mage mister remote`, `mage mister search`, `mage mister launchsync`
- `git diff --check`

## Limits
- No device memory profiling; directory/ZIP listings and visited-directory metadata still use memory.
- Staging requires space for a replacement index beside the live database.
- Web build reports a nonblocking bundle-size warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rebuilt search indexing now supports full and targeted refreshes, preserves unrelated entries, and publishes changes atomically.
  - Search results and indexed systems refresh automatically after successful regeneration.
  - Indexing progress and failure messages are clearer, with failed rebuilds preserving the previous working index.
  - Large playlists are indexed more efficiently without duplicate system processing.
- **Bug Fixes**
  - Prevented overlapping index rebuilds and improved retry behavior after failures.
  - Improved library scanning across directories, symbolic links, and supported archives.
- **Documentation**
  - Updated Search, Remote, and LaunchSync indexing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->