### PR TITLE
fix(remote): use normal screenshot shortcut for API capture

### DIFF
--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -287,7 +287,7 @@ func setupAPI(
 	sub.HandleFunc("/ws", websocket.Handle(logger, wsConnectPayload(trk), wsMsgHandler(kbd, mouse)))
 
 	sub.HandleFunc("/screenshots", screenshots.AllScreenshots(logger)).Methods("GET")
-	sub.HandleFunc("/screenshots", screenshots.TakeScreenshot(logger)).Methods("POST")
+	sub.HandleFunc("/screenshots", screenshots.TakeScreenshot(kbd, logger)).Methods("POST")
 	sub.HandleFunc("/screenshots/{core}/{image}", screenshots.ViewScreenshot(logger)).Methods("GET")
 	sub.HandleFunc("/screenshots/{core}/{image}", screenshots.DeleteScreenshot(logger)).Methods("DELETE")
 

--- a/cmd/remote/screenshots/screenshots.go
+++ b/cmd/remote/screenshots/screenshots.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/input"
 	"github.com/wizzomafizzo/mrext/pkg/service"
 )
 
@@ -124,36 +125,28 @@ func ViewScreenshot(_ *service.Logger) http.HandlerFunc {
 	}
 }
 
-func TakeScreenshot(logger *service.Logger) http.HandlerFunc {
+func TakeScreenshot(kbd input.Keyboard, logger *service.Logger) http.HandlerFunc {
+	return screenshotHandler(kbd.Screenshot, logger.Error, time.Sleep)
+}
+
+func screenshotHandler(
+	capture func() error, logError func(string, ...any), pause func(time.Duration),
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		screenshot := ScreenshotPayload{}
-
-		cmd, err := os.OpenFile(config.CmdInterface, os.O_RDWR, 0)
-		if err != nil {
-			logger.Error("take screenshot: open dev: %s", err)
-			return
-		}
-		defer func(cmd *os.File) {
-			closeErr := cmd.Close()
-			if closeErr != nil {
-				logger.Error("take screenshot: close dev: %s", closeErr)
-			}
-		}(cmd)
-
-		_, err = cmd.WriteString("screenshot\n")
-		if err != nil {
-			logger.Error("take screenshot: write dev: %s", err)
+		// Use the same normal capture shortcut as Control, not the command
+		// interface's capture path which can distort PSX screenshots.
+		if err := capture(); err != nil {
+			logError("take screenshot: keyboard: %s", err)
+			http.Error(w, "Could not request screenshot", http.StatusInternalServerError)
 			return
 		}
 
-		// TODO: don't pretend to wait
-		time.Sleep(1 * time.Second)
-
-		err = json.NewEncoder(w).Encode(screenshot)
-		if err != nil {
+		// Capture is asynchronous. Keep the existing delay before clients refresh
+		// the list; this does not acknowledge that MiSTer has finished writing.
+		pause(time.Second)
+		if err := json.NewEncoder(w).Encode(ScreenshotPayload{}); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-			logger.Error("take screenshot: encode: %s", err)
-			return
+			logError("take screenshot: encode: %s", err)
 		}
 	}
 }

--- a/cmd/remote/screenshots/screenshots_test.go
+++ b/cmd/remote/screenshots/screenshots_test.go
@@ -1,0 +1,106 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package screenshots
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/bendahl/uinput"
+	"github.com/wizzomafizzo/mrext/cmd/remote/control"
+	"github.com/wizzomafizzo/mrext/pkg/input"
+)
+
+type keyEvent struct {
+	key  int
+	down bool
+}
+
+type screenshotKeyboard struct {
+	uinput.Keyboard
+	events []keyEvent
+}
+
+func (k *screenshotKeyboard) KeyDown(key int) error {
+	k.events = append(k.events, keyEvent{key: key, down: true})
+	return nil
+}
+
+func (k *screenshotKeyboard) KeyUp(key int) error {
+	k.events = append(k.events, keyEvent{key: key})
+	return nil
+}
+
+func TestTakeScreenshotMatchesControlShortcut(t *testing.T) {
+	device := &screenshotKeyboard{}
+	keyboard := input.Keyboard{Device: device}
+	var delay time.Duration
+	var logged bool
+	handler := screenshotHandler(keyboard.Screenshot, func(string, ...any) { logged = true },
+		func(duration time.Duration) { delay += duration })
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/screenshots", http.NoBody)
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || delay != time.Second || logged {
+		t.Fatalf("status=%d delay=%v logged=%t", response.Code, delay, logged)
+	}
+	var payload ScreenshotPayload
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload != (ScreenshotPayload{}) {
+		t.Fatalf("response shape changed: %+v", payload)
+	}
+	controlDevice := &screenshotKeyboard{}
+	if err := control.SendKeyboard(input.Keyboard{Device: controlDevice}, "screenshot"); err != nil {
+		t.Fatal(err)
+	}
+	want := []keyEvent{
+		{key: uinput.KeyLeftalt, down: true},
+		{key: uinput.KeyScrolllock, down: true},
+		{key: uinput.KeyLeftalt},
+		{key: uinput.KeyScrolllock},
+	}
+	if !reflect.DeepEqual(device.events, want) || !reflect.DeepEqual(device.events, controlDevice.events) {
+		t.Fatalf("API events=%v Control events=%v", device.events, controlDevice.events)
+	}
+}
+
+func TestTakeScreenshotReportsCaptureFailure(t *testing.T) {
+	calls, logs, waits := 0, 0, 0
+	handler := screenshotHandler(func() error {
+		calls++
+		return errors.New("keyboard unavailable")
+	}, func(string, ...any) { logs++ }, func(time.Duration) { waits++ })
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/screenshots", http.NoBody)
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusInternalServerError || calls != 1 || logs != 1 || waits != 0 {
+		t.Fatalf("status=%d calls=%d logs=%d waits=%d", response.Code, calls, logs, waits)
+	}
+	if json.Valid(response.Body.Bytes()) {
+		t.Fatal("failure returned a success payload")
+	}
+}

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -147,11 +147,9 @@ Example response:
 
 #### Take new screenshot
 
-Request main to take a new screenshot of the current core using the `/dev/MiSTer_cmd` interface.
+Request MiSTer to take a normal screenshot using the same keyboard shortcut as Control's Screenshot action (`Alt+Scroll Lock`), rather than the command-interface capture path. This keeps both actions on the capture path reported to preserve PSX image shape. Like Control, it requires MiSTer to accept the shortcut; PS/2 keyboard mode can disable it.
 
-*Due to limitations with main, this method cannot report on errors during screenshot, when the screenshot is complete or
-which file is the taken screenshot. Check for newest screenshot from the full list after a delay to see taken
-screenshot. The method includes an artificial delay which has been reliable.*
+Capture is asynchronous. A successful request does not confirm that MiSTer accepted the shortcut or finished writing a file. The method retains its one-second delay; check the screenshot list for new files afterward.
 
 ```plaintext
 POST /screenshots
@@ -159,7 +157,7 @@ POST /screenshots
 
 This method takes no arguments.
 
-On success, returns `200`.
+On success, returns `200` with the existing empty screenshot payload. If sending the keyboard shortcut fails, returns `500`.
 
 Example request:
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,12 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## Screenshot compatibility notes
+
+The Screenshots-page camera and `POST /screenshots` use the same normal screenshot shortcut as Control's Screenshot button. This avoids the separate command-interface capture path reported to stretch PSX images. Raw Screenshot remains a separate Control action.
+
+Both normal screenshot actions depend on MiSTer accepting `Alt+Scroll Lock`; PS/2 keyboard mode can disable that shortcut. The API reports keyboard-send failures, but its one-second delay does not confirm a screenshot was saved. Check the screenshot list afterward.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.


### PR DESCRIPTION
## Summary
- Route camera/API captures through the same keyboard shortcut as Control, avoiding the command-interface path reported to stretch PSX images.
- Preserve success payload and delay; return HTTP 500 when sending the shortcut fails.
- Add shortcut-parity and failure regressions; document asynchronous capture and PS/2-mode limitations.

Closes #54

## Validation
`mage test`, `mage lint`, screenshot race tests, `mage mister remote`, and `git diff --check` passed. PSX image dimensions still need hardware verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Screenshot requests now use the standard keyboard shortcut, improving compatibility with PSX screenshots.
  - Capture failures return an HTTP 500 response and are logged.

- **Documentation**
  - Updated Remote API and Remote documentation with screenshot compatibility details, timing expectations, and shortcut requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->