### PR TITLE
fix(remote): notify SAM after successful launches

### DIFF
--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -292,7 +292,7 @@ func setupAPI(
 	sub.HandleFunc("/screenshots/{core}/{image}", screenshots.DeleteScreenshot(logger)).Methods("DELETE")
 
 	sub.HandleFunc("/systems", systems.ListSystems(logger)).Methods("GET")
-	sub.HandleFunc("/systems/{id}", systems.LaunchCore(cfg, logger)).Methods("POST")
+	sub.HandleFunc("/systems/{id}", withSAMActivity(systems.LaunchCore(cfg, logger), logger)).Methods("POST")
 
 	sub.HandleFunc("/wallpapers", wallpapers.AllWallpapersHandler(logger)).Methods("GET")
 	sub.HandleFunc("/wallpapers", wallpapers.UnsetWallpaperHandler(logger)).Methods("DELETE")
@@ -309,14 +309,14 @@ func setupAPI(
 
 	sub.HandleFunc("/games/search", games.Search(logger)).Methods("POST")
 	sub.HandleFunc("/games/search/systems", games.ListSystems(logger)).Methods("GET")
-	sub.HandleFunc("/games/launch", games.LaunchGame(logger, cfg)).Methods("POST")
+	sub.HandleFunc("/games/launch", withSAMActivity(games.LaunchGame(logger, cfg), logger)).Methods("POST")
 	sub.HandleFunc("/games/index", games.GenerateSearchIndex(logger, cfg)).Methods("POST")
 	sub.HandleFunc("/games/playing", games.HandlePlaying(trk)).Methods("GET")
 	sub.HandleFunc("/games/view", games.ListGamesFolder(logger)).Methods("POST")
 
-	sub.HandleFunc("/l/{data:.*}", games.LaunchToken(logger, cfg, kbd)).Methods("GET")
+	sub.HandleFunc("/l/{data:.*}", withSAMActivity(games.LaunchToken(logger, cfg, kbd), logger)).Methods("GET")
 
-	sub.HandleFunc("/launch", games.LaunchFile(logger, cfg)).Methods("POST")
+	sub.HandleFunc("/launch", withSAMActivity(games.LaunchFile(logger, cfg), logger)).Methods("POST")
 	sub.HandleFunc("/launch/menu", games.LaunchMenu).Methods("POST")
 	sub.HandleFunc("/launch/new", games.CreateLauncher(logger, cfg)).Methods("POST")
 

--- a/cmd/remote/sam.go
+++ b/cmd/remote/sam.go
@@ -1,0 +1,103 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/service"
+)
+
+func withSAMActivity(next http.HandlerFunc, logger *service.Logger) http.HandlerFunc {
+	return afterSuccessfulLaunch(next, func() error { return signalSAMActivity(config.SAMActivityFile) }, logger.Error)
+}
+
+func afterSuccessfulLaunch(
+	next http.HandlerFunc, notify func() error, logError func(string, ...any),
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		result := &launchResponse{ResponseWriter: w}
+		next(result, r)
+		if result.status == 0 || result.status >= 200 && result.status < 300 {
+			if err := notify(); err != nil {
+				logError("notify SAM after launch: %s", err)
+			}
+		}
+	}
+}
+
+type launchResponse struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *launchResponse) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+		w.ResponseWriter.WriteHeader(status)
+	}
+}
+
+func (w *launchResponse) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(data)
+	if err != nil {
+		return n, fmt.Errorf("write launch response: %w", err)
+	}
+	return n, nil
+}
+
+func signalSAMActivity(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect SAM activity file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("SAM activity path is not a regular file: %s", path)
+	}
+	// SAM owns this file. Never create it or its parent when SAM is absent.
+	// #nosec G304 -- path is fixed by config in production and injected only by tests.
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open SAM activity file: %w", err)
+	}
+	// MCP recognizes this exact token as external activity and keeps the
+	// current game running. Its generic keyboard action can return to Menu.
+	_, writeErr := file.WriteString("zaparoo\n")
+	closeErr := file.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write SAM activity: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close SAM activity file: %w", closeErr)
+	}
+	return nil
+}

--- a/cmd/remote/sam_test.go
+++ b/cmd/remote/sam_test.go
@@ -1,0 +1,102 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSAMActivityUsesExistingFileOnly(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "absent", "SAM_Joy_Activity")
+	if err := signalSAMActivity(missing); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Dir(missing)); !os.IsNotExist(err) {
+		t.Fatalf("created absent SAM directory: %v", err)
+	}
+	path := filepath.Join(root, "SAM_Joy_Activity")
+	if err := os.WriteFile(path, []byte("previous longer message"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := signalSAMActivity(path); err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- path is beneath t.TempDir.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "zaparoo\n" {
+		t.Fatalf("unexpected activity token: %q", data)
+	}
+	if err := signalSAMActivity(root); err == nil {
+		t.Fatal("accepted directory as activity file")
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := signalSAMActivity(link); err == nil {
+		t.Fatal("accepted symlink as activity file")
+	}
+}
+
+func TestSAMNotifiedOnlyAfterSuccessfulLaunch(t *testing.T) {
+	for _, status := range []int{0, http.StatusOK, http.StatusBadRequest, http.StatusInternalServerError} {
+		launched, notified := false, false
+		handler := afterSuccessfulLaunch(func(w http.ResponseWriter, _ *http.Request) {
+			launched = true
+			if status != 0 {
+				w.WriteHeader(status)
+			}
+		}, func() error {
+			if !launched {
+				t.Fatal("notified before launch")
+			}
+			notified = true
+			return nil
+		}, func(string, ...any) { t.Fatal("unexpected notification failure") })
+		response := httptest.NewRecorder()
+		request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/launch", http.NoBody)
+		handler.ServeHTTP(response, request)
+		if notified != (status == 0 || status == http.StatusOK) {
+			t.Fatalf("status=%d notified=%t", status, notified)
+		}
+	}
+}
+
+func TestSAMFailureDoesNotChangeLaunchResponse(t *testing.T) {
+	logged := false
+	handler := afterSuccessfulLaunch(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("launched"))
+	}, func() error { return errors.New("activity unavailable") }, func(string, ...any) { logged = true })
+	response := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/launch", http.NoBody)
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || response.Body.String() != "launched" || !logged {
+		t.Fatalf("status=%d body=%q logged=%t", response.Code, response.Body.String(), logged)
+	}
+}

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,14 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## MiSTer SAM compatibility
+
+After successful game, core, file, or launch-token requests, Remote signals user activity through SAM's existing `/tmp/.SAM_tmp/SAM_Joy_Activity` file. Current SAM MCP recognizes the `zaparoo` message as external activity: in normal mode it resets idle and exits attract mode while keeping the current game, rather than returning to Menu. This supports stock MiSTer without requiring Zaparoo Core.
+
+Remote never creates the activity file or starts SAM. A missing file is ignored; notification errors are logged without failing the launch. SAM must be running with its activity handling enabled (`listenjoy`); M82/kiosk mode retains its own behavior. Delivery is best-effort, not acknowledged. Older SAM versions using a different path are not targeted.
+
+The protocol is implemented in [SAM MCP's activity poller and action handler](https://github.com/mrchrisster/MiSTer_SAM/blob/45af68dd7a7e1b15337c2b04c79f196e7dd6da47/.MiSTer_SAM/MiSTer_SAM_MCP.py).
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -48,3 +48,5 @@ const (
 const GamesDB = ScriptsConfigFolder + "/mrext/games.db"
 
 const LastLaunchFile = SdFolder + "/.LASTLAUNCH.mgl"
+
+const SAMActivityFile = TempFolder + "/.SAM_tmp/SAM_Joy_Activity"


### PR DESCRIPTION
## Summary
- Signal current SAM MCP activity after successful game, core, file, and launch-token requests.
- Use SAM’s existing activity file and keep-current-game token; never create SAM state or start SAM.
- Keep missing SAM harmless and notification failures nonfatal; document protocol and limitations.

Closes #57

## Validation
`mage test`, `mage lint`, Remote race tests, `mage mister remote`, and `git diff --check` passed. Fixture tests cover file signaling and success-only notification. Hardware timing remains unverified.