### PR TITLE
fix(lastplayed): resolve arcade launches to installed MRA paths

### DIFF
--- a/cmd/lastplayed/arcade_test.go
+++ b/cmd/lastplayed/arcade_test.go
@@ -1,0 +1,139 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only on temporary fixture roots.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/tracker"
+)
+
+func TestArcadeEventCreatesLastAndRecentLinks(t *testing.T) {
+	root := t.TempDir()
+	folder := filepath.Join(root, "_Arcade", "nested")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(folder, "Pooyan.mra")
+	if err := os.WriteFile(path, []byte("<misterromdescription/>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db := &fakeDb{config: &config.UserConfig{}, sdRoot: root}
+	event := &tracker.EventAction{Action: tracker.EventActionGameStart, Target: "pooyan", TargetPath: path}
+	for range 2 {
+		if err := db.AddEvent(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, link := range []string{
+		filepath.Join(root, "Last Played.mra"),
+		filepath.Join(root, "_Recently Played", "01 Pooyan [Arcade].mra"),
+	} {
+		target, err := os.Readlink(link)
+		if err != nil || target != path {
+			t.Fatalf("link=%s target=%s err=%v", link, target, err)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "_Recently Played"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 { // One MRA and the shared cores link.
+		t.Fatalf("duplicate recent entries: %v", entries)
+	}
+	for _, unresolved := range []string{"", "   "} {
+		event.TargetPath = unresolved
+		if eventErr := db.AddEvent(event); eventErr != nil {
+			t.Fatal(eventErr)
+		}
+	}
+	event.TargetPath = filepath.Join(root, "missing.mra")
+	if eventErr := db.AddEvent(event); eventErr == nil {
+		t.Fatal("missing MRA was accepted")
+	}
+	target, err := os.Readlink(filepath.Join(root, "Last Played.mra"))
+	if err != nil || target != path {
+		t.Fatalf("failed resolution replaced valid launcher: %q %v", target, err)
+	}
+}
+
+func TestRecentFolderKeepsMixedGamesAcrossReplays(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.UserConfig{}
+	cfg.Systems.GamesFolder = []string{root}
+	arcade := filepath.Join(root, "_Arcade", "Pooyan.mra")
+	console := filepath.Join(root, "games", "NES", "Mario.nes")
+	for _, path := range []string{arcade, console} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, path := range []string{arcade, console, arcade, console} {
+		if err := addToRecentFolder(cfg, path, root); err != nil {
+			t.Fatal(err)
+		}
+	}
+	recent := filepath.Join(root, "_Recently Played")
+	entries, err := os.ReadDir(recent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected two launchers and cores link: %v", entries)
+	}
+	for _, entry := range entries {
+		path := filepath.Join(recent, entry.Name())
+		switch filepath.Ext(path) {
+		case ".mra":
+			target, readErr := os.Readlink(path)
+			if readErr != nil || target != arcade {
+				t.Fatalf("broken arcade link: %q %v", target, readErr)
+			}
+		case ".mgl":
+			data, readErr := os.ReadFile(path)
+			if readErr != nil || !strings.Contains(string(data), console) {
+				t.Fatalf("broken console launcher: %s %v", data, readErr)
+			}
+		}
+	}
+}
+
+func TestEmptyTargetCannotCreateLaunchers(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.UserConfig{}
+	if err := createLastPlayedMgl(cfg, "", root); err == nil {
+		t.Fatal("empty last-played target accepted")
+	}
+	if err := addToRecentFolder(cfg, "", root); err == nil {
+		t.Fatal("empty recent target accepted")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("empty target mutated menu: %v %v", entries, err)
+	}
+}

--- a/cmd/lastplayed/arcade_test.go
+++ b/cmd/lastplayed/arcade_test.go
@@ -137,3 +137,34 @@ func TestEmptyTargetCannotCreateLaunchers(t *testing.T) {
 		t.Fatalf("empty target mutated menu: %v %v", entries, err)
 	}
 }
+
+func TestLastPlayedKeepsOneLauncherAcrossSystems(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.UserConfig{}
+	cfg.Systems.GamesFolder = []string{root}
+	arcade := filepath.Join(root, "_Arcade", "Pooyan.mra")
+	console := filepath.Join(root, "games", "NES", "Mario.nes")
+	for _, path := range []string{arcade, console} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, step := range []struct{ path, kept, removed string }{
+		{console, "Last Played.mgl", "Last Played.mra"},
+		{arcade, "Last Played.mra", "Last Played.mgl"},
+		{console, "Last Played.mgl", "Last Played.mra"},
+	} {
+		if err := createLastPlayedMgl(cfg, step.path, root); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Lstat(filepath.Join(root, step.kept)); err != nil {
+			t.Fatalf("missing launcher for %s: %v", step.path, err)
+		}
+		if _, err := os.Lstat(filepath.Join(root, step.removed)); !os.IsNotExist(err) {
+			t.Fatalf("stale %s survived %s: %v", step.removed, step.path, err)
+		}
+	}
+}

--- a/cmd/lastplayed/main.go
+++ b/cmd/lastplayed/main.go
@@ -93,9 +93,26 @@ func createLastPlayedMgl(cfg *config.UserConfig, path, sdRoot string) error {
 		return err
 	}
 
-	_, err = mister.CreateLauncher(cfg, &system, path, sdRoot, mglName)
+	created, err := mister.CreateLauncher(cfg, &system, path, sdRoot, mglName)
 	if err != nil {
 		return fmt.Errorf("error creating mgl: %w", err)
+	}
+
+	return removeStaleLastPlayed(sdRoot, mglName, created)
+}
+
+// Arcade launchers are `.mra` links and everything else is a `.mgl` file, so a
+// system change leaves the previous extension behind. Remove it: a stale
+// shortcut keeps appearing in the menu and can boot the wrong game.
+func removeStaleLastPlayed(sdRoot, name, created string) error {
+	for _, extension := range []string{".mgl", ".mra"} {
+		stale := filepath.Join(sdRoot, name+extension)
+		if stale == created {
+			continue
+		}
+		if err := os.Remove(stale); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale last played launcher: %w", err)
+		}
 	}
 
 	return nil

--- a/cmd/lastplayed/main.go
+++ b/cmd/lastplayed/main.go
@@ -45,7 +45,32 @@ const (
 	maxRecentEntries        = 99
 )
 
-func createLastPlayedMgl(cfg *config.UserConfig, path string) error {
+func launcherSystem(cfg *config.UserConfig, path string) (games.System, error) {
+	if strings.TrimSpace(path) == "" {
+		return games.System{}, errors.New("launcher target is empty")
+	}
+	if strings.EqualFold(filepath.Ext(path), ".mra") {
+		info, err := os.Stat(path)
+		if err != nil {
+			return games.System{}, fmt.Errorf("inspect arcade target: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return games.System{}, errors.New("arcade target is not a regular file")
+		}
+		system, err := games.GetSystem(tracker.ArcadeSystem)
+		if err != nil {
+			return games.System{}, fmt.Errorf("get arcade system: %w", err)
+		}
+		return *system, nil
+	}
+	system, err := games.BestSystemMatch(cfg, path)
+	if err != nil {
+		return games.System{}, fmt.Errorf("find launcher system: %w", err)
+	}
+	return system, nil
+}
+
+func createLastPlayedMgl(cfg *config.UserConfig, path, sdRoot string) error {
 	var mglName string
 
 	switch {
@@ -63,12 +88,12 @@ func createLastPlayedMgl(cfg *config.UserConfig, path string) error {
 		return errors.New("name cannot be empty")
 	}
 
-	system, err := games.BestSystemMatch(cfg, path)
+	system, err := launcherSystem(cfg, path)
 	if err != nil {
-		return fmt.Errorf("no system match found: %s", path)
+		return err
 	}
 
-	_, err = mister.CreateLauncher(cfg, &system, path, config.SdFolder, mglName)
+	_, err = mister.CreateLauncher(cfg, &system, path, sdRoot, mglName)
 	if err != nil {
 		return fmt.Errorf("error creating mgl: %w", err)
 	}
@@ -83,7 +108,11 @@ type recentFile struct {
 	NewFilename string
 }
 
-func addToRecentFolder(cfg *config.UserConfig, path string) error {
+func addToRecentFolder(cfg *config.UserConfig, path, sdRoot string) error {
+	system, err := launcherSystem(cfg, path)
+	if err != nil {
+		return err
+	}
 	var recentFolderName string
 
 	if cfg.LastPlayed.RecentFolderName == "" {
@@ -98,19 +127,13 @@ func addToRecentFolder(cfg *config.UserConfig, path string) error {
 		return errors.New("name cannot be empty")
 	}
 
-	recentPath := filepath.Join(config.SdFolder, "_"+recentFolderName)
+	recentPath := filepath.Join(sdRoot, "_"+recentFolderName)
 
-	if _, err := os.Stat(recentPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(recentPath); os.IsNotExist(statErr) {
 		// #nosec G301 -- MiSTer menu folder must remain world-readable.
-		err = os.Mkdir(recentPath, 0o755)
-		if err != nil {
-			return fmt.Errorf("error creating recent folder: %w", err)
+		if mkdirErr := os.Mkdir(recentPath, 0o755); mkdirErr != nil {
+			return fmt.Errorf("error creating recent folder: %w", mkdirErr)
 		}
-	}
-
-	system, err := games.BestSystemMatch(cfg, path)
-	if err != nil {
-		return fmt.Errorf("no system match found: %s", path)
 	}
 
 	mglName := filepath.Base(path)
@@ -130,7 +153,15 @@ func addToRecentFolder(cfg *config.UserConfig, path string) error {
 
 	var recentFiles []recentFile
 	for _, file := range recentFolder {
-		if file.IsDir() || filepath.Ext(strings.ToLower(file.Name())) != ".mgl" {
+		extension := strings.ToLower(filepath.Ext(file.Name()))
+		if file.IsDir() || (extension != ".mgl" && extension != ".mra") {
+			continue
+		}
+		// Only number entries owned by LastPlayed, not unrelated menu files.
+		if len(file.Name()) < 4 || file.Name()[2] != ' ' {
+			continue
+		}
+		if _, parseErr := strconv.Atoi(file.Name()[:2]); parseErr != nil {
 			continue
 		}
 
@@ -149,12 +180,16 @@ func addToRecentFolder(cfg *config.UserConfig, path string) error {
 	prefixLength := len(strconv.Itoa(maxRecentEntries))
 
 	sort.Slice(recentFiles, func(i, j int) bool {
+		if recentFiles[i].Modified.Equal(recentFiles[j].Modified) {
+			return recentFiles[i].Filename < recentFiles[j].Filename
+		}
 		return recentFiles[i].Modified.After(recentFiles[j].Modified)
 	})
 
 	knownFiles := make(map[string]bool)
 
 	i := 0
+	retained := make([]recentFile, 0, len(recentFiles))
 	for _, file := range recentFiles {
 		if i >= maxRecentEntries {
 			err := os.Remove(file.Path)
@@ -175,14 +210,18 @@ func addToRecentFolder(cfg *config.UserConfig, path string) error {
 		}
 		knownFiles[filename] = true
 
-		newFilename := fmt.Sprintf("%0*d %s", prefixLength, i+1, filename)
-		newPath := filepath.Join(recentPath, newFilename)
-		err := os.Rename(file.Path, newPath)
-		if err != nil {
-			return fmt.Errorf("error renaming recent file: %w", err)
-		}
-
+		file.NewFilename = fmt.Sprintf("%0*d %s", prefixLength, i+1, filename)
+		retained = append(retained, file)
 		i++
+	}
+
+	// Remove duplicates before renumbering: otherwise an old duplicate's path
+	// can refer to the freshly renamed launcher when it is deleted.
+	for _, file := range retained {
+		newPath := filepath.Join(recentPath, file.NewFilename)
+		if renameErr := os.Rename(file.Path, newPath); renameErr != nil {
+			return fmt.Errorf("error renaming recent file: %w", renameErr)
+		}
 	}
 
 	return nil
@@ -190,6 +229,7 @@ func addToRecentFolder(cfg *config.UserConfig, path string) error {
 
 type fakeDb struct {
 	config *config.UserConfig
+	sdRoot string
 }
 
 func (*fakeDb) FixPowerLoss() (bool, error) {
@@ -197,19 +237,23 @@ func (*fakeDb) FixPowerLoss() (bool, error) {
 }
 
 func (f *fakeDb) AddEvent(ev *tracker.EventAction) error {
-	if ev.Action != tracker.EventActionGameStart {
+	if ev.Action != tracker.EventActionGameStart || strings.TrimSpace(ev.TargetPath) == "" {
 		return nil
+	}
+	root := f.sdRoot
+	if root == "" {
+		root = config.SdFolder
 	}
 
 	if !f.config.LastPlayed.DisableLastPlayed {
-		err := createLastPlayedMgl(f.config, ev.TargetPath)
+		err := createLastPlayedMgl(f.config, ev.TargetPath, root)
 		if err != nil {
 			return fmt.Errorf("error creating last played mgl: %w", err)
 		}
 	}
 
 	if !f.config.LastPlayed.DisableRecentFolder {
-		err := addToRecentFolder(f.config, ev.TargetPath)
+		err := addToRecentFolder(f.config, ev.TargetPath, root)
 		if err != nil {
 			return fmt.Errorf("error adding to recent folder: %w", err)
 		}

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -26,6 +26,14 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/last
 
 Once installed, run `lastplayed` from the MiSTer `Scripts` menu, and a prompt will offer to enable LastPlayed as a startup service.
 
+## Arcade games
+
+LastPlayed creates `.mra` links for arcade games in Last Played and Recently Played, including MRAs in nested installed arcade folders. The shared tracker uses Arcade Database to recognize the active set name, then confirms it against each candidate MRA's `<setname>`; display names alone do not select a launcher. Symlink aliases to the same file count once. Multiple distinct matching MRAs are treated as ambiguous rather than choosing one arbitrarily.
+
+If Arcade Database is unavailable, or no unique readable MRA can be found, existing shortcuts remain untouched. Successful resolutions are cached until the tracker's name map is reloaded or the service restarts, and cached files are revalidated before use. Restart after adding duplicate or replacement MRAs to force a fresh scan.
+
+Recently Played numbers `.mra` and `.mgl` shortcuts together. Replaying a game refreshes its entry without deleting the newly numbered shortcut. `/tmp/ACTIVEGAME` continues to contain the legacy arcade set name; tracker events carry the resolved launchable path separately. This works on stock MiSTer without Zaparoo Core.
+
 ## Configuration
 
 LastPlayed can be configured by creating a `lastplayed.ini` file in the `/media/fat/Scripts` folder where you put `lastplayed.sh`. For example:

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -32,6 +32,8 @@ LastPlayed creates `.mra` links for arcade games in Last Played and Recently Pla
 
 If Arcade Database is unavailable, or no unique readable MRA can be found, existing shortcuts remain untouched. Successful resolutions are cached until the tracker's name map is reloaded or the service restarts, and cached files are revalidated before use. Restart after adding duplicate or replacement MRAs to force a fresh scan.
 
+Arcade shortcuts are `.mra` links, so the Last Played shortcut becomes `Last Played.mra` after an arcade game and `Last Played.mgl` after any other game. Only one is kept: the other extension is removed so a stale shortcut cannot linger in the menu or be launched by `bootcore`. Set `bootcore` to the extension you actually use.
+
 Recently Played numbers `.mra` and `.mgl` shortcuts together. Replaying a game refreshes its entry without deleting the newly numbered shortcut. `/tmp/ACTIVEGAME` continues to contain the legacy arcade set name; tracker events carry the resolved launchable path separately. This works on stock MiSTer without Zaparoo Core.
 
 ## Uninstall

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -9,6 +9,10 @@ PlayLog is an application to track and store stats of what games and cores you p
 
 <a href="https://github.com/wizzomafizzo/mrext/releases/latest/download/playlog.sh"><img src="images/download.svg" alt="Download PlayLog" title="Download PlayLog" width="140"></a>
 
+## Arcade tracking
+
+When Arcade Database recognizes a running arcade set name, the shared tracker resolves a unique installed MRA by its XML `<setname>`, including nested arcade folders. Game-start events and game state include that path while retaining the set name as the game identifier. Ambiguous or unreadable matches leave the path empty rather than guessing. The legacy arcade value in `/tmp/ACTIVEGAME` remains the set name. Existing history is not backfilled.
+
 ## Install
 
 Enable the `recents` option in your `MiSTer.ini` file and reboot your MiSTer.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,10 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## Arcade tracking
+
+Remote's shared tracker now supplies a resolved `.mra` path for arcade games recognized through Arcade Database. It searches nested installed arcade folders and confirms the active set name against MRA XML, rather than relying on display names. Ambiguous or unreadable matches remain unresolved. Existing event fields are unchanged, and `/tmp/ACTIVEGAME` retains its legacy arcade set-name value.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/pkg/tracker/arcaderesolve.go
+++ b/pkg/tracker/arcaderesolve.go
@@ -1,0 +1,146 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Adapted from Zaparoo Core's pkg/platforms/mister/tracker/arcaderesolve.go
+// (ResolveArcadeSetName) and pkg/platforms/mister/mgls/mgls.go (MRA/ReadMRA).
+// Keep this boundary small so a future dependency-light Core library can replace
+// it. mrext discovers candidates on disk instead of using Core's MediaDB, and
+// rejects unreadable candidates rather than using Core's single-candidate guess.
+type arcadeMRA struct {
+	XMLName xml.Name `xml:"misterromdescription"`
+	SetName string   `xml:"setname"`
+}
+
+func mraMatches(path, setName string) bool {
+	// #nosec G304 -- path comes from installed arcade roots or the resolver cache.
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+	var mra arcadeMRA
+	return xml.NewDecoder(file).Decode(&mra) == nil && strings.EqualFold(strings.TrimSpace(mra.SetName), setName)
+}
+
+func resolveArcadeSetName(roots []string, setName string) (string, bool) {
+	if setName == "" {
+		return "", false
+	}
+	seen := make(map[string]bool)
+	var matches []string
+	var visit func(string)
+	visit = func(path string) {
+		canonical, err := filepath.EvalSymlinks(path)
+		if err != nil || seen[canonical] {
+			return
+		}
+		seen[canonical] = true
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return
+		}
+		if !info.IsDir() {
+			if info.Mode().IsRegular() && strings.EqualFold(filepath.Ext(path), ".mra") && mraMatches(path, setName) {
+				matches = append(matches, path)
+			}
+			return
+		}
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return
+		}
+		for _, entry := range entries {
+			visit(filepath.Join(path, entry.Name()))
+		}
+	}
+	for _, root := range roots {
+		visit(root)
+	}
+	if len(matches) != 1 {
+		return "", false
+	}
+	return matches[0], true
+}
+
+func (tr *Tracker) lookupArcadeSetPath(setName string) string {
+	if path := tr.arcadePaths[setName]; path != "" && mraMatches(path, setName) {
+		return path
+	}
+	var roots []string
+	if tr.arcadeRoots != nil {
+		roots = tr.arcadeRoots()
+	} else {
+		system, err := games.GetSystem(ArcadeSystem)
+		if err != nil {
+			return ""
+		}
+		paths := games.GetSystemPaths(tr.Config, []games.System{*system})
+		for i := range paths {
+			roots = append(roots, paths[i].Path)
+		}
+	}
+	path, ok := resolveArcadeSetName(roots, setName)
+	if !ok {
+		delete(tr.arcadePaths, setName)
+		return ""
+	}
+	if tr.arcadePaths == nil {
+		tr.arcadePaths = make(map[string]string)
+	}
+	tr.arcadePaths[setName] = path
+	return path
+}
+
+// startArcade keeps the legacy set-name identity and ACTIVEGAME payload while
+// supplying the installed MRA path to event consumers such as LastPlayed.
+func (tr *Tracker) startArcade(mapping NameMapping) {
+	id := tr.ActiveCore
+	path := tr.lookupArcadeSetPath(id)
+	if tr.ActiveGame == id && tr.ActiveGamePath == path {
+		return
+	}
+	if tr.ActiveGame != id {
+		tr.stopGame()
+	}
+	game, exists := tr.GameTimes[id]
+	if !exists {
+		loaded, err := tr.Db.GetGame(id)
+		if err == nil {
+			game = loaded
+		} else if !tr.Db.NoResults(err) {
+			tr.Logger.Error("error loading arcade game time: %s", err)
+		}
+	}
+	game.Id, game.Path, game.Name = id, path, mapping.ArcadeName
+	tr.GameTimes[id] = game
+	tr.ActiveGame, tr.ActiveGamePath, tr.ActiveGameName = id, path, mapping.ArcadeName
+	tr.addEvent(EventActionGameStart, id)
+}

--- a/pkg/tracker/arcaderesolve_test.go
+++ b/pkg/tracker/arcaderesolve_test.go
@@ -1,0 +1,221 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Fixtures only access t.TempDir paths.
+package tracker
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+func writeArcade(t *testing.T, path, setName string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := "<misterromdescription><name>Same Name</name><setname>" + setName + "</setname></misterromdescription>"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// Matching/ambiguity cases adapted from Core's
+// pkg/platforms/mister/tracker/arcaderesolve_test.go, using filesystem fixtures
+// instead of MediaDB mocks so they remain suitable for future library extraction.
+func TestResolveArcadeSetName(t *testing.T) {
+	root := t.TempDir()
+	wanted := filepath.Join(root, "nested", "game.mra")
+	writeArcade(t, wanted, "POOYAN")
+	writeArcade(t, filepath.Join(root, "clone.mra"), "pooyana")
+	if err := os.Symlink(wanted, filepath.Join(root, "alias.mra")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(root, "nested", "cycle")); err != nil {
+		t.Fatal(err)
+	}
+	path, ok := resolveArcadeSetName([]string{root, root}, "pooyan")
+	if !ok {
+		t.Fatal("nested exact set-name match was not resolved")
+	}
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil || canonical != wanted {
+		t.Fatalf("path=%q err=%v", path, err)
+	}
+	writeArcade(t, filepath.Join(root, "duplicate.mra"), "pooyan")
+	if _, found := resolveArcadeSetName([]string{root}, "pooyan"); found {
+		t.Fatal("ambiguous set name was guessed")
+	}
+	if _, found := resolveArcadeSetName([]string{root}, "missing"); found {
+		t.Fatal("unmatched set name resolved")
+	}
+	if _, found := resolveArcadeSetName([]string{root}, ""); found {
+		t.Fatal("empty set name resolved")
+	}
+}
+
+func TestResolverRejectsMalformedAndMissingFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "game.mra"), []byte("<bad>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resolveArcadeSetName([]string{root, filepath.Join(root, "missing")}, "game"); ok {
+		t.Fatal("malformed single candidate was guessed")
+	}
+}
+
+type silentLogger struct{}
+
+func (silentLogger) Info(string, ...any)  {}
+func (silentLogger) Warn(string, ...any)  {}
+func (silentLogger) Error(string, ...any) {}
+
+type arcadeDB struct {
+	Db
+	events []EventAction
+}
+
+func (d *arcadeDB) AddEvent(event *EventAction) error {
+	d.events = append(d.events, *event)
+	return nil
+}
+
+func (*arcadeDB) GetCore(name string) (CoreTime, error) { return CoreTime{Name: name}, nil }
+func (*arcadeDB) GetGame(string) (GameTime, error)      { return GameTime{}, errors.New("missing") }
+func (*arcadeDB) NoResults(err error) bool              { return err != nil }
+func (*arcadeDB) UpdateGame(GameTime) error             { return nil }
+func (*arcadeDB) UpdateCore(CoreTime) error             { return nil }
+
+func arcadeTracker(root string, db *arcadeDB) *Tracker {
+	return &Tracker{
+		Db: db, Logger: silentLogger{}, Config: &config.UserConfig{},
+		NameMap:   []NameMapping{{CoreName: "pooyan", System: ArcadeSystem, Name: ArcadeSystem, ArcadeName: "Pooyan"}},
+		GameTimes: make(map[string]GameTime), CoreTimes: make(map[string]CoreTime),
+		arcadeRoots:   func() []string { return []string{root} },
+		setActiveGame: func(string) error { return nil },
+	}
+}
+
+func TestArcadeLifecycleProvidesPathOnceAndPreservesIdentity(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "nested", "Pooyan.mra")
+	writeArcade(t, path, "pooyan")
+	db := &arcadeDB{}
+	tr := arcadeTracker(root, db)
+	var signal string
+	tr.setActiveGame = func(value string) error { signal = value; return nil }
+	tr.processCore("pooyan")
+	if signal != "pooyan" {
+		t.Fatalf("legacy ACTIVEGAME payload changed: %q", signal)
+	}
+	if len(db.events) != 2 {
+		t.Fatalf("expected core and game start, got %v", db.events)
+	}
+	event := db.events[1]
+	if event.TargetPath != path || event.Target != "pooyan" || event.ActiveGame.Path != path ||
+		event.ActiveCore.System != ArcadeSystem || event.ActiveCore.Core != "pooyan" {
+		t.Fatalf("incomplete arcade start event: %+v", event)
+	}
+	tr.processGame("pooyan")
+	if len(db.events) != 2 {
+		t.Fatal("ACTIVEGAME notification duplicated arcade start")
+	}
+	game := tr.GameTimes["pooyan"]
+	game.Time = 47
+	tr.GameTimes["pooyan"] = game
+	tr.processCore(config.MenuCore)
+	if tr.ActiveGame != "" || tr.ActiveGamePath != "" || signal != "" {
+		t.Fatal("arcade state survived return to Menu")
+	}
+	if len(db.events) != 4 || db.events[2].Action != EventActionGameStop || db.events[2].TargetPath != path {
+		t.Fatalf("arcade stop missing: %+v", db.events)
+	}
+	tr.processCore("pooyan")
+	if tr.GameTimes["pooyan"].Time != 47 {
+		t.Fatal("returning to arcade game lost accumulated play time")
+	}
+}
+
+func TestConsoleTrackingDoesNotScanArcadeRoots(t *testing.T) {
+	root := t.TempDir()
+	db := &arcadeDB{}
+	tr := arcadeTracker(root, db)
+	tr.Config.Systems.GamesFolder = []string{root}
+	tr.NameMap = []NameMapping{{CoreName: "NES", System: "NES", Name: "NES"}}
+	tr.arcadeRoots = func() []string {
+		t.Fatal("console launch scanned arcade files")
+		return nil
+	}
+	path := filepath.Join(root, "games", "NES", "game.nes")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tr.processCore("NES")
+	tr.processGame(path)
+	if tr.ActiveSystem != "NES" || tr.ActiveGamePath != path || len(db.events) != 2 {
+		t.Fatalf("console tracking regressed: %+v", db.events)
+	}
+	tr.processGame(path)
+	if len(db.events) != 2 {
+		t.Fatal("same console game emitted duplicate start")
+	}
+}
+
+func TestMissingArcadeMappingDoesNotInventGame(t *testing.T) {
+	db := &arcadeDB{}
+	tr := arcadeTracker(t.TempDir(), db)
+	tr.NameMap = nil
+	tr.arcadeRoots = func() []string {
+		t.Fatal("unmapped core triggered arcade scan")
+		return nil
+	}
+	tr.processCore("pooyan")
+	if tr.ActiveGame != "" || len(db.events) != 1 || db.events[0].Action != EventActionCoreStart {
+		t.Fatalf("missing Arcade Database mapping invented game state: %+v", db.events)
+	}
+}
+
+func TestArcadeMissRetriedAndRemovedCachedPathDiscarded(t *testing.T) {
+	root := t.TempDir()
+	tr := arcadeTracker(root, &arcadeDB{})
+	tr.processCore("pooyan")
+	if tr.GameTimes["pooyan"].Path != "" {
+		t.Fatal("missing MRA produced a target")
+	}
+	path := filepath.Join(root, "Pooyan.mra")
+	writeArcade(t, path, "pooyan")
+	tr.processGame("pooyan")
+	if tr.ActiveGamePath != path {
+		t.Fatal("miss was cached permanently")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := tr.lookupArcadeSetPath("pooyan"); got != "" {
+		t.Fatalf("removed cached MRA retained: %q", got)
+	}
+}

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -98,12 +98,21 @@ type Db interface {
 	NoResults(err error) bool
 }
 
+type trackerLogger interface {
+	Info(string, ...any)
+	Warn(string, ...any)
+	Error(string, ...any)
+}
+
 type Tracker struct {
 	Db               Db
-	Logger           *service.Logger
+	Logger           trackerLogger
 	Config           *config.UserConfig
 	GameTimes        map[string]GameTime
 	CoreTimes        map[string]CoreTime
+	arcadePaths      map[string]string
+	arcadeRoots      func() []string
+	setActiveGame    func(string) error
 	ActiveGamePath   string
 	ActiveSystemName string
 	ActiveGame       string
@@ -115,7 +124,7 @@ type Tracker struct {
 	mu               sync.Mutex
 }
 
-func generateNameMap(logger *service.Logger) []NameMapping {
+func generateNameMap(logger trackerLogger) []NameMapping {
 	nameMap := make([]NameMapping, 0)
 
 	for id := range games.Systems {
@@ -194,6 +203,7 @@ func (tr *Tracker) ReloadNameMap() {
 	nameMap := generateNameMap(tr.Logger)
 	tr.Logger.Info("loaded %d name mappings", len(nameMap))
 	tr.NameMap = nameMap
+	tr.arcadePaths = nil
 }
 
 func (tr *Tracker) LookupName(name, game string) NameMapping {
@@ -204,6 +214,10 @@ func (tr *Tracker) LookupName(name, game string) NameMapping {
 
 		if !strings.EqualFold(mapping.CoreName, name) {
 			continue
+		}
+
+		if mapping.System == ArcadeSystem {
+			return mapping
 		}
 
 		sys, err := games.BestSystemMatch(tr.Config, game)
@@ -316,13 +330,10 @@ func (tr *Tracker) stopCore() bool {
 		}
 	}
 
-	tr.addEvent(EventActionCoreStop, tr.ActiveCore)
-
-	if tr.ActiveCore == ArcadeSystem {
-		tr.ActiveGame = ""
-		tr.ActiveGameName = ""
-		tr.addEvent(EventActionGameStop, ArcadeSystem)
+	if tr.ActiveSystem == ArcadeSystem {
+		tr.stopGame()
 	}
+	tr.addEvent(EventActionCoreStop, tr.ActiveCore)
 
 	tr.ActiveCore = ""
 	tr.ActiveSystem = ""
@@ -360,8 +371,17 @@ func (tr *Tracker) LoadCore() {
 		return
 	}
 
+	tr.processCore(coreName)
+}
+
+// processCore runs under the tracker lock; separated from device reads for tests.
+func (tr *Tracker) processCore(coreName string) {
+	publish := tr.setActiveGame
+	if publish == nil {
+		publish = mister.SetActiveGame
+	}
 	if coreName == config.MenuCore {
-		err := mister.SetActiveGame("")
+		err := publish("")
 		if err != nil {
 			tr.Logger.Error("error setting active game: %s", err)
 		}
@@ -384,12 +404,9 @@ func (tr *Tracker) LoadCore() {
 
 			switch result.System {
 			case ArcadeSystem:
-				if err := mister.SetActiveGame(coreName); err != nil {
+				if err := publish(coreName); err != nil {
 					tr.Logger.Error("error setting active arcade game: %s", err)
 				}
-				tr.ActiveGame = coreName
-				tr.ActiveGameName = result.ArcadeName
-				tr.addEvent(EventActionGameStart, coreName)
 			case "":
 				tr.ActiveSystem = coreName
 				tr.ActiveSystemName = coreName
@@ -415,6 +432,9 @@ func (tr *Tracker) LoadCore() {
 		}
 
 		tr.addEvent(EventActionCoreStart, coreName)
+		if result.System == ArcadeSystem {
+			tr.startArcade(result)
+		}
 	}
 }
 
@@ -432,6 +452,7 @@ func (tr *Tracker) stopGame() bool {
 	target := tr.ActiveGame
 	tr.ActiveGame = ""
 	tr.ActiveGameName = ""
+	tr.ActiveGamePath = ""
 	tr.addEvent(EventActionGameStop, target)
 	return true
 }
@@ -447,9 +468,23 @@ func (tr *Tracker) loadGame() {
 		tr.stopGame()
 		return
 	}
+	tr.processGame(activeGame)
+}
+
+// processGame runs under the tracker lock, with the compatibility signal supplied
+// by loadGame. Arcade set names must not be interpreted as relative filenames.
+func (tr *Tracker) processGame(activeGame string) {
 	if activeGame == "" {
 		tr.stopGame()
 		return
+	}
+
+	if tr.ActiveSystem == ArcadeSystem {
+		mapping := tr.LookupName(tr.ActiveCore, activeGame)
+		if mapping.System == ArcadeSystem {
+			tr.startArcade(mapping)
+			return
+		}
 	}
 
 	path := mister.ResolvePath(activeGame)


### PR DESCRIPTION
## Summary
- Adapt Core’s MRA parsing and set-name resolution with attribution and a future shared-library note; use recursive installed-file discovery instead of MediaDB.
- Populate arcade tracker paths before events, preserve legacy identifiers and ACTIVEGAME, and handle arcade lifecycle without duplicate starts.
- Preserve LastPlayed shortcuts on unresolved targets; include MRA links in Recently Played and fix replay renumbering deleting replacement entries.
- Add fixtures and document behavior across LastPlayed, Remote, and PlayLog. Core checkout unchanged.

Closes #94

## Validation
`mage test`, `mage lint`, targeted race checks, LastPlayed/PlayLog/Remote MiSTer builds, and `git diff --check` passed.

No hardware verification. Ambiguous matches stay unresolved; restart/reload clears successful-resolution cache. Existing history is not backfilled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Arcade games are now tracked using their installed MRA files, including games in nested folders.
  - Last Played and Recently Played menus now support arcade shortcuts alongside console games.
  - Duplicate recent entries are prevented, with consistent numbering across arcade and console titles.
  - Ambiguous, missing, or invalid arcade matches are safely excluded.

- **Documentation**
  - Added guidance for arcade tracking, shortcut generation, path resolution, caching, fallback behavior, and legacy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->