### PR TITLE
fix(remote): harden service startup and PID checks

### DIFF
--- a/cmd/remote/games/tracker.go
+++ b/cmd/remote/games/tracker.go
@@ -102,12 +102,14 @@ func StartTracker(logger *service.Logger, cfg *config.UserConfig) (*tracker.Trac
 		}
 	}
 
-	watcher, err := tracker.StartFileWatch(tr)
+	watcher, err := tracker.StartFileWatchWithRetry(tr)
 	if err != nil {
 		tr.Logger.Error("error starting file watch: %s", err)
 		return nil, nil, fmt.Errorf("start tracker file watch: %w", err)
 	}
 
+	// The core state may have appeared while watch setup was retrying.
+	tr.LoadCore()
 	tr.StartTicker(0)
 
 	return tr, func() error {

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -187,6 +188,24 @@ func parseMouseCoords(args string) (x, y int, err error) {
 }
 
 func startService(logger *service.Logger, cfg *config.UserConfig) (func() error, error) {
+	return startServiceWithListener(logger, cfg, net.Listen)
+}
+
+func startServiceWithListener(
+	logger *service.Logger, cfg *config.UserConfig, listen func(string, string) (net.Listener, error),
+) (func() error, error) {
+	// Bind before reporting success or allocating devices. Bind errors then use
+	// the service harness's normal startup-error logging and PID cleanup.
+	listener, err := listen("tcp", ":"+strconv.Itoa(appPort))
+	if err != nil {
+		return nil, fmt.Errorf("bind Remote HTTP listener: %w", err)
+	}
+	started := false
+	defer func() {
+		if !started {
+			_ = listener.Close()
+		}
+	}()
 	kbd, err := input.NewKeyboard()
 	if err != nil {
 		logger.Error("failed to initialize keyboard: %s", err)
@@ -240,8 +259,9 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		ReadTimeout:  15 * time.Second,
 	}
 
+	started = true
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("critical server error: %s", err)
 			os.Exit(1)
 		}

--- a/cmd/remote/startup_test.go
+++ b/cmd/remote/startup_test.go
@@ -1,0 +1,44 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestBindFailureReturnsBeforeDeviceSetup(t *testing.T) {
+	// No logger/config/devices are needed if bind fails. An injected listener
+	// avoids touching either a real port or the MiSTer input devices.
+	calls := 0
+	stop, err := startServiceWithListener(nil, nil, func(network, address string) (net.Listener, error) {
+		calls++
+		if network != "tcp" || address != ":"+strconv.Itoa(appPort) {
+			t.Fatalf("unexpected listener: %s %s", network, address)
+		}
+		return nil, syscall.EADDRINUSE
+	})
+	if stop != nil || !errors.Is(err, syscall.EADDRINUSE) || calls != 1 {
+		t.Fatalf("bind failure hidden: stop=%v err=%v calls=%d", stop != nil, err, calls)
+	}
+}

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -26,6 +26,8 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/last
 
 Once installed, run `lastplayed` from the MiSTer `Scripts` menu, and a prompt will offer to enable LastPlayed as a startup service.
 
+Service status and stop commands verify the recorded PID's executable and daemon arguments before trusting it, so an unrelated process reusing a stale PID is not treated as LastPlayed. The PID-file format is unchanged.
+
 ## Configuration
 
 LastPlayed can be configured by creating a `lastplayed.ini` file in the `/media/fat/Scripts` folder where you put `lastplayed.sh`. For example:

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -31,6 +31,8 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/play
 
 From this point, PlayLog will always run on boot and silently track game playing stats in the background. At any point you can run `playlog` again and see a summary report of the stats.
 
+Service status and stop commands verify the recorded PID's executable and daemon arguments before trusting it, so an unrelated process reusing a stale PID is not treated as PlayLog. The PID-file format is unchanged.
+
 ## Configuration
 
 PlayLog can be configured by creating a `playlog.ini` file in the `/media/fat/Scripts` folder where you put `playlog.sh`. For example:

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,16 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## Startup diagnostics
+
+Remote retries tracker setup when required MiSTer state files or directories are missing: at most six attempts, with one-second gaps. Each retry is logged. Permission errors and other failures stop immediately. This does not retry a missing `remote.sh` before the executable starts, or missing input devices.
+
+The HTTP listener is bound before device/tracker setup. A port conflict therefore follows normal startup-error logging and PID cleanup rather than terminating from the background HTTP goroutine. A service-start command still launches a background process; its return is not an HTTP-readiness acknowledgment.
+
+Remote verifies that a PID belongs to its copied executable running the service subcommand before treating it as running or sending it a stop signal. Numeric PID-file format is unchanged. This prevents an unrelated process using a stale PID from being mistaken for Remote.
+
+If startup fails, capture `/tmp/remote.log`, `/tmp/remote.pid` (if present), and `/media/fat/linux/user-startup.sh` before restarting or re-enabling Remote. Also note executable location, mounted storage, and whether the recorded PID exists. These checks harden startup but do not establish the cause of intermittent reboot failures.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -48,3 +48,9 @@ const (
 const GamesDB = ScriptsConfigFolder + "/mrext/games.db"
 
 const LastLaunchFile = SdFolder + "/.LASTLAUNCH.mgl"
+
+const (
+	ServiceProcFolder       = "/proc"
+	RemoteWatchAttempts     = 6
+	RemoteWatchRetrySeconds = 1
+)

--- a/pkg/service/identity.go
+++ b/pkg/service/identity.go
@@ -1,0 +1,64 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+func (*Service) matchesDaemon(pid int) bool {
+	path := os.Getenv(config.UserAppPathEnv)
+	if path == "" {
+		var err error
+		path, err = os.Executable()
+		if err != nil {
+			return false
+		}
+	}
+	return daemonIdentity(config.ServiceProcFolder, pid, filepath.Join(config.TempFolder, filepath.Base(path)))
+}
+
+// A live PID alone is not proof of ownership: it may have been recycled after
+// a crash. Require the copied executable and the daemon subcommand. Keep the
+// numeric PID-file format compatible with installed scripts and other apps.
+func daemonIdentity(procRoot string, pid int, executable string) bool {
+	if pid <= 1 {
+		return false
+	}
+	root := filepath.Join(procRoot, strconv.Itoa(pid))
+	actual, err := os.Readlink(filepath.Join(root, "exe"))
+	if err != nil || strings.TrimSuffix(actual, " (deleted)") != executable {
+		return false
+	}
+	// #nosec G304 -- fixed proc path in production; injected temporary root in tests.
+	data, err := os.ReadFile(filepath.Join(root, "cmdline"))
+	if err != nil {
+		return false
+	}
+	args := strings.Split(string(data), "\x00")
+	return len(args) >= 3 && args[1] == "-service" && args[2] == "exec"
+}

--- a/pkg/service/identity_test.go
+++ b/pkg/service/identity_test.go
@@ -1,0 +1,85 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+//nolint:gosec // Tests use only temporary filesystem fixtures.
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDaemonIdentityRejectsReusedPID(t *testing.T) {
+	root := t.TempDir()
+	proc := filepath.Join(root, "42")
+	if err := os.Mkdir(proc, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	executable := filepath.Join(root, "remote.sh")
+	link := filepath.Join(proc, "exe")
+	if err := os.Symlink(executable, link); err != nil {
+		t.Fatal(err)
+	}
+	cmdline := filepath.Join(proc, "cmdline")
+	if err := os.WriteFile(cmdline, []byte("remote.sh\x00-service\x00exec\x00&\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !daemonIdentity(root, 42, executable) {
+		t.Fatal("valid daemon was rejected")
+	}
+	if daemonIdentity(root, 42, filepath.Join(root, "playlog.sh")) {
+		t.Fatal("different executable was treated as Remote")
+	}
+	if err := os.WriteFile(cmdline, []byte("remote.sh\x00-service\x00start\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if daemonIdentity(root, 42, executable) {
+		t.Fatal("launcher process was treated as daemon")
+	}
+	if err := os.Remove(cmdline); err != nil {
+		t.Fatal(err)
+	}
+	if daemonIdentity(root, 42, executable) || daemonIdentity(root, 99, executable) {
+		t.Fatal("unverifiable process was accepted")
+	}
+}
+
+func TestServicePIDValidation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "remote.pid")
+	if pid, err := readServicePID(path); err != nil || pid != 0 {
+		t.Fatalf("missing PID: %d %v", pid, err)
+	}
+	for _, value := range []string{"", "0", "1", "-42", "not a PID"} {
+		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readServicePID(path); err == nil {
+			t.Fatalf("unsafe PID accepted: %q", value)
+		}
+	}
+	if err := os.WriteFile(path, []byte("42\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if pid, err := readServicePID(path); err != nil || pid != 42 {
+		t.Fatalf("valid legacy PID: %d %v", pid, err)
+	}
+}

--- a/pkg/service/identity_test.go
+++ b/pkg/service/identity_test.go
@@ -25,6 +25,7 @@ package service
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -81,5 +82,13 @@ func TestServicePIDValidation(t *testing.T) {
 	}
 	if pid, err := readServicePID(path); err != nil || pid != 42 {
 		t.Fatalf("valid legacy PID: %d %v", pid, err)
+	}
+}
+
+func TestStopReportsNotRunningWithoutPIDFile(t *testing.T) {
+	svc := &Service{Name: "mrext-stop-" + filepath.Base(t.TempDir())}
+	err := svc.Stop()
+	if err == nil || !strings.Contains(err.Error(), "service not running") {
+		t.Fatalf("expected not-running error, got %v", err)
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -287,6 +287,11 @@ func (s *Service) Stop() error {
 		return fmt.Errorf("read service PID: %w", err)
 	}
 
+	// No PID file at all is the ordinary stopped case, not a mismatched PID.
+	if pid == 0 {
+		return fmt.Errorf("%s service not running", s.Name)
+	}
+
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find service process: %w", err)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -78,24 +78,25 @@ func (s *Service) removePidFile() error {
 
 // Return the process ID of the current running service daemon.
 func (s *Service) Pid() (int, error) {
-	pidPath := fmt.Sprintf(config.PidFileTemplate, s.Name)
-	pid := 0
+	return readServicePID(s.pidFilePath())
+}
 
-	if _, err := os.Stat(pidPath); err == nil {
-		// #nosec G304 -- path is derived from configured service name and PID template.
-		pidFile, err := os.ReadFile(pidPath)
-		if err != nil {
-			return pid, fmt.Errorf("error reading pid file: %w", err)
-		}
-
-		pidInt, err := strconv.Atoi(string(pidFile))
-		if err != nil {
-			return pid, fmt.Errorf("error parsing pid: %w", err)
-		}
-
-		pid = pidInt
+func readServicePID(path string) (int, error) {
+	// #nosec G304 -- configured PID path in production; temporary fixture in tests.
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0, nil
 	}
-
+	if err != nil {
+		return 0, fmt.Errorf("read service PID: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse service PID: %w", err)
+	}
+	if pid <= 1 {
+		return 0, errors.New("invalid service PID: must be greater than 1")
+	}
 	return pid, nil
 }
 
@@ -115,9 +116,8 @@ func (s *Service) Running() bool {
 		return false
 	}
 
-	err = process.Signal(syscall.Signal(0))
-
-	return err == nil
+	defer func() { _ = process.Release() }()
+	return s.matchesDaemon(pid) && process.Signal(syscall.Signal(0)) == nil
 }
 
 func (s *Service) stopService() error {
@@ -198,8 +198,8 @@ func (s *Service) startService() {
 		os.Exit(1)
 	}
 
-	s.setupStopService()
 	s.stop = stop
+	s.setupStopService()
 
 	if !s.daemon {
 		err := s.stopService()
@@ -282,10 +282,6 @@ func (s *Service) Start() error {
 
 // Stop the service daemon.
 func (s *Service) Stop() error {
-	if !s.Running() {
-		return fmt.Errorf("%s service not running", s.Name)
-	}
-
 	pid, err := s.Pid()
 	if err != nil {
 		return fmt.Errorf("read service PID: %w", err)
@@ -294,6 +290,11 @@ func (s *Service) Stop() error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("find service process: %w", err)
+	}
+
+	defer func() { _ = process.Release() }()
+	if !s.matchesDaemon(pid) {
+		return fmt.Errorf("%s PID does not identify its service daemon", s.Name)
 	}
 
 	err = process.Signal(syscall.SIGTERM)

--- a/pkg/tracker/retry.go
+++ b/pkg/tracker/retry.go
@@ -1,0 +1,53 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// StartFileWatchWithRetry tolerates MiSTer state files appearing late in boot.
+// Each failed StartFileWatch closes its watcher before the next attempt.
+func StartFileWatchWithRetry(tr *Tracker) (*fsnotify.Watcher, error) {
+	return retryFileWatch(func() (*fsnotify.Watcher, error) { return StartFileWatch(tr) },
+		time.Sleep, tr.Logger.Warn)
+}
+
+func retryFileWatch(
+	start func() (*fsnotify.Watcher, error), pause func(time.Duration), warn func(string, ...any),
+) (*fsnotify.Watcher, error) {
+	for attempt := 1; ; attempt++ {
+		watcher, err := start()
+		if err == nil {
+			return watcher, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) || attempt >= config.RemoteWatchAttempts {
+			return nil, fmt.Errorf("tracker watch setup failed after %d attempt(s): %w", attempt, err)
+		}
+		warn("tracker files not ready (attempt %d/%d), retrying: %s", attempt, config.RemoteWatchAttempts, err)
+		pause(time.Duration(config.RemoteWatchRetrySeconds) * time.Second)
+	}
+}

--- a/pkg/tracker/retry_test.go
+++ b/pkg/tracker/retry_test.go
@@ -1,0 +1,68 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+func TestWatchRetriesMissingPathsUntilReady(t *testing.T) {
+	calls, waits, logs := 0, 0, 0
+	want := &fsnotify.Watcher{}
+	got, err := retryFileWatch(func() (*fsnotify.Watcher, error) {
+		calls++
+		if calls < 3 {
+			return nil, fmt.Errorf("watch core name: %w", fs.ErrNotExist)
+		}
+		return want, nil
+	}, func(delay time.Duration) {
+		waits++
+		if delay != time.Duration(config.RemoteWatchRetrySeconds)*time.Second {
+			t.Fatalf("unexpected retry delay: %v", delay)
+		}
+	}, func(string, ...any) { logs++ })
+	if err != nil || got != want || calls != 3 || waits != 2 || logs != 2 {
+		t.Fatalf("result=%p err=%v calls=%d waits=%d logs=%d", got, err, calls, waits, logs)
+	}
+}
+
+func TestWatchRetryIsBoundedAndOnlyForMissingPaths(t *testing.T) {
+	for _, failure := range []error{fs.ErrNotExist, fs.ErrPermission} {
+		calls, waits := 0, 0
+		_, err := retryFileWatch(func() (*fsnotify.Watcher, error) {
+			calls++
+			return nil, fmt.Errorf("watch setup: %w", failure)
+		}, func(time.Duration) { waits++ }, func(string, ...any) {})
+		wantCalls := 1
+		if errors.Is(failure, fs.ErrNotExist) {
+			wantCalls = config.RemoteWatchAttempts
+		}
+		if !errors.Is(err, failure) || calls != wantCalls || waits != wantCalls-1 {
+			t.Fatalf("failure=%v calls=%d waits=%d err=%v", failure, calls, waits, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Retry missing tracker watch paths with bounded attempts and diagnostic logs; fail immediately on other errors.
- Verify executable and daemon arguments before trusting or signaling recorded PIDs; preserve numeric PID-file format.
- Bind HTTP before device setup so bind failures use normal startup logging and PID cleanup.
- Add fixture tests and update Remote, LastPlayed, and PlayLog docs.

Closes #109

## Validation
`mage test`, `mage lint`, targeted race checks, Remote/LastPlayed/PlayLog MiSTer builds, and `git diff --check` passed.

No hardware testing. This hardens concrete failure paths; the original intermittent reboot cause was not reproduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote startup now retries tracker setup when required state files are temporarily unavailable.
  * Port conflicts are detected before device setup, with clearer startup failure handling.
  * Service status and stop operations verify the recorded process identity, preventing stale or reused PIDs from targeting unrelated processes.

* **Documentation**
  * Added startup diagnostics, retry behavior, port-conflict guidance, and process identity details to the Remote documentation.
  * Documented safer PID verification for LastPlayed and PlayLog services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->