### PR TITLE
fix(remote): create missing Main INI only on save

### DIFF
--- a/cmd/remote/settings/ini.go
+++ b/cmd/remote/settings/ini.go
@@ -21,6 +21,7 @@ package settings
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -88,20 +89,22 @@ func HandleSaveIni(logger *service.Logger, reqID int) http.HandlerFunc {
 			logger.Info("update mister.ini: %s=%s", key, value)
 		}
 
-		err = mi.Save()
-		if err != nil {
+		if err = saveAndRelaunch(&mi, mister.RelaunchIfInMenu); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			logger.Error("save mister.ini: %s", err)
-			return
-		}
-
-		err = mister.RelaunchIfInMenu()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			logger.Error("relaunch mister: %s", err)
+			logger.Error("save settings: %s", err)
 			return
 		}
 	}
+}
+
+func saveAndRelaunch(mi *mister.MisterIni, relaunch func() error) error {
+	if err := mi.Save(); err != nil {
+		return fmt.Errorf("save MiSTer INI: %w", err)
+	}
+	if err := relaunch(); err != nil {
+		return fmt.Errorf("relaunch MiSTer: %w", err)
+	}
+	return nil
 }
 
 func HandleLoadIni(logger *service.Logger, reqID int) http.HandlerFunc {

--- a/cmd/remote/settings/ini_test.go
+++ b/cmd/remote/settings/ini_test.go
@@ -1,0 +1,54 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+)
+
+func TestRelaunchOnlyAfterSuccessfulINISave(t *testing.T) {
+	root := t.TempDir()
+	mi := &mister.MisterIni{Filename: mister.DefaultIniFilename, Path: filepath.Join(root, mister.DefaultIniFilename)}
+	if err := mi.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if err := mi.SetKey("vscale_mode", "2"); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	relaunch := func() error {
+		calls++
+		if _, err := os.Stat(mi.Path); err != nil {
+			t.Fatalf("relaunch before save: %v", err)
+		}
+		return nil
+	}
+	if err := saveAndRelaunch(mi, relaunch); err != nil || calls != 1 {
+		t.Fatalf("successful save: calls=%d err=%v", calls, err)
+	}
+	mi.Path = filepath.Join(root, "missing-directory", mister.DefaultIniFilename)
+	if err := saveAndRelaunch(mi, relaunch); err == nil || calls != 1 {
+		t.Fatalf("failed save triggered relaunch: calls=%d err=%v", calls, err)
+	}
+}

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1405,7 +1405,7 @@ Notes on usage:
 
 #### List .ini files
 
-List all available MiSTer.ini files on the SD card including alternate files.
+List Main and available alternate MiSTer.ini files on the SD card. Main is always ID 1, including when `MiSTer.ini` does not exist. `MiSTer_example.ini` is excluded case-insensitively. Loading missing Main returns blank configuration without creating a file; saving it creates `MiSTer.ini` with a `[MiSTer]` section. Example and alternate files are not changed by saving Main.
 
 ```plaintext
 GET /settings/inis

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,10 @@ This service must be running to use Remote's web UI or API.
 
 From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The `remote` app in the `Scripts` menu will display the exact address to use if you're not sure.
 
+## Main configuration
+
+Settings always offers Main, even if `MiSTer.ini` is absent. Loading it uses blank defaults without writing a file. Save creates `/media/fat/MiSTer.ini` with a `[MiSTer]` section and the selected settings; the Save screen explains this. `MiSTer_example.ini` is never offered as an active configuration or edited. Saving Main leaves alternate INIs unchanged, and the menu is relaunched only after saving succeeds.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/pkg/mister/config.go
+++ b/pkg/mister/config.go
@@ -211,5 +211,6 @@ var ShadowedIniKeys = []string{
 
 const (
 	DefaultIniFilename = "MiSTer.ini"
+	ExampleIniFilename = "MiSTer_example.ini"
 	MainIniSection     = "MiSTer"
 )

--- a/pkg/mister/ini.go
+++ b/pkg/mister/ini.go
@@ -44,9 +44,16 @@ type MisterIni struct {
 }
 
 func GetAllMisterIni() ([]MisterIni, error) {
-	var inis []MisterIni
+	return getAllMisterIniAt(config.SdFolder)
+}
 
-	files, err := os.ReadDir(config.SdFolder)
+func getAllMisterIniAt(root string) ([]MisterIni, error) {
+	inis := []MisterIni{{
+		Id: 1, DisplayName: "Main", Filename: DefaultIniFilename,
+		Path: filepath.Join(root, DefaultIniFilename),
+	}}
+
+	files, err := os.ReadDir(root)
 	if err != nil {
 		return nil, fmt.Errorf("read MiSTer root: %w", err)
 	}
@@ -54,7 +61,7 @@ func GetAllMisterIni() ([]MisterIni, error) {
 	var iniFilenames []string
 
 	for _, file := range files {
-		if file.IsDir() {
+		if file.IsDir() || strings.EqualFold(file.Name(), ExampleIniFilename) {
 			continue
 		}
 
@@ -63,26 +70,20 @@ func GetAllMisterIni() ([]MisterIni, error) {
 		}
 	}
 
-	currentID := 1
+	currentID := 2
 
 	for _, filename := range iniFilenames {
 		lower := strings.ToLower(filename)
 
 		if strings.EqualFold(lower, DefaultIniFilename) {
-			inis = append(inis, MisterIni{
-				Id:          currentID,
-				DisplayName: "Main",
-				Filename:    filename,
-				Path:        filepath.Join(config.SdFolder, filename),
-			})
-
-			currentID++
+			inis[0].Filename = filename
+			inis[0].Path = filepath.Join(root, filename)
 		} else if strings.HasPrefix(lower, "mister_") {
 			iniFile := MisterIni{
 				Id:          currentID,
 				DisplayName: "",
 				Filename:    filename,
-				Path:        filepath.Join(config.SdFolder, filename),
+				Path:        filepath.Join(root, filename),
 			}
 
 			iniFile.DisplayName = filename[7:]
@@ -149,23 +150,9 @@ func GetMisterIni(id int) (MisterIni, error) {
 	return inis[id-1], nil
 }
 
-// GetAllWithDefaultMisterIni returns all ini files, setting up a default one if none exist.
+// GetAllWithDefaultMisterIni includes Main even when its file does not exist.
 func GetAllWithDefaultMisterIni() ([]MisterIni, error) {
-	inis, err := GetAllMisterIni()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(inis) == 0 {
-		inis = append(inis, MisterIni{
-			Id:          1,
-			DisplayName: "Main",
-			Filename:    DefaultIniFilename,
-			Path:        filepath.Join(config.SdFolder, DefaultIniFilename),
-		})
-	}
-
-	return inis, nil
+	return GetAllMisterIni()
 }
 
 func blankMisterIniFile() (*ini.File, error) {
@@ -190,9 +177,10 @@ func (mi *MisterIni) Load() error {
 		if err != nil {
 			return err
 		}
-		if err = blank.SaveTo(mi.Path); err != nil {
-			return fmt.Errorf("save blank MiSTer INI: %w", err)
-		}
+		// Reading settings must not create configuration. Save is the explicit
+		// write boundary, including on installations containing only the example.
+		mi.File = blank
+		return nil
 	}
 
 	iniFile, err := ini.ShadowLoad(mi.Path)

--- a/pkg/mister/ini_test.go
+++ b/pkg/mister/ini_test.go
@@ -1,0 +1,103 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests operate only within temporary roots.
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExampleOnlyRootCreatesMainOnlyOnSave(t *testing.T) {
+	root := t.TempDir()
+	example := filepath.Join(root, ExampleIniFilename)
+	original := "; example must stay untouched\n[MiSTer]\nvscale_mode=4\n"
+	if err := os.WriteFile(example, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inis, err := getAllMisterIniAt(root)
+	if err != nil || len(inis) != 1 {
+		t.Fatalf("inis=%v err=%v", inis, err)
+	}
+	main := &inis[0]
+	if main.Id != 1 || main.DisplayName != "Main" || main.Filename != DefaultIniFilename {
+		t.Fatalf("Main not exposed: %+v", main)
+	}
+	if loadErr := main.Load(); loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if _, statErr := os.Stat(main.Path); !os.IsNotExist(statErr) {
+		t.Fatalf("Load created Main: %v", statErr)
+	}
+	if setErr := main.SetKey("vscale_mode", "2"); setErr != nil {
+		t.Fatal(setErr)
+	}
+	if saveErr := main.Save(); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	data, err := os.ReadFile(main.Path)
+	if err != nil || !strings.Contains(string(data), "[MiSTer]") || !strings.Contains(string(data), "vscale_mode=2") {
+		t.Fatalf("invalid saved Main: %s %v", data, err)
+	}
+	data, err = os.ReadFile(example)
+	if err != nil || string(data) != original {
+		t.Fatalf("example changed: %s %v", data, err)
+	}
+}
+
+func TestMissingMainKeepsAlternateFilesSeparate(t *testing.T) {
+	root := t.TempDir()
+	original := "; preserve this file\n[MiSTer]\nvideo_mode=8\n"
+	for _, name := range []string{"MISTER_EXAMPLE.INI", "MiSTer_alt_1.ini", "MiSTer_alt_2.ini"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(original), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inis, err := getAllMisterIniAt(root)
+	if err != nil || len(inis) != 3 {
+		t.Fatalf("inis=%v err=%v", inis, err)
+	}
+	for i := range inis {
+		if inis[i].Id != i+1 {
+			t.Fatalf("noncontiguous IDs: %v", inis)
+		}
+	}
+	if inis[0].Filename != DefaultIniFilename || inis[1].Filename != "MiSTer_alt_1.ini" {
+		t.Fatalf("Main or alternate redirected: %v", inis)
+	}
+	if loadErr := inis[0].Load(); loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if saveErr := inis[0].Save(); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	for _, name := range []string{"MISTER_EXAMPLE.INI", "MiSTer_alt_1.ini", "MiSTer_alt_2.ini"} {
+		data, readErr := os.ReadFile(filepath.Join(root, name))
+		if readErr != nil || string(data) != original {
+			t.Fatalf("changed %s: %s %v", name, data, readErr)
+		}
+	}
+	listed, err := getAllMisterIniAt(root)
+	if err != nil || len(listed) != 3 || listed[0].Path != inis[0].Path {
+		t.Fatalf("saving Main changed selection identity: %v %v", listed, err)
+	}
+}

--- a/web/remote/src/components/settings/SettingsCommon.test.tsx
+++ b/web/remote/src/components/settings/SettingsCommon.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { NumberOption } from "./SettingsCommon";
+import { NumberOption, SaveButton } from "./SettingsCommon";
 
 afterEach(cleanup);
 
@@ -25,6 +25,16 @@ function NumberOptionHarness(props: { onChange: (value: string) => void }) {
     />
   );
 }
+
+describe("SaveButton", () => {
+  it("explains that Save creates missing Main without editing the example", () => {
+    render(<SaveButton />);
+    expect(
+      screen.getByText(/Saving Main creates MiSTer.ini if it is missing/),
+    ).toBeTruthy();
+    expect(screen.getByText(/MiSTer_example.ini is never edited/)).toBeTruthy();
+  });
+});
 
 describe("NumberOption", () => {
   it("preserves an incomplete negative value without committing zero", () => {

--- a/web/remote/src/components/settings/SettingsCommon.tsx
+++ b/web/remote/src/components/settings/SettingsCommon.tsx
@@ -97,6 +97,10 @@ export function SaveButton() {
 
   return (
     <>
+      <Typography variant="caption" component="p" sx={{ px: 2 }}>
+        Saving Main creates MiSTer.ini if it is missing. MiSTer_example.ini is
+        never edited.
+      </Typography>
       <Paper
         sx={{
           boxShadow: 2,


### PR DESCRIPTION
## Summary
- Always expose Main as ID 1 and exclude MiSTer_example.ini.
- Load missing Main in memory; create MiSTer.ini only on Save, with an explicit UI notice.
- Preserve example/alternate files and relaunch only after successful save.
- Add regression tests and update documentation.

Closes #111

## Validation
Go tests/lint, targeted race checks, all 13 web tests, web build, Remote MiSTer build, and diff check passed. No device testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Main settings are always available, even when `MiSTer.ini` is missing.
  * Saving Main creates `MiSTer.ini` without modifying example or alternate configuration files.
  * The interface now explains the behavior of saving Main settings.

* **Bug Fixes**
  * Missing configuration files are no longer created during loading.
  * The menu relaunches only after settings are saved successfully.

* **Documentation**
  * Updated remote settings documentation to describe Main configuration and file-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->