### PR TITLE
feat(gamesmenu): add bulk system selection

### DIFF
--- a/cmd/gamesmenu/ui.go
+++ b/cmd/gamesmenu/ui.go
@@ -111,13 +111,13 @@ func (u *ui) renderMain() {
 		list.SetCurrentItem(min(u.mainSelection, len(u.entries)-1))
 	}
 	bar := tui.NewButtonBar(u.app)
-	toggle := func() {
+	updateSelection := func(update func()) {
 		if len(u.entries) == 0 {
 			return
 		}
 		u.mainSelection, u.mainButton = list.GetCurrentItem(), bar.FocusedIndex()
 		buttonFocus := bar.HasFocus()
-		u.entries[u.mainSelection].Selected = !u.entries[u.mainSelection].Selected
+		update()
 		u.renderMain()
 		if buttonFocus {
 			_, primitive := u.pages.GetFrontPage()
@@ -127,11 +127,29 @@ func (u *ui) renderMain() {
 			}
 		}
 	}
+	toggle := func() {
+		updateSelection(func() { u.entries[u.mainSelection].Selected = !u.entries[u.mainSelection].Selected })
+	}
+	bulk := func() {
+		updateSelection(func() {
+			selectAll := false
+			for _, entry := range u.entries {
+				if !entry.Selected {
+					selectAll = true
+					break
+				}
+			}
+			for i := range u.entries {
+				u.entries[i].Selected = selectAll
+			}
+		})
+	}
 	remember := func(action func()) func() {
 		return func() { u.mainSelection, u.mainButton = list.GetCurrentItem(), bar.FocusedIndex(); action() }
 	}
 	list.SetSelectedFunc(func(int, string, string, rune) { toggle() })
 	bar.AddButtonWithHelp("Toggle", "Include or exclude this games folder", toggle).
+		AddButtonWithHelp("All/None", "Select all folders, or clear selection when all are selected", bulk).
 		AddButtonWithHelp("Generate", "Create shortcuts; confirm folder removal", remember(u.startGenerate)).
 		AddButtonWithHelp("Clean Up", "Remove shortcuts whose game is gone", remember(u.startCleanUp)).
 		AddButtonWithHelp("Settings", "Configure GamesMenu interface", remember(u.startSettings)).

--- a/cmd/gamesmenu/ui_test.go
+++ b/cmd/gamesmenu/ui_test.go
@@ -100,7 +100,8 @@ func TestMainPageRendersAndPreservesToggleFocus(t *testing.T) {
 	view := newWorkflowUI(t, false)
 	for _, size := range [][2]int{{75, 15}, {100, 30}} {
 		text := drawText(t, view, size[0], size[1])
-		for _, label := range []string{"[x] NES", "[x] SNES", "Toggle", "Generate", "Clean Up", "Settings", "Exit"} {
+		labels := []string{"[x] NES", "[x] SNES", "Toggle", "All/None", "Generate", "Clean Up", "Settings", "Exit"}
+		for _, label := range labels {
 			if !strings.Contains(text, label) {
 				t.Errorf("missing %q:\n%s", label, text)
 			}
@@ -131,6 +132,73 @@ func TestMainPageRendersAndPreservesToggleFocus(t *testing.T) {
 	}
 	if bar, ok := view.app.GetFocus().(*tui.ButtonBar); !ok || bar.FocusedIndex() != 0 {
 		t.Fatal("button focus lost")
+	}
+}
+
+func TestBulkSelectionPreservesFocusAndFiles(t *testing.T) {
+	view := newWorkflowUI(t, true)
+	custom := filepath.Join(view.manager.Paths().MenuFolder, "_NES", "custom.txt")
+	if err := os.WriteFile(custom, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sendUIKey(view, tcell.KeyDown)
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	for _, entry := range view.entries {
+		if entry.Selected {
+			t.Fatal("All/None did not clear all selections")
+		}
+	}
+	if view.mainButton != 1 || view.mainSelection != 1 {
+		t.Fatal("bulk selection lost footer or row selection")
+	}
+	_, primitive := view.pages.GetFrontPage()
+	frame, ok := primitive.(*tui.PageFrame)
+	if !ok {
+		t.Fatalf("page: %T", primitive)
+	}
+	frame.FocusButtonBar()
+	sendUIKey(view, tcell.KeyEnter)
+	if bar, focused := view.app.GetFocus().(*tui.ButtonBar); !focused || bar.FocusedIndex() != 1 {
+		t.Fatal("bulk selection lost button focus")
+	}
+	for _, entry := range view.entries {
+		if !entry.Selected {
+			t.Fatal("All/None did not select all")
+		}
+	}
+	sendUIKey(view, tcell.KeyEnter)
+	sendUIKey(view, tcell.KeyRight) // Generate with nothing selected still asks before removal.
+	sendUIKey(view, tcell.KeyEnter)
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("bulk deselection bypassed removal confirmation")
+	}
+	sendUIKey(view, tcell.KeyRight) // No.
+	sendUIKey(view, tcell.KeyEnter)
+	data, err := os.ReadFile(custom)
+	if err != nil || string(data) != "keep" {
+		t.Fatalf("selection or cancellation changed files: %q %v", data, err)
+	}
+}
+
+func TestBulkSelectionFromMixedAndEmptyLists(t *testing.T) {
+	view := newWorkflowUI(t, true)
+	view.entries[0].Selected = false
+	view.renderMain()
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	for _, entry := range view.entries {
+		if !entry.Selected {
+			t.Fatal("mixed selection was not expanded to all")
+		}
+	}
+	view.entries = nil
+	view.mainButton = 0
+	view.renderMain()
+	sendUIKey(view, tcell.KeyRight)
+	sendUIKey(view, tcell.KeyEnter)
+	if len(view.entries) != 0 || !view.manager.MenuExists() || view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("empty-list bulk selection changed menu state")
 	}
 }
 

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -13,6 +13,7 @@ Download [gamesmenu.sh](https://github.com/wizzomafizzo/mrext/releases/latest/do
 Each row represents an existing games folder supported by the Zaparoo MiSTer catalog's MGL definitions. Shared folders appear once. Names are sorted by folder key and displayed using `names.txt` replacements. The footer shows the selected row's source paths.
 
 - **Toggle** changes `[x]` (include) to `[ ]` (exclude), or back.
+- **All/None** selects every folder if any are unselected; otherwise it clears every selection. It changes selection only, not files. Generate still asks for confirmation before deleting deselected folders or the whole menu.
 - **Generate** creates missing shortcuts for selected folders.
 - **Clean Up** explicitly removes broken shortcuts.
 - **Settings** opens staged interface settings.


### PR DESCRIPTION
## Summary
- Add controller-accessible All/None footer action, preserving row and button focus.
- Keep selection staged and existing deletion confirmations intact.
- Add simulation regressions and document behavior.

Closes #185

## Validation
`mage test`, `mage lint`, GamesMenu UI race tests, `mage mister gamesmenu`, and `git diff --check` passed.