### PR TITLE
fix(remote): map INI labels and edits to correct configuration

### DIFF
--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -229,6 +229,7 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 
 	corsHandler := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"Origin", "Accept", "Content-Type", "X-Requested-With", mister.IniFilenameHeader},
 		AllowedMethods: []string{"GET", "POST", "DELETE", "PUT"},
 	})
 

--- a/cmd/remote/settings/ini.go
+++ b/cmd/remote/settings/ini.go
@@ -58,6 +58,9 @@ func HandleSaveIni(logger *service.Logger, reqID int) http.HandlerFunc {
 			return
 		}
 
+		if !checkIniFilename(w, r, mi) {
+			return
+		}
 		err = mi.Load()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -108,7 +111,7 @@ func saveAndRelaunch(mi *mister.MisterIni, relaunch func() error) error {
 }
 
 func HandleLoadIni(logger *service.Logger, reqID int) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("load ini request: %d", reqID)
 
 		mi, err := mister.GetMisterIni(reqID)
@@ -118,6 +121,9 @@ func HandleLoadIni(logger *service.Logger, reqID int) http.HandlerFunc {
 			return
 		}
 
+		if !checkIniFilename(w, r, mi) {
+			return
+		}
 		err = mi.Load()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -195,6 +201,16 @@ func HandleListInis(logger *service.Logger) http.HandlerFunc {
 	}
 }
 
+// Optional identity guard extends the API without changing existing JSON shapes.
+func checkIniFilename(w http.ResponseWriter, r *http.Request, mi mister.MisterIni) bool {
+	expected := r.Header.Get(mister.IniFilenameHeader)
+	if expected != "" && expected != mi.Filename {
+		http.Error(w, "INI filename no longer matches this slot; reload settings", http.StatusConflict)
+		return false
+	}
+	return true
+}
+
 type SetActiveIniRequest struct {
 	Ini int `json:"ini"`
 }
@@ -216,16 +232,14 @@ func HandleSetActiveIni(logger *service.Logger) http.HandlerFunc {
 			return
 		}
 
-		availableInis, err := mister.GetAllWithDefaultMisterIni()
+		selectedIni, err := mister.GetMisterIni(args.Ini)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			logger.Error("list mister.inis: %s", err)
 			return
 		}
 
-		if args.Ini > len(availableInis) {
-			http.Error(w, "ini does not exist", http.StatusInternalServerError)
-			logger.Error("ini does not exist")
+		if !checkIniFilename(w, r, selectedIni) {
 			return
 		}
 

--- a/cmd/remote/settings/ini_test.go
+++ b/cmd/remote/settings/ini_test.go
@@ -20,12 +20,28 @@
 package settings
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 )
+
+func TestExpectedFilenameGuard(t *testing.T) {
+	mi := mister.MisterIni{Id: 4, Filename: "MiSTer_ultrawide.ini"}
+	for _, expected := range []string{"", mi.Filename, "MiSTer_auto.ini"} {
+		request := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/settings/inis/4", http.NoBody)
+		request.Header.Set(mister.IniFilenameHeader, expected)
+		response := httptest.NewRecorder()
+		accepted := checkIniFilename(response, request, mi)
+		want := expected == "" || expected == mi.Filename
+		if accepted != want || (!want && response.Code != http.StatusConflict) {
+			t.Fatalf("expected=%q accepted=%t status=%d", expected, accepted, response.Code)
+		}
+	}
+}
 
 func TestRelaunchOnlyAfterSuccessfulINISave(t *testing.T) {
 	root := t.TempDir()

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1417,15 +1417,15 @@ On success, returns `200` and object:
 
 | Attribute | Type   | Description                                                                                                                                          |
 |-----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `active`  | number | `0` to `4`. This is the current active .ini file's ID in the list. `0` is a special value meaning no value has been set, which falls back on ID `1`. |
+| `active`  | number | Active MiSTer slot, `0` to `4`; `0` falls back to Main (`1`). An excluded/unavailable slot may not appear in `inis`. |
 | `inis`    | Ini[]  | List of Ini objects (see below).                                                                                                                     |
 
 Ini object:
 
 | Attribute     | Type   | Description                                        |
 |---------------|--------|----------------------------------------------------|
-| `id`          | number | ID of .ini file.                                   |
-| `displayName` | string | Name of the .ini file as it would show in the OSD. |
+| `id`          | number | MiSTer slot ID, not array position. IDs may have gaps. |
+| `displayName` | string | Descriptive INI name; custom names are no longer truncated to OSD label length. |
 | `filename`    | string | Filename of the .ini file.                         |
 | `path`        | string | Absolute path to the .ini file.                    |
 
@@ -1472,6 +1472,10 @@ Example request:
 ```shell
 curl --request PUT --url "http://mister:8182/api/settings/inis" --data '{"ini":1}'
 ```
+
+INI listing uses MiSTer's first-three-candidates-then-case-insensitive-sort rule. The example is excluded only after slot assignment. Clients must use each object's `id`, not its array index. Detected slot-layout changes fail requests; restart MiSTer and Remote together after changing alternate filenames.
+
+For loading, saving, or activating an INI, clients may send `X-Mrext-Ini-Filename` with the expected `filename` from the listing. A mismatch returns `409` before reading, saving, or activating another file. Existing JSON shapes are unchanged; the header is optional for legacy clients and always sent by the current UI. Editors should retain the loaded ID/filename rather than re-fetching the active slot at Save time.
 
 #### Get .ini file values
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -53,6 +53,14 @@ From a web browser, navigate to `http://<mister_ip>:8182` to access Remote. The 
 
 Settings always offers Main, even if `MiSTer.ini` is absent. Loading it uses blank defaults without writing a file. Save creates `/media/fat/MiSTer.ini` with a `[MiSTer]` section and the selected settings; the Save screen explains this. `MiSTer_example.ini` is never offered as an active configuration or edited. Saving Main leaves alternate INIs unchanged, and the menu is relaunched only after saving succeeds.
 
+## INI slot identity
+
+Remote follows current MiSTer `cfg_get_name` ordering: take the first three `MiSTer_*.ini` names in filesystem directory order, then sort that subset case-insensitively. Main remains slot 1. The example file can consume a MiSTer slot but is not editable in Remote, so displayed IDs can have gaps. Custom names are shown in full rather than truncated to four characters.
+
+Each settings page shows the file being edited. Save targets that loaded filename even if the active slot changes elsewhere. Switching files asks before discarding edits; missing values in the new file return to defaults. Failed loads disable Save and report the error.
+
+Remote retains its first observed slot layout and refuses further access if it detects a change. **After adding, removing, or renaming alternate INIs, restart both MiSTer and Remote before editing.** MiSTer caches its mapping internally; Remote cannot reconstruct a different mapping cached before Remote started. Older firmware with different ordering is not verified. No INI files are renamed to force an order.
+
 ## Uninstall
 
 After opening `remote` from the `Scripts` menu, there is an option available to uninstall Remote called `Uninstall`. You can also run `remote.sh -uninstall` from the console or via SSH.

--- a/pkg/mister/config.go
+++ b/pkg/mister/config.go
@@ -212,5 +212,6 @@ var ShadowedIniKeys = []string{
 const (
 	DefaultIniFilename = "MiSTer.ini"
 	ExampleIniFilename = "MiSTer_example.ini"
+	IniFilenameHeader  = "X-Mrext-Ini-Filename"
 	MainIniSection     = "MiSTer"
 )

--- a/pkg/mister/ini.go
+++ b/pkg/mister/ini.go
@@ -24,7 +24,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
@@ -43,76 +46,113 @@ type MisterIni struct {
 	Id          int       `json:"id"` //nolint:revive // Legacy public field name.
 }
 
+type iniLayout struct {
+	names       []string
+	mu          sync.Mutex
+	initialized bool
+}
+
+var currentIniLayout iniLayout
+
+func (layout *iniLayout) accept(names []string) bool {
+	layout.mu.Lock()
+	defer layout.mu.Unlock()
+	if !layout.initialized {
+		layout.names = slices.Clone(names)
+		layout.initialized = true
+	}
+	return slices.Equal(layout.names, names)
+}
+
 func GetAllMisterIni() ([]MisterIni, error) {
-	return getAllMisterIniAt(config.SdFolder)
+	return discoverMisterInis(config.SdFolder, &currentIniLayout)
 }
 
 func getAllMisterIniAt(root string) ([]MisterIni, error) {
-	inis := []MisterIni{{
-		Id: 1, DisplayName: "Main", Filename: DefaultIniFilename,
-		Path: filepath.Join(root, DefaultIniFilename),
-	}}
+	return discoverMisterInis(root, nil)
+}
 
-	files, err := os.ReadDir(root)
+func discoverMisterInis(root string, layout *iniLayout) ([]MisterIni, error) {
+	// os.ReadDir sorts names; MiSTer's cfg.cpp cfg_get_name first selects
+	// three candidates in readdir order, THEN sorts that subset ignoring case.
+	// #nosec G304 -- configured MiSTer root, or an injected temporary fixture root.
+	dir, err := os.Open(root)
+	if err != nil {
+		return nil, fmt.Errorf("open MiSTer root: %w", err)
+	}
+	defer func() { _ = dir.Close() }()
+	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return nil, fmt.Errorf("read MiSTer root: %w", err)
 	}
+	slots := alternateIniNames(names)
+	if layout != nil && !layout.accept(slots) {
+		return nil, errors.New("INI slot layout changed; restart MiSTer and Remote before editing settings")
+	}
+	return iniEntries(root, names, slots), nil
+}
 
-	var iniFilenames []string
+// MiSTer's C-locale strcasecmp folds ASCII bytes, not Unicode case variants.
+func iniASCIILower(name string) string {
+	lower := []byte(name)
+	for i, b := range lower {
+		if b >= 'A' && b <= 'Z' {
+			lower[i] = b + ('a' - 'A')
+		}
+	}
+	return string(lower)
+}
 
-	for _, file := range files {
-		if file.IsDir() || strings.EqualFold(file.Name(), ExampleIniFilename) {
+func alternateIniNames(names []string) []string {
+	slots := make([]string, 0, 3)
+	for _, name := range names {
+		lower := iniASCIILower(name)
+		if strings.HasPrefix(lower, "mister_") && strings.HasSuffix(lower, ".ini") {
+			// Match MiSTer's 64-byte name buffer, including its terminator.
+			if len(name) > 63 {
+				name = name[:63]
+			}
+			slots = append(slots, name)
+			if len(slots) == 3 {
+				break
+			}
+		}
+	}
+	sort.SliceStable(slots, func(i, j int) bool { return iniASCIILower(slots[i]) < iniASCIILower(slots[j]) })
+	return slots
+}
+
+func iniEntries(root string, names, slots []string) []MisterIni {
+	main := DefaultIniFilename
+	for _, name := range names {
+		if strings.EqualFold(name, DefaultIniFilename) {
+			main = name
+			break
+		}
+	}
+	inis := []MisterIni{{Id: 1, DisplayName: "Main", Filename: main, Path: filepath.Join(root, main)}}
+	for i, filename := range slots {
+		// The example consumes a MiSTer slot but must never become editable.
+		// Do not compact IDs when omitting it or an unusable filename.
+		if strings.EqualFold(filename, ExampleIniFilename) || !strings.EqualFold(filepath.Ext(filename), ".ini") {
 			continue
 		}
-
-		if filepath.Ext(strings.ToLower(file.Name())) == ".ini" {
-			iniFilenames = append(iniFilenames, file.Name())
+		label := strings.TrimSuffix(filename[7:], filepath.Ext(filename))
+		switch strings.ToLower(label) {
+		case "alt_1":
+			label = "Alt1"
+		case "alt_2":
+			label = "Alt2"
+		case "alt_3":
+			label = "Alt3"
+		case "":
+			label = " -- "
 		}
+		inis = append(inis, MisterIni{
+			Id: i + 2, DisplayName: label, Filename: filename, Path: filepath.Join(root, filename),
+		})
 	}
-
-	currentID := 2
-
-	for _, filename := range iniFilenames {
-		lower := strings.ToLower(filename)
-
-		if strings.EqualFold(lower, DefaultIniFilename) {
-			inis[0].Filename = filename
-			inis[0].Path = filepath.Join(root, filename)
-		} else if strings.HasPrefix(lower, "mister_") {
-			iniFile := MisterIni{
-				Id:          currentID,
-				DisplayName: "",
-				Filename:    filename,
-				Path:        filepath.Join(root, filename),
-			}
-
-			iniFile.DisplayName = filename[7:]
-			iniFile.DisplayName = strings.TrimSuffix(iniFile.DisplayName, filepath.Ext(iniFile.DisplayName))
-
-			switch iniFile.DisplayName {
-			case "":
-				iniFile.DisplayName = " -- "
-			case "alt_1":
-				iniFile.DisplayName = "Alt1"
-			case "alt_2":
-				iniFile.DisplayName = "Alt2"
-			case "alt_3":
-				iniFile.DisplayName = "Alt3"
-			}
-
-			if len(iniFile.DisplayName) > 4 {
-				iniFile.DisplayName = iniFile.DisplayName[0:4]
-			}
-
-			if len(inis) < 4 {
-				inis = append(inis, iniFile)
-			}
-
-			currentID++
-		}
-	}
-
-	return inis, nil
+	return inis
 }
 
 func GetActiveMisterIni() (MisterIni, error) {
@@ -130,11 +170,7 @@ func GetActiveMisterIni() (MisterIni, error) {
 		return MisterIni{}, err
 	}
 
-	if activeID < 1 || activeID > len(inis) {
-		return MisterIni{}, fmt.Errorf("active ini id is out of range: %d (%d)", activeID, len(inis))
-	}
-
-	return inis[activeID-1], nil
+	return iniByID(inis, activeID)
 }
 
 func GetMisterIni(id int) (MisterIni, error) {
@@ -143,11 +179,16 @@ func GetMisterIni(id int) (MisterIni, error) {
 		return MisterIni{}, err
 	}
 
-	if id < 1 || id > len(inis) {
-		return MisterIni{}, fmt.Errorf("ini id is out of range: %d (%d)", id, len(inis))
-	}
+	return iniByID(inis, id)
+}
 
-	return inis[id-1], nil
+func iniByID(inis []MisterIni, id int) (MisterIni, error) {
+	for i := range inis {
+		if inis[i].Id == id {
+			return inis[i], nil
+		}
+	}
+	return MisterIni{}, fmt.Errorf("INI slot %d is unavailable for editing", id)
 }
 
 // GetAllWithDefaultMisterIni includes Main even when its file does not exist.

--- a/pkg/mister/ini_test.go
+++ b/pkg/mister/ini_test.go
@@ -23,9 +23,58 @@ package mister
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestIniSlotsMatchMisterFirstThreeThenSort(t *testing.T) {
+	names := []string{"MiSTer_z.ini", "MiSTer_ultrawide.ini", "MiSTer_AUTO.ini", "MiSTer_aaa.ini"}
+	slots := alternateIniNames(names)
+	want := []string{"MiSTer_AUTO.ini", "MiSTer_ultrawide.ini", "MiSTer_z.ini"}
+	if !reflect.DeepEqual(slots, want) {
+		t.Fatalf("slots=%v want=%v", slots, want)
+	}
+	entries := iniEntries(t.TempDir(), names, slots)
+	if entries[2].DisplayName != "ultrawide" || entries[2].Id != 3 {
+		t.Fatalf("label or ID lost: %+v", entries[2])
+	}
+}
+
+func TestIniSlotsUseASCIICaseOrdering(t *testing.T) {
+	names := []string{"MiSTer_K.ini", "MiSTer_z.ini", "MiSTer_a.ini"}
+	want := []string{"MiSTer_a.ini", "MiSTer_z.ini", "MiSTer_K.ini"}
+	if got := alternateIniNames(names); !reflect.DeepEqual(got, want) {
+		t.Fatalf("slots=%v want=%v", got, want)
+	}
+}
+
+func TestExampleSlotIsNotReassigned(t *testing.T) {
+	names := []string{"MiSTer_ultrawide.ini", "MiSTer_example.ini", "MiSTer_auto.ini"}
+	entries := iniEntries(t.TempDir(), names, alternateIniNames(names))
+	if _, err := iniByID(entries, 3); err == nil {
+		t.Fatal("example slot reassigned to another file")
+	}
+	selected, err := iniByID(entries, 4)
+	if err != nil || selected.Filename != "MiSTer_ultrawide.ini" {
+		t.Fatalf("wrong slot identity: %+v %v", selected, err)
+	}
+}
+
+func TestIniLayoutRejectsDrift(t *testing.T) {
+	var layout iniLayout
+	names := []string{"MiSTer_auto.ini", "MiSTer_ultrawide.ini"}
+	if !layout.accept(names) {
+		t.Fatal("initial layout rejected")
+	}
+	if !layout.accept(names) {
+		t.Fatal("stable layout rejected")
+	}
+	names[0] = "MiSTer_another.ini"
+	if layout.accept(names) {
+		t.Fatal("changed slot layout accepted")
+	}
+}
 
 func TestExampleOnlyRootCreatesMainOnlyOnSave(t *testing.T) {
 	root := t.TempDir()

--- a/pkg/mister/launchers.go
+++ b/pkg/mister/launchers.go
@@ -583,8 +583,8 @@ func LaunchToken(cfg *config.UserConfig, manual bool, kbd input.Keyboard, text s
 				return fmt.Errorf("parse INI ID: %w", err)
 			}
 
-			if id < 1 || id > len(inis) {
-				return fmt.Errorf("ini id out of range: %d", id)
+			if _, lookupErr := iniByID(inis, id); lookupErr != nil {
+				return lookupErr
 			}
 
 			return SetActiveIni(id, true)

--- a/web/remote/src/components/settings/Settings.tsx
+++ b/web/remote/src/components/settings/Settings.tsx
@@ -36,7 +36,11 @@ import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import Dialog from "@mui/material/Dialog";
 import Typography from "@mui/material/Typography";
 import { ControlApi } from "../../lib/api";
-import { loadMisterIni, useIniSettingsStore } from "../../lib/ini";
+import {
+  iniErrorMessage,
+  loadMisterIni,
+  useIniSettingsStore,
+} from "../../lib/ini";
 
 function SettingsPageLink(props: {
   page: SettingsPageId;
@@ -66,13 +70,25 @@ function IniSwitcher() {
   const iniSettings = useIniSettingsStore();
 
   const changeIni = async (id: number) => {
+    const target = inis.data?.inis.find((ini) => ini.id === id);
+    if (!target) return;
+    if (
+      iniSettings.modified.length &&
+      !window.confirm("Discard unsaved settings before switching INI?")
+    )
+      return;
     setChangingIni(true);
     try {
-      await api.setMisterIni({ ini: id });
+      await api.setMisterIni({ ini: id }, target.filename);
       setIniDialogOpen(false);
-      await Promise.all([inis.refetch(), loadMisterIni(id, iniSettings, true)]);
+      await Promise.all([
+        inis.refetch(),
+        loadMisterIni(id, iniSettings, true).catch(() => {}),
+      ]);
     } catch (error) {
-      console.error(error);
+      useIniSettingsStore.setState({
+        iniError: iniErrorMessage(error),
+      });
     } finally {
       setChangingIni(false);
     }
@@ -92,7 +108,9 @@ function IniSwitcher() {
       id = inis.data.active;
     }
 
-    activeIni.name = inis.data.inis[id - 1].displayName;
+    activeIni.name =
+      inis.data.inis.find((ini) => ini.id === id)?.displayName ??
+      `Unavailable slot ${id}`;
     activeIni.id = id;
   }
 
@@ -113,19 +131,13 @@ function IniSwitcher() {
               </Typography>
             </ListItem>
             {(inis.data?.inis || []).map(
-              (
-                ini: {
-                  filename: string;
-                  displayName: string;
-                },
-                i: number,
-              ) => (
+              (ini: { id: number; filename: string; displayName: string }) => (
                 <ListItem key={ini.filename} disableGutters>
                   <Button
                     fullWidth
-                    variant={activeIni.id == i + 1 ? "contained" : "outlined"}
-                    disabled={changingIni}
-                    onClick={() => void changeIni(i + 1)}
+                    variant={activeIni.id === ini.id ? "contained" : "outlined"}
+                    disabled={changingIni || iniSettings.loadingIni}
+                    onClick={() => void changeIni(ini.id)}
                   >
                     {ini.displayName}
                   </Button>
@@ -146,6 +158,22 @@ function IniSwitcher() {
           Active INI: {activeIni.name}
         </Button>
       </ListItem>
+      {iniSettings.loadedIni && (
+        <ListItem>
+          <Typography>
+            Editing: {iniSettings.loadedIni.displayName} (
+            {iniSettings.loadedIni.filename})
+          </Typography>
+        </ListItem>
+      )}
+      {(iniSettings.iniError || inis.error) && (
+        <ListItem>
+          <Typography color="error">
+            {iniSettings.iniError ||
+              "Unable to list INI slots. Restart MiSTer and Remote if the INI layout changed."}
+          </Typography>
+        </ListItem>
+      )}
     </>
   );
 }
@@ -213,17 +241,9 @@ export default function Settings() {
   const iniSettingsStore = useIniSettingsStore();
 
   useEffect(() => {
-    const api = new ControlApi();
-    api.listMisterInis().then((inis) => {
-      let id: number;
-      if (inis.active === 0) {
-        id = 1;
-      } else {
-        id = inis.active;
-      }
-
-      loadMisterIni(id, iniSettingsStore).catch((err) => console.error(err));
-    });
+    // Active-slot discovery belongs to the guarded load, so a late listing
+    // cannot undo a newer explicit switch. The loader owns its error state.
+    void loadMisterIni(undefined, iniSettingsStore).catch(() => {});
   }, []);
 
   const page = (() => {

--- a/web/remote/src/components/settings/SettingsCommon.test.tsx
+++ b/web/remote/src/components/settings/SettingsCommon.test.tsx
@@ -1,12 +1,24 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NumberOption, SaveButton } from "./SettingsCommon";
+import { useIniSettingsStore } from "../../lib/ini";
+import { ControlApi } from "../../lib/api";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  useIniSettingsStore.getState().reset();
+});
 
 function NumberOptionHarness(props: { onChange: (value: string) => void }) {
   const [value, setValue] = useState("10");
@@ -27,6 +39,35 @@ function NumberOptionHarness(props: { onChange: (value: string) => void }) {
 }
 
 describe("SaveButton", () => {
+  it("shows and saves the loaded filename without re-fetching active slot", async () => {
+    useIniSettingsStore.setState({
+      loadedIni: {
+        id: 4,
+        filename: "MiSTer_ultrawide.ini",
+        displayName: "ultrawide",
+        path: "/media/fat/MiSTer_ultrawide.ini",
+      },
+    });
+    useIniSettingsStore.getState().setFont("test/font");
+    const list = vi.spyOn(ControlApi.prototype, "listMisterInis");
+    const save = vi
+      .spyOn(ControlApi.prototype, "saveMisterIni")
+      .mockResolvedValue();
+    render(<SaveButton />);
+    expect(
+      screen.getByText("Editing: ultrawide (MiSTer_ultrawide.ini)"),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith(
+        4,
+        { font: "test/font" },
+        "MiSTer_ultrawide.ini",
+      ),
+    );
+    expect(list).not.toHaveBeenCalled();
+  });
+
   it("explains that Save creates missing Main without editing the example", () => {
     render(<SaveButton />);
     expect(

--- a/web/remote/src/components/settings/SettingsCommon.tsx
+++ b/web/remote/src/components/settings/SettingsCommon.tsx
@@ -23,8 +23,13 @@ import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 
 import { useUIStateStore, SettingsPageId } from "../../lib/store";
-import { saveMisterIni, useIniSettingsStore } from "../../lib/ini";
-import { ControlApi } from "../../lib/api";
+import {
+  iniErrorMessage,
+  loadMisterIni,
+  saveMisterIni,
+  useIniSettingsStore,
+} from "../../lib/ini";
+import Alert from "@mui/material/Alert";
 import { ListInisPayload } from "../../lib/models";
 
 export function activeIniId(inis: ListInisPayload): number {
@@ -97,6 +102,26 @@ export function SaveButton() {
 
   return (
     <>
+      <Typography variant="body2" sx={{ px: 2 }}>
+        {store.loadedIni
+          ? `Editing: ${store.loadedIni.displayName} (${store.loadedIni.filename})`
+          : "No INI loaded"}
+      </Typography>
+      {store.iniError && (
+        <Alert severity="error">
+          {store.iniError}
+          {store.loadedIni && (
+            <Button
+              disabled={store.loadingIni}
+              onClick={() => {
+                void loadMisterIni(store.loadedIni!.id, store).catch(() => {});
+              }}
+            >
+              Reload settings
+            </Button>
+          )}
+        </Alert>
+      )}
       <Typography variant="caption" component="p" sx={{ px: 2 }}>
         Saving Main creates MiSTer.ini if it is missing. MiSTer_example.ini is
         never edited.
@@ -117,14 +142,25 @@ export function SaveButton() {
             <Button
               variant="contained"
               onClick={() => {
-                const api = new ControlApi();
-                api.listMisterInis().then((inis) => {
-                  saveMisterIni(activeIniId(inis), store).catch((err) =>
-                    console.error(err),
-                  );
+                if (!store.loadedIni) return;
+                void saveMisterIni(store.loadedIni.id, store).catch((error) => {
+                  if (
+                    useIniSettingsStore.getState().loadedIni?.filename ===
+                    store.loadedIni?.filename
+                  ) {
+                    useIniSettingsStore.setState({
+                      iniError: iniErrorMessage(error),
+                    });
+                  }
                 });
               }}
-              disabled={modified.length === 0}
+              disabled={
+                modified.length === 0 ||
+                !store.loadedIni ||
+                store.loadingIni ||
+                store.savingIni ||
+                !!store.iniError
+              }
               color="success"
               fullWidth
             >

--- a/web/remote/src/lib/api.ts
+++ b/web/remote/src/lib/api.ts
@@ -213,16 +213,21 @@ export class ControlApi {
   async saveMisterIni(
     id: number,
     data: { [key: string]: string },
+    filename?: string,
   ): Promise<void> {
-    await axios.put(`/settings/inis/${id}`, data);
+    await axios.put(`/settings/inis/${id}`, data, {
+      headers: filename ? { "X-Mrext-Ini-Filename": filename } : {},
+    });
   }
 
   async listMisterInis(): Promise<ListInisPayload> {
     return (await axios.get<ListInisPayload>(`/settings/inis`)).data;
   }
 
-  async setMisterIni(data: { ini: number }): Promise<void> {
-    await axios.put(`/settings/inis`, data);
+  async setMisterIni(data: { ini: number }, filename?: string): Promise<void> {
+    await axios.put(`/settings/inis`, data, {
+      headers: filename ? { "X-Mrext-Ini-Filename": filename } : {},
+    });
   }
 
   async setMenuBackgroundMode(data: { mode: number }): Promise<void> {
@@ -233,9 +238,15 @@ export class ControlApi {
     await axios.post(`/settings/remote/restart`);
   }
 
-  async loadMisterIni(id: number): Promise<{ [key: string]: string }> {
-    return (await axios.get<{ [key: string]: string }>(`/settings/inis/${id}`))
-      .data;
+  async loadMisterIni(
+    id: number,
+    filename?: string,
+  ): Promise<{ [key: string]: string }> {
+    return (
+      await axios.get<{ [key: string]: string }>(`/settings/inis/${id}`, {
+        headers: filename ? { "X-Mrext-Ini-Filename": filename } : {},
+      })
+    ).data;
   }
 
   async sysInfo(): Promise<SysInfoResponse> {

--- a/web/remote/src/lib/ini.test.ts
+++ b/web/remote/src/lib/ini.test.ts
@@ -9,6 +9,164 @@ describe("INI settings state", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     useIniSettingsStore.getState().reset();
+    vi.spyOn(ControlApi.prototype, "listMisterInis").mockResolvedValue({
+      active: 1,
+      inis: [
+        {
+          id: 1,
+          filename: "MiSTer.ini",
+          displayName: "Main",
+          path: "/media/fat/MiSTer.ini",
+        },
+        {
+          id: 2,
+          filename: "MiSTer_auto.ini",
+          displayName: "auto",
+          path: "/media/fat/MiSTer_auto.ini",
+        },
+        {
+          id: 4,
+          filename: "MiSTer_ultrawide.ini",
+          displayName: "ultrawide",
+          path: "/media/fat/MiSTer_ultrawide.ini",
+        },
+      ],
+    });
+  });
+
+  it("pins saves to the loaded file even when active slot changes", async () => {
+    vi.spyOn(ControlApi.prototype, "loadMisterIni").mockResolvedValue({});
+    const save = vi
+      .spyOn(ControlApi.prototype, "saveMisterIni")
+      .mockResolvedValue();
+    await loadMisterIni(4, useIniSettingsStore.getState());
+    useIniSettingsStore.getState().setHostname("wide");
+    vi.mocked(ControlApi.prototype.listMisterInis).mockResolvedValue({
+      active: 2,
+      inis: [],
+    });
+    await saveMisterIni(4, useIniSettingsStore.getState());
+    expect(save).toHaveBeenCalledWith(
+      4,
+      { __hostname: "wide" },
+      "MiSTer_ultrawide.ini",
+    );
+    await expect(
+      saveMisterIni(2, useIniSettingsStore.getState()),
+    ).rejects.toThrow("Load a valid INI");
+  });
+
+  it("rejects unavailable slot gaps rather than editing the next file", async () => {
+    const load = vi.spyOn(ControlApi.prototype, "loadMisterIni");
+    await expect(
+      loadMisterIni(3, useIniSettingsStore.getState()),
+    ).rejects.toThrow("unavailable");
+    expect(load).not.toHaveBeenCalled();
+    expect(useIniSettingsStore.getState().loadedIni).toBeNull();
+  });
+
+  it("resets settings omitted by the target file on explicit switch", async () => {
+    vi.spyOn(ControlApi.prototype, "loadMisterIni")
+      .mockResolvedValueOnce({ font: "custom/font" })
+      .mockResolvedValueOnce({});
+    await loadMisterIni(1, useIniSettingsStore.getState());
+    await loadMisterIni(2, useIniSettingsStore.getState(), true);
+    expect(useIniSettingsStore.getState().font).toBe("");
+    expect(useIniSettingsStore.getState().loadedIni?.filename).toBe(
+      "MiSTer_auto.ini",
+    );
+  });
+
+  it("ignores late initial active-slot discovery after an explicit switch", async () => {
+    const listing = await ControlApi.prototype.listMisterInis();
+    let complete!: (value: typeof listing) => void;
+    vi.mocked(ControlApi.prototype.listMisterInis).mockReturnValueOnce(
+      new Promise((resolve) => {
+        complete = resolve;
+      }),
+    );
+    const request = vi
+      .spyOn(ControlApi.prototype, "loadMisterIni")
+      .mockResolvedValue({});
+    const initial = loadMisterIni(undefined, useIniSettingsStore.getState());
+    await loadMisterIni(4, useIniSettingsStore.getState(), true);
+    complete(listing);
+    await initial;
+    expect(useIniSettingsStore.getState().loadedIni?.id).toBe(4);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(4, "MiSTer_ultrawide.ini");
+  });
+
+  it("ignores an old load that completes after switching", async () => {
+    let complete!: (value: { [key: string]: string }) => void;
+    const old = new Promise<{ [key: string]: string }>((resolve) => {
+      complete = resolve;
+    });
+    vi.spyOn(ControlApi.prototype, "loadMisterIni")
+      .mockReturnValueOnce(old)
+      .mockResolvedValueOnce({ font: "new/font" });
+    const first = loadMisterIni(1, useIniSettingsStore.getState());
+    await Promise.resolve();
+    await loadMisterIni(2, useIniSettingsStore.getState(), true);
+    complete({ font: "old/font" });
+    await first;
+    expect(useIniSettingsStore.getState().font).toBe("new/font");
+    expect(useIniSettingsStore.getState().loadedIni?.id).toBe(2);
+  });
+
+  it("ignores save completion after the editor switches files", async () => {
+    vi.spyOn(ControlApi.prototype, "loadMisterIni").mockResolvedValue({});
+    let complete!: () => void;
+    vi.spyOn(ControlApi.prototype, "saveMisterIni").mockReturnValue(
+      new Promise<void>((resolve) => {
+        complete = resolve;
+      }),
+    );
+    await loadMisterIni(1, useIniSettingsStore.getState());
+    useIniSettingsStore.getState().setFont("old/font");
+    const save = saveMisterIni(1, useIniSettingsStore.getState());
+    await loadMisterIni(2, useIniSettingsStore.getState(), true);
+    useIniSettingsStore.getState().setFont("new/font");
+    complete();
+    await save;
+    expect(useIniSettingsStore.getState().original.font).toBe("");
+    expect(useIniSettingsStore.getState().modified).toContain("font");
+  });
+
+  it("keeps failed loads unsaveable and reports the failure", async () => {
+    vi.spyOn(ControlApi.prototype, "loadMisterIni").mockRejectedValue(
+      new Error("layout changed"),
+    );
+    const save = vi.spyOn(ControlApi.prototype, "saveMisterIni");
+    await expect(
+      loadMisterIni(1, useIniSettingsStore.getState()),
+    ).rejects.toThrow("layout changed");
+    expect(useIniSettingsStore.getState().iniError).toBe("layout changed");
+    expect(useIniSettingsStore.getState().loadingIni).toBe(false);
+    await expect(
+      saveMisterIni(1, useIniSettingsStore.getState()),
+    ).rejects.toThrow();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("blocks overlapping saves even with the same stale UI snapshot", async () => {
+    vi.spyOn(ControlApi.prototype, "loadMisterIni").mockResolvedValue({});
+    await loadMisterIni(1, useIniSettingsStore.getState());
+    let complete!: () => void;
+    const request = vi
+      .spyOn(ControlApi.prototype, "saveMisterIni")
+      .mockReturnValue(
+        new Promise<void>((resolve) => {
+          complete = resolve;
+        }),
+      );
+    const snapshot = useIniSettingsStore.getState();
+    const first = saveMisterIni(1, snapshot);
+    await expect(saveMisterIni(1, snapshot)).rejects.toThrow();
+    expect(request).toHaveBeenCalledTimes(1);
+    complete();
+    await first;
+    expect(useIniSettingsStore.getState().savingIni).toBe(false);
   });
 
   it("clears modified keys when all changes are reverted", () => {
@@ -77,6 +235,8 @@ describe("INI settings state", () => {
       pendingSave,
     );
 
+    vi.spyOn(ControlApi.prototype, "loadMisterIni").mockResolvedValue({});
+    await loadMisterIni(1, useIniSettingsStore.getState());
     useIniSettingsStore.getState().setHostname("first");
     const save = saveMisterIni(1, useIniSettingsStore.getState());
     useIniSettingsStore.getState().setHostname("second");

--- a/web/remote/src/lib/ini.ts
+++ b/web/remote/src/lib/ini.ts
@@ -1,5 +1,16 @@
 import { ControlApi } from "./api";
+import { IniResponse } from "./models";
+
 import { create } from "zustand";
+import { isAxiosError } from "axios";
+
+let loadSequence = 0;
+
+export function iniErrorMessage(error: unknown): string {
+  if (isAxiosError(error) && typeof error.response?.data === "string")
+    return error.response.data.trim();
+  return error instanceof Error ? error.message : String(error);
+}
 
 const iniKeyMap: { [key: string]: string } = {
   ypbpr: "ypbpr",
@@ -313,6 +324,10 @@ type IniStore = IniState &
   IniActions & {
     original: IniState;
     modified: string[];
+    loadedIni: IniResponse | null;
+    loadingIni: boolean;
+    savingIni: boolean;
+    iniError: string;
   };
 
 const initialState: IniState = {
@@ -448,13 +463,28 @@ export const useIniSettingsStore = create<IniStore>()((set) => ({
 
   original: initialState,
   modified: [],
+  loadedIni: null,
+  loadingIni: false,
+  savingIni: false,
+  iniError: "",
 
   setAttribute: (key: string, value: string) =>
     set(() => ({
       [key]: value,
     })),
 
-  reset: () => set(initialState),
+  reset: () => {
+    loadSequence++;
+    set({
+      ...initialState,
+      original: initialState,
+      modified: [],
+      loadedIni: null,
+      loadingIni: false,
+      savingIni: false,
+      iniError: "",
+    });
+  },
   resetModified: () => set({ modified: [] }),
 
   setOriginal: (ini: IniState) => set({ original: ini }),
@@ -594,75 +624,111 @@ function newIniRequest(state: IniStore): {
 }
 
 export function saveMisterIni(id: number, state: IniStore) {
-  const changes = newIniRequest(state);
+  const target = state.loadedIni;
+  const live = useIniSettingsStore.getState();
+  if (
+    !target ||
+    target.id !== id ||
+    live.loadedIni?.filename !== target.filename ||
+    live.loadedIni?.id !== target.id ||
+    live.loadingIni ||
+    live.savingIni ||
+    live.iniError
+  ) {
+    return Promise.reject(new Error("Load a valid INI before saving settings"));
+  }
+  const sequence = loadSequence;
+  const changes = newIniRequest(live);
   const api = new ControlApi();
-  return api.saveMisterIni(id, changes).then(() => {
-    const current = useIniSettingsStore.getState();
-    const newOriginal = { ...current.original };
-    const savedUnchanged = new Set<string>();
+  useIniSettingsStore.setState({ savingIni: true });
+  return api
+    .saveMisterIni(target.id, changes, target.filename)
+    .then(() => {
+      const current = useIniSettingsStore.getState();
+      if (
+        sequence !== loadSequence ||
+        current.loadedIni?.filename !== target.filename
+      )
+        return;
+      const newOriginal = { ...current.original };
+      const savedUnchanged = new Set<string>();
 
-    for (const key in changes) {
-      if (!(key in iniKeyMapReverse)) {
-        console.warn(`Unknown ini key ${key}`);
-        continue;
+      for (const key in changes) {
+        if (!(key in iniKeyMapReverse)) {
+          console.warn(`Unknown ini key ${key}`);
+          continue;
+        }
+
+        const mKey = iniKeyMapReverse[key];
+        (newOriginal as Indexable)[mKey] = changes[key];
+        if ((current as Indexable)[mKey] === changes[key]) {
+          savedUnchanged.add(mKey);
+        }
       }
 
-      const mKey = iniKeyMapReverse[key];
-      (newOriginal as Indexable)[mKey] = changes[key];
-      if ((current as Indexable)[mKey] === changes[key]) {
-        savedUnchanged.add(mKey);
-      }
-    }
-
-    useIniSettingsStore.setState({
-      modified: current.modified.filter((key) => !savedUnchanged.has(key)),
-      original: newOriginal,
-    });
-  });
+      useIniSettingsStore.setState({
+        modified: current.modified.filter((key) => !savedUnchanged.has(key)),
+        original: newOriginal,
+      });
+    })
+    .finally(() => useIniSettingsStore.setState({ savingIni: false }));
 }
 
-export function loadMisterIni(id: number, _state: IniStore, reset = false) {
+export async function loadMisterIni(
+  id: number | undefined,
+  _state: IniStore,
+  reset = false,
+) {
+  const sequence = ++loadSequence;
   const api = new ControlApi();
-  return api
-    .loadMisterIni(id)
-    .then((data) => {
-      console.log("Loading MiSTer.ini data...");
-      const newState = { ...initialState };
-
-      for (const key in data) {
-        if (key in iniKeyMapReverse) {
-          const mKey = iniKeyMapReverse[key];
-          (newState as Indexable)[mKey] = data[key];
-        } else {
-          console.warn(`Unknown ini key ${key}`);
-        }
-      }
-
-      let current = useIniSettingsStore.getState();
-      current.setOriginal(newState);
-
-      if (reset) {
-        current.resetModified();
-        current = useIniSettingsStore.getState();
-      }
-
-      for (const key in data) {
-        if (key in iniKeyMapReverse) {
-          const mKey = iniKeyMapReverse[key];
-
-          if (current.modified.includes(mKey)) {
-            console.log(`Skipping ini key ${mKey} as ${key} is modified`);
-            continue;
-          }
-
-          console.log(`Setting ini key ${mKey} to ${data[key]}`);
-          current.setAttribute(mKey, data[key]);
-        } else {
-          console.warn(`Unknown ini key ${key}`);
-        }
-      }
-    })
-    .catch((e) => {
-      console.error(e);
+  useIniSettingsStore.setState({ loadingIni: true, iniError: "" });
+  try {
+    const listing = await api.listMisterInis();
+    if (sequence !== loadSequence) return;
+    const selectedID = id ?? (listing.active || 1);
+    const target = listing.inis.find((ini) => ini.id === selectedID);
+    if (!target)
+      throw new Error(`INI slot ${selectedID} is unavailable for editing`);
+    const before = useIniSettingsStore.getState();
+    if (
+      !reset &&
+      before.loadedIni &&
+      before.loadedIni.filename !== target.filename &&
+      before.modified.length
+    ) {
+      throw new Error(
+        "Unsaved settings belong to another INI; switch explicitly or revert first",
+      );
+    }
+    const data = await api.loadMisterIni(target.id, target.filename);
+    if (sequence !== loadSequence) return;
+    const original = { ...initialState };
+    for (const key in data) {
+      const mapped = iniKeyMapReverse[key];
+      if (mapped) (original as Indexable)[mapped] = data[key];
+    }
+    const current = useIniSettingsStore.getState();
+    const sameFile =
+      !current.loadedIni || current.loadedIni.filename === target.filename;
+    const modified = !reset && sameFile ? current.modified : [];
+    const values = { ...original };
+    for (const key of modified)
+      (values as Indexable)[key] = (current as Indexable)[key];
+    useIniSettingsStore.setState({
+      ...values,
+      original,
+      modified,
+      loadedIni: target,
+      loadingIni: false,
+      iniError: "",
     });
+  } catch (error) {
+    if (sequence === loadSequence) {
+      useIniSettingsStore.setState({
+        loadingIni: false,
+        iniError: iniErrorMessage(error),
+      });
+    }
+    throw error;
+  }
 }

--- a/web/remote/src/lib/models.ts
+++ b/web/remote/src/lib/models.ts
@@ -126,7 +126,8 @@ export interface CreateLauncherRequest {
   name: string;
 }
 
-interface IniResponse {
+export interface IniResponse {
+  id: number;
   displayName: string;
   filename: string;
   path: string;


### PR DESCRIPTION
## Summary
- Match current MiSTer slot ordering, preserve example-slot gaps, and show full labels.
- Bind loads, saves, and activation to explicit slot IDs and filenames; ignore stale editor responses.
- Retain missing-Main behavior from #204 (included here; merge #204 first).
- Reject detected layout changes. Restart MiSTer and Remote after alternate filenames change; earlier MiSTer-only cached mappings cannot be reconstructed.

## Validation
- Go tests/lint, 14 targeted race tests, 22 web tests, web build, Remote ARM build, and diff checks passed.
- No device testing; existing bundle-size warning remains.

Closes #118
Ref #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Remote INI configuration management with stable slot identities and support for missing Main configurations.
  - Added protection against applying changes to the wrong configuration file.
  - Added prompts for unsaved changes when switching configurations.
  - Added clearer loading, saving, and error states, including reload actions and unavailable-slot messaging.
  - Main configuration files are created only when saved successfully.

- **Bug Fixes**
  - Prevented stale or overlapping configuration requests from overwriting current settings.
  - Improved handling of failed loads and saves.

- **Documentation**
  - Expanded guidance on INI slot ordering, file behavior, and configuration switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->