### PR TITLE
feat(bgm): include boot sounds in playlist rotation

### DIFF
--- a/cmd/bgm/settings.go
+++ b/cmd/bgm/settings.go
@@ -63,6 +63,7 @@ func (s *settingsPage) show(selection int) {
 	s.list.AddHeader("Playback")
 	s.addToggle("Start on boot", &s.staged.Startup)
 	s.addToggle("Play music in cores", &s.staged.PlayInCore)
+	s.addToggle("Boot sounds in rotation", &s.staged.BootInPlaylist)
 	s.addText("Core boot delay", bgm.FormatDelay(s.staged.CoreBootDelay), func(value string) error {
 		if _, err := bgm.ParseDelay(value); err != nil {
 			return fmt.Errorf("invalid core boot delay: %w", err)
@@ -229,6 +230,16 @@ func (s *settingsPage) save() {
 	// The file is written, so the in-memory configuration follows it even
 	// when the running service cannot be told about the change.
 	s.apply()
+	if s.staged.BootInPlaylist != s.original.BootInPlaylist {
+		message := "set bootinplaylist no"
+		if s.staged.BootInPlaylist {
+			message = "set bootinplaylist yes"
+		}
+		if _, _, err := s.ui.send(message); err != nil {
+			s.ui.showError(err, s.ui.mustShowMain)
+			return
+		}
+	}
 	if s.staged.PlayInCore != s.original.PlayInCore {
 		message := "set playincore no"
 		if s.staged.PlayInCore {

--- a/cmd/bgm/settings_help.go
+++ b/cmd/bgm/settings_help.go
@@ -20,14 +20,15 @@
 package main
 
 var settingsHelp = map[string]string{
-	"Start on boot":       "Start the BGM service automatically when MiSTer boots.",
-	"Play music in cores": "Keep playing music while a core is running instead of only in the menu.",
-	"Core boot delay":     "Seconds to wait before a core boot sound plays, for slow display sync.",
-	"Menu volume":         "MiSTer volume while the menu is open; needs Default volume too.",
-	"Default volume":      "MiSTer volume restored when a core runs; needs Menu volume too.",
-	"Debug logging":       "Write detailed service output to /tmp/bgm.log.",
-	"Theme":               "Choose a color palette to apply after saving.",
-	"Mouse":               "Enable mouse input alongside keyboard and controller navigation.",
-	"CRT mode":            "Use a compact 75-column, 15-row layout for CRT displays.",
-	"On-screen keyboard":  "Use controller-friendly text entry; Off needs a physical keyboard.",
+	"Boot sounds in rotation": "Add playlist and global boot sounds to normal playback after saving.",
+	"Start on boot":           "Start the BGM service automatically when MiSTer boots.",
+	"Play music in cores":     "Keep playing music while a core is running instead of only in the menu.",
+	"Core boot delay":         "Seconds to wait before a core boot sound plays, for slow display sync.",
+	"Menu volume":             "MiSTer volume while the menu is open; needs Default volume too.",
+	"Default volume":          "MiSTer volume restored when a core runs; needs Menu volume too.",
+	"Debug logging":           "Write detailed service output to /tmp/bgm.log.",
+	"Theme":                   "Choose a color palette to apply after saving.",
+	"Mouse":                   "Enable mouse input alongside keyboard and controller navigation.",
+	"CRT mode":                "Use a compact 75-column, 15-row layout for CRT displays.",
+	"On-screen keyboard":      "Use controller-friendly text entry; Off needs a physical keyboard.",
 }

--- a/cmd/bgm/ui_test.go
+++ b/cmd/bgm/ui_test.go
@@ -242,6 +242,34 @@ func TestRefreshDiscardsStatusFetchedBeforeACommand(t *testing.T) {
 	player.StopPlaylist()
 }
 
+func TestBootRotationSettingsAreStagedAndApplied(t *testing.T) {
+	view, player := newWorkflowUI(t)
+	view.startSettings()
+	sendUIKey(view, tcell.KeyDown, 0)
+	sendUIKey(view, tcell.KeyDown, 0) // Boot sounds in rotation
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if player.BootInPlaylist() || view.cfg.BootInPlaylist {
+		t.Fatal("unsaved setting applied")
+	}
+	sendUIKey(view, tcell.KeyRight, 0) // Save
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if !player.BootInPlaylist() || !view.cfg.BootInPlaylist {
+		t.Fatal("saved setting not applied")
+	}
+	if !strings.Contains(readINI(t, view), "bootinplaylist = yes\n") {
+		t.Fatal("setting not persisted")
+	}
+	view.startSettings()
+	sendUIKey(view, tcell.KeyDown, 0)
+	sendUIKey(view, tcell.KeyDown, 0)
+	sendUIKey(view, tcell.KeyEnter, 0)
+	sendUIKey(view, tcell.KeyRight, 0)
+	sendUIKey(view, tcell.KeyEnter, 0)
+	if player.BootInPlaylist() || view.cfg.BootInPlaylist {
+		t.Fatal("disable not applied")
+	}
+}
+
 func TestSettingsSaveWritesINIAndUpdatesService(t *testing.T) {
 	view, player := newWorkflowUI(t)
 	view.startSettings()

--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -41,6 +41,7 @@ Intentional differences:
 - A socket file left behind by a crashed service is removed automatically instead of blocking BGM until reboot. `restart` waits for the old service to exit before starting the new one.
 - Stopping a playlist waits for the running track to be killed, so a stopped playlist can never start one more track. Unknown command-line arguments print usage instead of opening the menu.
 - Playlist folders are listed alphabetically in the menu.
+- Optional `bootinplaylist = yes` includes boot sounds in normal playback without changing the selected playlist. It defaults to `no`, preserving existing behavior. When enabled, random playback avoids immediately repeating a track whenever another candidate exists, including small playlists.
 
 ## Music folder
 
@@ -78,6 +79,10 @@ Create a subfolder in `music` and fill it with tracks; it appears in the control
 
 Prefix a file with `_` to mark it as a boot sound (for example `_Startup.mp3`). One boot sound is picked at random from the active playlist's top level when MiSTer starts, and `_` files are excluded from normal playback. Files placed directly in `music/boot` are global boot sounds that apply to every playlist and need no prefix.
 
+To keep boot sounds in normal rotation, enable **Boot sounds in rotation** in Settings and Save, or set `bootinplaylist = yes` in `[bgm]` and restart BGM. This includes underscore-prefixed tracks within the selected playlist and files directly inside `music/boot`; no copies or renaming are needed. It does not add unrelated playlists or core-specific boot folders (unless already included by `all`). Startup selection remains unchanged. Global tracks already present in `all` are not added twice.
+
+Settings changes apply to subsequent track selections without interrupting the current track. Random playback avoids an immediate repeat when another candidate exists; a one-track playlist can repeat. Loop playback still repeats its chosen track until the playlist restarts. Disabled playback still plays only boot sounds.
+
 ### Core boot sounds
 
 Create a folder inside `music/boot` named after a core, such as `music/boot/SNES`, and add tracks. One is played when that core launches. The match is case-insensitive and also triggers for `.mgl` launches of the core. `corebootdelay` in `bgm.ini` waits the given number of seconds (decimals allowed) before playing, to allow a display to sync.
@@ -107,6 +112,7 @@ playback = random
 playlist = none
 startup = yes
 playincore = no
+bootinplaylist = no
 corebootdelay = 0
 menuvolume = -1
 defaultvolume = -1
@@ -117,6 +123,7 @@ debug = no
 - `playlist`: `none`, `all` or a folder name inside `music`.
 - `startup`: start the service from `user-startup.sh` on boot.
 - `playincore`: keep playing music while a core runs.
+- `bootinplaylist`: include boot sounds in normal playlist playback; defaults to `no`.
 - `corebootdelay`: seconds to wait before core boot sounds.
 - `menuvolume`, `defaultvolume`: `-1` to `7`, see Volume control.
 - `debug`: print service output and append it to `/tmp/bgm.log`. Re-read on every log line, so it can be toggled while the service runs.
@@ -173,6 +180,7 @@ The service listens on the unix socket `/tmp/bgm.sock`. Each connection carries 
 | `set playback <type>` | none; unknown types play random tracks but are reported verbatim |
 | `set playlist <name>` | none; `none` clears the playlist, names may contain spaces |
 | `set playincore yes` / `set playincore no` | none |
+| `set bootinplaylist yes` / `set bootinplaylist no` | none; applies to subsequent track selections |
 | `get playback`, `get playincore` | the value |
 | `get playlist` | the name; nothing when no playlist is set |
 | `pid` | the service process id |

--- a/pkg/bgm/config.go
+++ b/pkg/bgm/config.go
@@ -32,7 +32,7 @@ import (
 
 // DefaultINI is written byte-for-byte when bgm.ini is missing, exactly as the
 // Python script did.
-const DefaultINI = "[bgm]\nplayback = random\nplaylist = none\nstartup = yes\nplayincore = no\n" +
+const DefaultINI = "[bgm]\nplayback = random\nplaylist = none\nstartup = yes\nplayincore = no\nbootinplaylist = no\n" +
 	"corebootdelay = 0\nmenuvolume = -1\ndefaultvolume = -1\ndebug = no\n"
 
 const (
@@ -96,15 +96,16 @@ type TUIOptions struct {
 
 // Config is the typed view of bgm.ini with Python's defaults applied.
 type Config struct {
-	Playback      string
-	Playlist      Playlist
-	TUI           TUIOptions
-	CoreBootDelay float64
-	MenuVolume    int
-	DefaultVolume int
-	Startup       bool
-	PlayInCore    bool
-	Debug         bool
+	Playback       string
+	Playlist       Playlist
+	TUI            TUIOptions
+	CoreBootDelay  float64
+	MenuVolume     int
+	DefaultVolume  int
+	Startup        bool
+	PlayInCore     bool
+	BootInPlaylist bool
+	Debug          bool
 }
 
 // DefaultConfig returns the values used when keys are missing.
@@ -167,6 +168,7 @@ func ConfigFromDocument(doc *Document) Config {
 	}
 	cfg.Startup = docBool(doc, iniSectionBGM, "startup", cfg.Startup)
 	cfg.PlayInCore = docBool(doc, iniSectionBGM, "playincore", cfg.PlayInCore)
+	cfg.BootInPlaylist = docBool(doc, iniSectionBGM, "bootinplaylist", cfg.BootInPlaylist)
 	cfg.Debug = docBool(doc, iniSectionBGM, "debug", cfg.Debug)
 	cfg.MenuVolume = docInt(doc, iniSectionBGM, "menuvolume", cfg.MenuVolume)
 	cfg.DefaultVolume = docInt(doc, iniSectionBGM, "defaultvolume", cfg.DefaultVolume)
@@ -282,6 +284,7 @@ type Settings struct {
 	DefaultVolume    int
 	Startup          bool
 	PlayInCore       bool
+	BootInPlaylist   bool
 	Debug            bool
 	Mouse            bool
 	CRTMode          bool
@@ -297,6 +300,7 @@ func SettingsFromConfig(cfg *Config) Settings {
 		DefaultVolume:    cfg.DefaultVolume,
 		Startup:          cfg.Startup,
 		PlayInCore:       cfg.PlayInCore,
+		BootInPlaylist:   cfg.BootInPlaylist,
 		Debug:            cfg.Debug,
 		Mouse:            cfg.TUI.Mouse,
 		CRTMode:          cfg.TUI.CRTMode,
@@ -312,6 +316,7 @@ func (s *Settings) ApplyTo(cfg *Config) {
 	cfg.DefaultVolume = s.DefaultVolume
 	cfg.Startup = s.Startup
 	cfg.PlayInCore = s.PlayInCore
+	cfg.BootInPlaylist = s.BootInPlaylist
 	cfg.Debug = s.Debug
 	cfg.TUI.Mouse = s.Mouse
 	cfg.TUI.CRTMode = s.CRTMode
@@ -348,6 +353,7 @@ func SaveSettings(path string, settings *Settings) error {
 	return UpdateINI(path, func(doc *Document) {
 		doc.Set(iniSectionBGM, "startup", formatYesNo(settings.Startup))
 		doc.Set(iniSectionBGM, "playincore", formatYesNo(settings.PlayInCore))
+		doc.Set(iniSectionBGM, "bootinplaylist", formatYesNo(settings.BootInPlaylist))
 		doc.Set(iniSectionBGM, "corebootdelay", FormatDelay(settings.CoreBootDelay))
 		doc.Set(iniSectionBGM, "menuvolume", strconv.Itoa(settings.MenuVolume))
 		doc.Set(iniSectionBGM, "defaultvolume", strconv.Itoa(settings.DefaultVolume))

--- a/pkg/bgm/config_test.go
+++ b/pkg/bgm/config_test.go
@@ -131,12 +131,14 @@ func TestSaveSettingsPreservesUnknownEntriesAndFormat(t *testing.T) {
 	writeINI(t, &paths, "[bgm]\nplayback = loop\ncustom = keep\nstartup = yes\n[extra]\nfoo = bar\n")
 	settings := Settings{
 		Theme: "nord", CoreBootDelay: 0.5, MenuVolume: 5, DefaultVolume: -1,
-		Startup: false, PlayInCore: true, Debug: true, Mouse: false, CRTMode: true, OnScreenKeyboard: true,
+		Startup: false, PlayInCore: true, BootInPlaylist: true, Debug: true,
+		Mouse: false, CRTMode: true, OnScreenKeyboard: true,
 	}
 	if err := SaveSettings(paths.IniFile, &settings); err != nil {
 		t.Fatal(err)
 	}
-	want := "[bgm]\nplayback = loop\ncustom = keep\nstartup = no\nplayincore = yes\ncorebootdelay = 0.5\n" +
+	want := "[bgm]\nplayback = loop\ncustom = keep\nstartup = no\nplayincore = yes\n" +
+		"bootinplaylist = yes\ncorebootdelay = 0.5\n" +
 		"menuvolume = 5\ndefaultvolume = -1\ndebug = yes\n\n[extra]\nfoo = bar\n\n" +
 		"[tui]\ntheme = nord\nmouse = no\ncrt_mode = yes\non_screen_keyboard = yes\n\n"
 	if got := readFile(t, paths.IniFile); got != want {

--- a/pkg/bgm/player.go
+++ b/pkg/bgm/player.go
@@ -48,16 +48,17 @@ type Player struct {
 
 	CmdMu sync.Mutex
 
-	mu           sync.Mutex
-	proc         *playerProcess
-	current      *playState
-	playback     string
-	playlist     Playlist
-	playInCore   bool
-	history      []string
-	endPlaylist  bool
-	playlistDone chan struct{}
-	nextToken    uint64
+	mu             sync.Mutex
+	proc           *playerProcess
+	current        *playState
+	playback       string
+	playlist       Playlist
+	playInCore     bool
+	bootInPlaylist bool
+	history        []string
+	endPlaylist    bool
+	playlistDone   chan struct{}
+	nextToken      uint64
 
 	// randIndex and sleep are replaced by tests.
 	randIndex func(n int) int
@@ -78,13 +79,14 @@ type playerProcess struct {
 // NewPlayer initialises playback settings from the configuration.
 func NewPlayer(paths *Paths, logger *Logger, cfg *Config) *Player {
 	return &Player{
-		paths:      *paths,
-		logger:     logger,
-		playback:   cfg.Playback,
-		playlist:   cfg.Playlist,
-		playInCore: cfg.PlayInCore,
-		randIndex:  rand.IntN,
-		sleep:      time.Sleep,
+		paths:          *paths,
+		logger:         logger,
+		playback:       cfg.Playback,
+		playlist:       cfg.Playlist,
+		playInCore:     cfg.PlayInCore,
+		bootInPlaylist: cfg.BootInPlaylist,
+		randIndex:      rand.IntN,
+		sleep:          time.Sleep,
 	}
 }
 
@@ -121,6 +123,20 @@ func (p *Player) SetPlayInCore(enabled bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.playInCore = enabled
+}
+
+// BootInPlaylist reports whether boot sounds participate in normal playback.
+func (p *Player) BootInPlaylist() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.bootInPlaylist
+}
+
+// SetBootInPlaylist applies the rotation preference without interrupting a track.
+func (p *Player) SetBootInPlaylist(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.bootInPlaylist = enabled
 }
 
 // Playing returns the path of the track being played, if any.
@@ -180,7 +196,7 @@ func (p *Player) filterTracks(names []string, includeBoot bool) []string {
 			tracks = append(tracks, name)
 			continue
 		}
-		if strings.HasPrefix(name, "_") {
+		if strings.HasPrefix(name, "_") && !p.BootInPlaylist() {
 			continue
 		}
 		if current.IsAll() && IsPLS(name) {
@@ -208,7 +224,7 @@ func (p *Player) Tracks(playlist Playlist, includeBoot bool) []string {
 		for _, name := range p.filterTracks(names, includeBoot) {
 			tracks = append(tracks, filepath.Join(folder, name))
 		}
-		return tracks
+		return p.withGlobalBootTracks(tracks, includeBoot)
 	}
 	byFolder := make(map[string][]string)
 	var order []string
@@ -231,6 +247,29 @@ func (p *Player) Tracks(playlist Playlist, includeBoot bool) []string {
 			tracks = append(tracks, filepath.Join(parent, name))
 		}
 	}
+	return p.withGlobalBootTracks(tracks, includeBoot)
+}
+
+func (p *Player) withGlobalBootTracks(tracks []string, includeBoot bool) []string {
+	if !p.BootInPlaylist() {
+		return tracks
+	}
+	entries, err := os.ReadDir(p.paths.BootFolder)
+	if err != nil {
+		return tracks
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	for _, name := range p.filterTracks(names, includeBoot) {
+		path := filepath.Join(p.paths.BootFolder, name)
+		if !containsString(tracks, path) {
+			tracks = append(tracks, path)
+		}
+	}
 	return tracks
 }
 
@@ -251,6 +290,9 @@ func (p *Player) TotalTracks(playlist Playlist, includeBoot bool) int {
 
 func (p *Player) addHistory(filename string) {
 	size := int(math.Floor(float64(p.TotalTracks(p.Playlist(), false)) * HistorySize))
+	if p.BootInPlaylist() {
+		size = max(size, 1)
+	}
 	if size < 1 {
 		return
 	}
@@ -428,6 +470,16 @@ func (p *Player) randomTrack() (string, bool) {
 	}
 	if len(candidates) == 0 {
 		candidates = tracks
+		// Exhausted history must not immediately repeat a boot sound when
+		// another track exists, including in very small playlists.
+		if p.BootInPlaylist() && len(history) > 0 && len(tracks) > 1 {
+			candidates = make([]string, 0, len(tracks))
+			for _, track := range tracks {
+				if track != history[len(history)-1] {
+					candidates = append(candidates, track)
+				}
+			}
+		}
 	}
 	return candidates[p.randIndex(len(candidates))], true
 }

--- a/pkg/bgm/player_test.go
+++ b/pkg/bgm/player_test.go
@@ -92,6 +92,77 @@ func layoutMusic(t *testing.T, paths *Paths) {
 	}
 }
 
+func TestBootRotationPreservesSelectedPlaylist(t *testing.T) {
+	paths := newTestPaths(t)
+	layoutMusic(t, &paths)
+	cfg := DefaultConfig()
+	cfg.Playlist = NamedPlaylist("chip")
+	player := newTestPlayer(t, &paths, &cfg)
+	before := player.Tracks(cfg.Playlist, false)
+	player.SetBootInPlaylist(true)
+	got := relativeTracks(t, &paths, player.Tracks(cfg.Playlist, false))
+	for _, name := range []string{"chip/_intro.wav", "chip/one.ogg", "chip/deep/two.vgm", "boot/global.wav"} {
+		if !slices.Contains(got, name) {
+			t.Fatalf("missing %s in %v", name, got)
+		}
+	}
+	for _, name := range []string{"_boot.mp3", "top.mp3", "boot/SNES/snes.mp3"} {
+		if slices.Contains(got, name) {
+			t.Fatalf("unrelated track %s in %v", name, got)
+		}
+	}
+	if player.Playlist() != cfg.Playlist {
+		t.Fatal("selected playlist changed")
+	}
+	player.SetBootInPlaylist(false)
+	if !slices.Equal(before, player.Tracks(cfg.Playlist, false)) {
+		t.Fatal("disabling did not restore tracks")
+	}
+	player.SetBootInPlaylist(true)
+	player.playlist = NamedPlaylist("all")
+	all := player.Tracks(player.Playlist(), false)
+	count := 0
+	for _, name := range all {
+		if name == filepath.Join(paths.BootFolder, "global.wav") {
+			count++
+		}
+		if IsPLS(name) {
+			t.Fatalf("all unexpectedly includes radio: %s", name)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("global boot track appears %d times", count)
+	}
+}
+
+func TestBootRotationAvoidsImmediateRepeat(t *testing.T) {
+	paths := newTestPaths(t)
+	touchTracks(t, paths.MusicFolder, "_boot.wav", "song.wav")
+	cfg := DefaultConfig()
+	cfg.BootInPlaylist = true
+	player := newTestPlayer(t, &paths, &cfg)
+	player.randIndex = func(int) int { return 0 }
+	boot := filepath.Join(paths.MusicFolder, "_boot.wav")
+	song := filepath.Join(paths.MusicFolder, "song.wav")
+	player.addHistory(boot)
+	for range 4 {
+		if got, ok := player.randomTrack(); !ok || got != song {
+			t.Fatalf("after boot: %q %v", got, ok)
+		}
+		player.addHistory(song)
+		if got, ok := player.randomTrack(); !ok || got != boot {
+			t.Fatalf("after song: %q %v", got, ok)
+		}
+		player.addHistory(boot)
+	}
+	if err := os.Remove(song); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := player.randomTrack(); !ok || got != boot {
+		t.Fatalf("single track: %q %v", got, ok)
+	}
+}
+
 func TestTracksNoneIsTopLevelOnly(t *testing.T) {
 	paths := newTestPaths(t)
 	layoutMusic(t, &paths)

--- a/pkg/bgm/remote.go
+++ b/pkg/bgm/remote.go
@@ -134,6 +134,10 @@ func (r *Remote) Handle(command string) (reply string, ok bool) {
 				player.StartCurrentPlaylist()
 			}
 		}
+	case command == "set bootinplaylist yes":
+		player.SetBootInPlaylist(true)
+	case command == "set bootinplaylist no":
+		player.SetBootInPlaylist(false)
 	case command == "set playincore yes":
 		player.SetPlayInCore(true)
 	case command == "set playincore no":


### PR DESCRIPTION
## Summary
- Add opt-in bootinplaylist setting and controller-friendly Settings toggle, disabled by default.
- Keep selected playlist; include its boot tracks and global boot sounds without duplicate files.
- Avoid immediate random repeats when alternatives exist; preserve loop and disabled modes.
- Document compatibility, configuration, and live service command.

## Validation
Go tests/lint, 80 BGM tests under race detector, ARM BGM build, and diff checks passed. No device testing.

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **“Boot sounds in rotation”** setting.
  * Boot sounds can now be included in normal playback while preserving startup behavior.
  * Added remote commands to enable or disable boot sound rotation.
  * Playback avoids immediate repeats when alternatives are available.

* **Documentation**
  * Documented configuration, control-screen behavior, and remote commands.

* **Bug Fixes**
  * Settings changes are now applied and persisted correctly when saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->