### PR TITLE
docs(random): use executable path in custom launcher example

### DIFF
--- a/docs/random.md
+++ b/docs/random.md
@@ -45,9 +45,11 @@ To create, for example, a launcher which only picks random PSX games:
 1. Create a new file in `/media/fat/Scripts` called `random_psx.sh` (or anything with `.sh` on the end)
 2. Set the contents of the file to:
 
-   ```
+   ```sh
    #!/bin/bash
-   random.sh -filter psx
+   /media/fat/Scripts/random.sh -filter psx
    ```
+
+Use the absolute path so the launcher works regardless of the current directory or whether `Scripts` is in `PATH`.
 
 And that's it, you'll have a new entry in your `Scripts` menu to launch a random PSX game.


### PR DESCRIPTION
## Summary
Use /media/fat/Scripts/random.sh in the custom PSX launcher so it does not depend on the working directory or Scripts being in PATH.

## Validation
Shell syntax and argument forwarding from / passed using a harmless shell-function stub; diff check passed. No actual game launch or MiSTer Scripts-menu test.

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the custom launcher example to use the absolute path for `random.sh`.
  * Clarified that this avoids reliance on the current directory or system `PATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->