### PR TITLE
fix(bgm): handle HTTPS and unsupported PLS radio streams

### DIFF
--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -41,6 +41,7 @@ Intentional differences:
 - A socket file left behind by a crashed service is removed automatically instead of blocking BGM until reboot. `restart` waits for the old service to exit before starting the new one.
 - Stopping a playlist waits for the running track to be killed, so a stopped playlist can never start one more track. Unknown command-line arguments print usage instead of opening the menu.
 - Playlist folders are listed alphabetically in the menu.
+- Radio streams use Go's HTTP/HTTPS client and feed audio to `mpg123` through stdin, avoiding dependence on the installed player's HTTPS support. Short-lived radio attempts are spaced at least five seconds apart and remain interruptible. Radio failures are logged even with debug off; identical failures for a station are suppressed until the error changes or playback succeeds.
 
 ## Music folder
 
@@ -63,6 +64,14 @@ BGM plays `.mp3`, `.ogg`, `.wav`, `.mid`, `.vgm`, `.vgz` and `.vgm.gz` files thr
 ### Internet radio
 
 Internet radio stations are played from `.pls` files containing a stream URL. The best way to manage these is a playlist folder with a single `.pls` file. Multiple `.pls` files in a folder are only moved on by skipping. The `all` playlist excludes `.pls` files.
+
+Radio requires a direct MP3/MPEG audio stream. A `.pls` file is only a URL container: AAC/AAC+, HLS playlists, web pages, and other codecs are not made playable by putting their URL in it. BGM reports unsupported response types before starting the player; mislabeled or unrecognized audio can still fail in `mpg123`.
+
+Both HTTP and HTTPS URLs are supported by BGM itself. HTTPS certificates are verified using the device's trust store; check its clock and CA certificates if verification fails. BGM does not silently follow redirects from HTTPS to HTTP or disable certificate checks. Stations must support ordinary HTTP responses and honor the request for audio without ICY metadata; metadata-bearing responses are rejected rather than fed to the decoder as audio.
+
+If a station is silent, check `/tmp/bgm.log` for transport, HTTP status, format, or player errors. Set `debug = yes` for full player output. A failed or immediately closed stream cannot cause a rapid reconnect loop; Stop and Skip cancel network requests and retry waits. Header and connection setup have timeouts; an established silent stream remains connected until the station closes it or playback is stopped/skipped.
+
+Changing `bgm.ini` manually requires restarting BGM to reload playback and playlist settings; the control screen applies those changes directly without a MiSTer reboot.
 
 ### Playback types
 
@@ -182,7 +191,7 @@ Commands are processed one at a time and wait while a core boot sound plays, exa
 
 ## Logging
 
-With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players.
+With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players. Actionable radio failures are also logged with debug off, with identical repeated failures suppressed.
 
 ## Local development
 

--- a/pkg/bgm/helpers_test.go
+++ b/pkg/bgm/helpers_test.go
@@ -110,6 +110,8 @@ func newTestLogger(paths *Paths) (*Logger, *syncBuffer) {
 const stubScript = `#!/bin/sh
 printf '%s\n' "$(basename "$0") $*" >> "$BGM_STUB_LOG"
 if [ -n "$BGM_STUB_FINISH" ]; then echo "[0:03] Decoding of track finished."; fi
+if [ -n "$BGM_STUB_FAIL" ]; then echo "unsupported audio encoding" >&2; exit 1; fi
+if [ -n "$BGM_STUB_INPUT" ]; then cat > "$BGM_STUB_INPUT"; fi
 if [ -n "$BGM_STUB_EXIT" ]; then exit 0; fi
 exec sleep "${BGM_STUB_SLEEP:-30}"
 `
@@ -129,6 +131,8 @@ func installStubPlayers(t *testing.T) string {
 	t.Setenv("BGM_STUB_FINISH", "")
 	t.Setenv("BGM_STUB_EXIT", "")
 	t.Setenv("BGM_STUB_SLEEP", "")
+	t.Setenv("BGM_STUB_INPUT", "")
+	t.Setenv("BGM_STUB_FAIL", "")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return logPath
 }

--- a/pkg/bgm/log.go
+++ b/pkg/bgm/log.go
@@ -48,15 +48,20 @@ func NewLoggerTo(paths *Paths, out io.Writer) *Logger {
 }
 
 // Log records a debug message.
-func (l *Logger) Log(msg string) { l.write(msg, false) }
+func (l *Logger) Log(msg string) { l.write(msg, false, false) }
 
 // Logf records a formatted debug message.
-func (l *Logger) Logf(format string, args ...any) { l.write(fmt.Sprintf(format, args...), false) }
+func (l *Logger) Logf(format string, args ...any) {
+	l.write(fmt.Sprintf(format, args...), false, false)
+}
 
 // Print records a message that is always shown to the user.
-func (l *Logger) Print(msg string) { l.write(msg, true) }
+func (l *Logger) Print(msg string) { l.write(msg, true, false) }
 
-func (l *Logger) write(msg string, always bool) {
+// Error records actionable failures even when daemon stdout is discarded.
+func (l *Logger) Error(msg string) { l.write(msg, true, true) }
+
+func (l *Logger) write(msg string, always, persist bool) {
 	cfg, _ := LoadConfig(&l.paths)
 	if msg == "" {
 		return
@@ -66,7 +71,7 @@ func (l *Logger) write(msg string, always bool) {
 	if always || cfg.Debug {
 		_, _ = fmt.Fprintln(l.out, msg)
 	}
-	if !cfg.Debug {
+	if !cfg.Debug && !persist {
 		return
 	}
 	// #nosec G302,G304 -- the log lives in MiSTer's world-readable /tmp.

--- a/pkg/bgm/player.go
+++ b/pkg/bgm/player.go
@@ -23,9 +23,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"math/rand/v2"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,11 +62,16 @@ type Player struct {
 	nextToken    uint64
 
 	// randIndex and sleep are replaced by tests.
-	randIndex func(n int) int
-	sleep     func(time.Duration)
+	randIndex       func(n int) int
+	sleep           func(time.Duration)
+	radioClient     *http.Client
+	radioRetryDelay time.Duration
+	radioErrors     map[string]string
 }
 
 type playState struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
 	filename   string
 	token      uint64
 	inPlaylist bool
@@ -78,13 +85,16 @@ type playerProcess struct {
 // NewPlayer initialises playback settings from the configuration.
 func NewPlayer(paths *Paths, logger *Logger, cfg *Config) *Player {
 	return &Player{
-		paths:      *paths,
-		logger:     logger,
-		playback:   cfg.Playback,
-		playlist:   cfg.Playlist,
-		playInCore: cfg.PlayInCore,
-		randIndex:  rand.IntN,
-		sleep:      time.Sleep,
+		paths:           *paths,
+		logger:          logger,
+		playback:        cfg.Playback,
+		playlist:        cfg.Playlist,
+		playInCore:      cfg.PlayInCore,
+		randIndex:       rand.IntN,
+		sleep:           time.Sleep,
+		radioClient:     newRadioClient(),
+		radioRetryDelay: radioRetryDelay,
+		radioErrors:     make(map[string]string),
 	}
 }
 
@@ -269,16 +279,17 @@ func (p *Player) History() []string {
 	return append([]string(nil), p.history...)
 }
 
-// Stop mirrors stop(): only when a player process exists is the current
-// track cleared and the process killed.
+// Stop cancels pending stream requests as well as running audio players.
 func (p *Player) Stop() {
 	p.mu.Lock()
 	proc := p.proc
-	if proc != nil {
-		p.current = nil
-		p.proc = nil
-	}
+	state := p.current
+	p.current = nil
+	p.proc = nil
 	p.mu.Unlock()
+	if state != nil {
+		state.cancel()
+	}
 	if proc != nil {
 		killPlayer(proc.cmd)
 		_ = proc.reader.Close()
@@ -299,7 +310,9 @@ func (p *Player) playTrack(filename string, inPlaylist bool) {
 	}
 	p.mu.Lock()
 	p.nextToken++
-	state := &playState{filename: filename, token: p.nextToken, inPlaylist: inPlaylist}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	state := &playState{ctx: ctx, cancel: cancel, filename: filename, token: p.nextToken, inPlaylist: inPlaylist}
 	p.current = state
 	p.mu.Unlock()
 	p.addHistory(filename)
@@ -308,7 +321,9 @@ func (p *Player) playTrack(filename string, inPlaylist bool) {
 	for loop := LoopAmount(filename); loop > 0 && p.shouldContinue(state); loop-- {
 		p.logger.Logf("Loop #%d", loop)
 		switch {
-		case IsMP3(filename), IsPLS(filename):
+		case IsPLS(filename):
+			p.playRadio(state, filename)
+		case IsMP3(filename):
 			p.playMP3(state, filename)
 		case IsOGG(filename):
 			p.playFile(state, "ogg123", filename)
@@ -339,9 +354,6 @@ func (p *Player) shouldContinue(state *playState) bool {
 // playMP3 runs mpg123, killing it as soon as it reports the track finished
 // to work around the hang the Python script describes.
 func (p *Player) playMP3(state *playState, filename string) {
-	if IsPLS(filename) {
-		filename = PLSURL(filename, p.logger)
-	}
 	proc, err := p.startProcess(state, "mpg123", "--no-control", filename)
 	if err != nil {
 		p.logger.Log(err.Error())
@@ -355,7 +367,7 @@ func (p *Player) playMP3(state *playState, filename string) {
 			break
 		}
 	}
-	p.finishProcess(proc)
+	_ = p.finishProcess(proc)
 }
 
 // playFile runs a player until it exits, logging its output.
@@ -369,16 +381,23 @@ func (p *Player) playFile(state *playState, name string, args ...string) {
 	for scanner.Scan() {
 		p.logger.Log(strings.TrimRight(scanner.Text(), " \t\r\n\f\v"))
 	}
-	p.finishProcess(proc)
+	_ = p.finishProcess(proc)
 }
 
 func (p *Player) startProcess(state *playState, name string, args ...string) (*playerProcess, error) {
+	return p.startProcessInput(state, nil, name, args...)
+}
+
+func (p *Player) startProcessInput(
+	state *playState, input io.Reader, name string, args ...string,
+) (*playerProcess, error) {
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("create %s output pipe: %w", name, err)
 	}
 	// #nosec G204 -- players are fixed MiSTer tools; arguments are music file paths.
 	cmd := exec.CommandContext(context.Background(), name, args...)
+	cmd.Stdin = input
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	cmd.SysProcAttr = playerAttributes()
@@ -390,8 +409,10 @@ func (p *Player) startProcess(state *playState, name string, args ...string) (*p
 	_ = writer.Close()
 	proc := &playerProcess{cmd: cmd, reader: reader}
 	p.mu.Lock()
-	p.proc = proc
-	ended := state.inPlaylist && p.endPlaylist
+	ended := p.current != state || (state.inPlaylist && p.endPlaylist)
+	if !ended {
+		p.proc = proc
+	}
 	p.mu.Unlock()
 	if ended {
 		// The playlist stopped while this player was starting.
@@ -401,7 +422,7 @@ func (p *Player) startProcess(state *playState, name string, args ...string) (*p
 }
 
 // finishProcess mirrors kill_player() for the process this call started.
-func (p *Player) finishProcess(proc *playerProcess) {
+func (p *Player) finishProcess(proc *playerProcess) error {
 	p.mu.Lock()
 	if p.proc == proc {
 		p.proc = nil
@@ -409,7 +430,10 @@ func (p *Player) finishProcess(proc *playerProcess) {
 	p.mu.Unlock()
 	killPlayer(proc.cmd)
 	_ = proc.reader.Close()
-	_ = proc.cmd.Wait()
+	if err := proc.cmd.Wait(); err != nil {
+		return fmt.Errorf("audio player exited: %w", err)
+	}
+	return nil
 }
 
 // randomTrack mirrors get_random_track() with a guard against the Python

--- a/pkg/bgm/player_test.go
+++ b/pkg/bgm/player_test.go
@@ -21,6 +21,8 @@
 package bgm
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -35,6 +37,8 @@ func newTestPlayer(t *testing.T, paths *Paths, cfg *Config) *Player {
 	player := NewPlayer(paths, logger, cfg)
 	player.randIndex = func(int) int { return 0 }
 	player.sleep = func(time.Duration) {}
+	player.radioRetryDelay = 0
+	t.Cleanup(func() { player.radioClient.CloseIdleConnections() })
 	t.Cleanup(player.StopPlaylist)
 	return player
 }
@@ -235,11 +239,15 @@ func TestPlayerCommandsAndArguments(t *testing.T) {
 	logPath := installStubPlayers(t)
 	t.Setenv("BGM_STUB_EXIT", "1")
 	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
-	writeFile(t, filepath.Join(paths.MusicFolder, "radio.pls"), "File1=http://example.com/live\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("test audio"))
+	}))
+	t.Cleanup(server.Close)
 	for _, name := range []string{"a.ogg", "b.wav", "c.mid", "d.vgz", "radio.pls"} {
 		touchTracks(t, paths.MusicFolder, name)
 	}
-	writeFile(t, filepath.Join(paths.MusicFolder, "radio.pls"), "File1=http://example.com/live\n")
+	writeFile(t, filepath.Join(paths.MusicFolder, "radio.pls"), "File1="+server.URL+"\n")
 	for _, name := range []string{"a.ogg", "b.wav", "c.mid", "d.vgz", "radio.pls"} {
 		player.Play(filepath.Join(paths.MusicFolder, name))
 	}
@@ -249,7 +257,7 @@ func TestPlayerCommandsAndArguments(t *testing.T) {
 		"aplay " + filepath.Join(paths.MusicFolder, "b.wav"),
 		"aplaymidi " + filepath.Join(paths.MusicFolder, "c.mid") + " --port=128:0",
 		"vgmplay " + filepath.Join(paths.MusicFolder, "d.vgz"),
-		"mpg123 --no-control http://example.com/live",
+		"mpg123 --no-control -",
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("invocations %v want %v", got, want)

--- a/pkg/bgm/radio.go
+++ b/pkg/bgm/radio.go
@@ -1,0 +1,163 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const radioRetryDelay = 5 * time.Second
+
+func newRadioClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 15 * time.Second,
+			IdleConnTimeout:       30 * time.Second,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("too many radio redirects")
+			}
+			if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+				return errors.New("radio redirect must use HTTP or HTTPS")
+			}
+			if via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return errors.New("refusing radio redirect from HTTPS to insecure HTTP")
+			}
+			return nil
+		},
+	}
+}
+
+func (p *Player) playRadio(state *playState, filename string) {
+	started := time.Now()
+	err := p.streamRadio(state, filename)
+	if state.ctx.Err() != nil {
+		return
+	}
+	p.reportRadioError(filename, err)
+	// Pace even clean but short-lived streams: a closed connection or rejected
+	// format must not cause an unbounded player-spawn/reconnect loop.
+	if remaining := p.radioRetryDelay - time.Since(started); remaining > 0 {
+		timer := time.NewTimer(remaining)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-state.ctx.Done():
+		}
+	}
+}
+
+// Suppress identical station failures to keep default-mode retry logs bounded.
+func (p *Player) reportRadioError(filename string, err error) {
+	p.mu.Lock()
+	if err == nil {
+		delete(p.radioErrors, filename)
+		p.mu.Unlock()
+		return
+	}
+	message := fmt.Sprintf("Radio %s: %v", filepath.Base(filename), err)
+	changed := p.radioErrors[filename] != message
+	p.radioErrors[filename] = message
+	p.mu.Unlock()
+	if changed {
+		p.logger.Error(message)
+	}
+}
+
+func (p *Player) streamRadio(state *playState, filename string) error {
+	address := PLSURL(filename, p.logger)
+	if address == "" {
+		return errors.New("playlist has no HTTP/HTTPS stream URL")
+	}
+	req, err := http.NewRequestWithContext(state.ctx, http.MethodGet, address, http.NoBody)
+	if err != nil {
+		return errors.New("invalid radio stream URL")
+	}
+	req.Header.Set("Icy-MetaData", "0")
+	response, err := p.radioClient.Do(req)
+	if err != nil {
+		// URL errors include the full address, which can contain stream credentials.
+		var requestErr *url.Error
+		if errors.As(err, &requestErr) {
+			err = requestErr.Err
+		}
+		return fmt.Errorf("fetch stream (HTTPS requires a valid clock and trusted certificates): %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("station returned HTTP %d", response.StatusCode)
+	}
+	mediaType := response.Header.Get("Content-Type")
+	if mediaType != "" {
+		mediaType, _, err = mime.ParseMediaType(mediaType)
+		if err != nil {
+			return errors.New("station returned an invalid Content-Type")
+		}
+	}
+	switch mediaType {
+	case "", "audio/mpeg", "audio/mp3", "audio/x-mpeg", "audio/x-mp3", "application/octet-stream":
+	default:
+		return fmt.Errorf(
+			"unsupported stream type %q; use direct MP3/MPEG audio, not AAC, HLS, or a web page", mediaType,
+		)
+	}
+	if interval := response.Header.Get("Icy-Metaint"); interval != "" && interval != "0" {
+		return errors.New("station sent ICY metadata despite requesting audio only; use a metadata-free MP3 stream")
+	}
+	proc, err := p.startProcessInput(state, response.Body, "mpg123", "--no-control", "-")
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(proc.reader)
+	lastLine := ""
+	finished := false
+	for scanner.Scan() {
+		lastLine = strings.TrimSpace(scanner.Text())
+		p.logger.Log(lastLine)
+		if strings.Contains(lastLine, "finished.") {
+			finished = true
+			break
+		}
+	}
+	// exec.Cmd copies stdin asynchronously. Close the network reader before
+	// Wait, including when mpg123 rejects audio while the station keeps sending.
+	_ = response.Body.Close()
+	waitErr := p.finishProcess(proc)
+	if scanErr := scanner.Err(); scanErr != nil {
+		return fmt.Errorf("read radio player output: %w", scanErr)
+	}
+	if waitErr != nil && !finished {
+		return fmt.Errorf("mpg123 could not play the stream (MP3/MPEG audio required): %w; %s", waitErr, lastLine)
+	}
+	return nil
+}

--- a/pkg/bgm/radio_test.go
+++ b/pkg/bgm/radio_test.go
@@ -1,0 +1,221 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package bgm
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func radioFixture(t *testing.T, address string) (*Player, string, *syncBuffer) {
+	t.Helper()
+	paths := newTestPaths(t)
+	logger, out := newTestLogger(&paths)
+	player := newTestPlayer(t, &paths, ptr(DefaultConfig()))
+	player.logger = logger
+	file := filepath.Join(paths.MusicFolder, "radio.pls")
+	writeFile(t, file, "[Playlist]\nFile1="+address+"\n")
+	return player, file, out
+}
+
+func TestRadioHTTPSVerifiedAndPipedToPlayer(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Icy-MetaData") != "0" {
+			t.Error("metadata not disabled")
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("stream bytes"))
+	}))
+	t.Cleanup(server.Close)
+	logPath := installStubPlayers(t)
+	t.Setenv("BGM_STUB_EXIT", "1")
+	input := filepath.Join(t.TempDir(), "input")
+	t.Setenv("BGM_STUB_INPUT", input)
+	player, file, out := radioFixture(t, server.URL)
+	player.Play(file)
+	if !strings.Contains(out.String(), "certificate") {
+		t.Fatalf("missing TLS error: %s", out.String())
+	}
+	if len(stubInvocations(t, logPath)) != 0 {
+		t.Fatal("untrusted stream reached decoder")
+	}
+	// Trust only the local fixture certificate; production verification stays on.
+	player.radioClient.Transport = server.Client().Transport
+	player.Play(file)
+	if got := readFile(t, input); got != "stream bytes" {
+		t.Fatalf("input %q", got)
+	}
+	calls := stubInvocations(t, logPath)
+	if len(calls) != 1 || calls[0] != "mpg123 --no-control -" {
+		t.Fatalf("calls %v", calls)
+	}
+}
+
+func TestRadioRejectsHTTPSDowngrade(t *testing.T) {
+	var reached atomic.Bool
+	plain := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reached.Store(true) }))
+	t.Cleanup(plain.Close)
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, plain.URL, http.StatusFound)
+	}))
+	t.Cleanup(secure.Close)
+	player, file, out := radioFixture(t, secure.URL)
+	player.radioClient.Transport = secure.Client().Transport
+	player.Play(file)
+	if reached.Load() || !strings.Contains(out.String(), "insecure HTTP") {
+		t.Fatalf("downgrade: %s", out.String())
+	}
+}
+
+func TestRadioRejectsUnsupportedResponses(t *testing.T) {
+	for _, scenario := range []struct {
+		name, mediaType, message string
+		status                   int
+	}{
+		{name: "AAC", mediaType: "audio/aacp", status: 200, message: "unsupported stream type"},
+		{name: "HLS", mediaType: "application/vnd.apple.mpegurl", status: 200, message: "unsupported stream type"},
+		{name: "HTTP error", status: 503, message: "HTTP 503"},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", scenario.mediaType)
+				w.WriteHeader(scenario.status)
+			}))
+			t.Cleanup(server.Close)
+			calls := installStubPlayers(t)
+			player, file, out := radioFixture(t, server.URL)
+			player.Play(file)
+			if !strings.Contains(out.String(), scenario.message) {
+				t.Fatalf("error: %s", out.String())
+			}
+			if len(stubInvocations(t, calls)) != 0 {
+				t.Fatal("unsupported response reached decoder")
+			}
+		})
+	}
+}
+
+func TestRadioStopCancelsHeadersAndBody(t *testing.T) {
+	for _, body := range []bool{false, true} {
+		t.Run(map[bool]string{false: "headers", true: "body"}[body], func(t *testing.T) {
+			requested := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if body {
+					w.Header().Set("Content-Type", "audio/mpeg")
+					w.WriteHeader(http.StatusOK)
+					w.(http.Flusher).Flush()
+				}
+				close(requested)
+				<-r.Context().Done()
+			}))
+			t.Cleanup(server.Close)
+			installStubPlayers(t)
+			t.Setenv("BGM_STUB_INPUT", filepath.Join(t.TempDir(), "input"))
+			player, file, _ := radioFixture(t, server.URL)
+			done := make(chan struct{})
+			go func() { player.Play(file); close(done) }()
+			select {
+			case <-requested:
+			case <-time.After(5 * time.Second):
+				t.Fatal("no request")
+			}
+			if body {
+				waitFor(t, func() bool { player.mu.Lock(); defer player.mu.Unlock(); return player.proc != nil })
+			}
+			player.Stop()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Stop blocked on stream")
+			}
+		})
+	}
+}
+
+func TestRadioDecoderFailureClosesStalledInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+	installStubPlayers(t)
+	t.Setenv("BGM_STUB_FAIL", "1")
+	player, file, out := radioFixture(t, server.URL)
+	done := make(chan struct{})
+	go func() { player.Play(file); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("decoder exit hung on stdin")
+	}
+	if !strings.Contains(out.String(), "unsupported audio encoding") {
+		t.Fatalf("missing decoder error: %s", out.String())
+	}
+}
+
+func TestRadioErrorsPersistWithoutDebugAndDoNotFlood(t *testing.T) {
+	player, file, out := radioFixture(t, "http://unused.invalid")
+	failure := errors.New("unsupported codec")
+	player.reportRadioError(file, failure)
+	player.reportRadioError(file, failure)
+	if strings.Count(out.String(), "unsupported codec") != 1 {
+		t.Fatal("repeated console error")
+	}
+	if strings.Count(readFile(t, player.paths.LogFile), "unsupported codec") != 1 {
+		t.Fatal("missing or repeated log error")
+	}
+	player.reportRadioError(file, nil)
+	player.reportRadioError(file, failure)
+	if strings.Count(out.String(), "unsupported codec") != 2 {
+		t.Fatal("recovered station did not report a new failure")
+	}
+}
+
+func TestRadioRetryDelayIsInterruptible(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	player, _, out := radioFixture(t, server.URL)
+	player.radioRetryDelay = time.Hour
+	player.StartPlaylist(PlaybackLoop)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "HTTP 503") })
+	time.Sleep(30 * time.Millisecond)
+	if requests.Load() != 1 {
+		t.Fatal("failed station retried without pacing")
+	}
+	done := make(chan struct{})
+	go func() { player.StopPlaylist(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop waited for retry timer")
+	}
+}


### PR DESCRIPTION
## Summary
- Stream HTTP/HTTPS audio through Go into mpg123 stdin, retaining certificate verification and rejecting HTTPS downgrades.
- Cancel network work on Stop/Skip, prevent stdin shutdown hangs, and pace short-lived attempts.
- Log actionable radio errors with debug off and suppress identical repeated failures.
- Document unsupported codecs, transport limits, and configuration reload behavior.

## Validation
Full Go tests, lint, 89 BGM race tests, ARM build, and diff checks passed. Local fixtures cover TLS, response errors, cancellation, decoder failures, and retry pacing. No MiSTer or live-station test. AAC/HLS decoding is not added.

Closes #151