### PR TITLE
feat(bgm): configure startup boot sound delay

### DIFF
--- a/cmd/bgm/settings.go
+++ b/cmd/bgm/settings.go
@@ -74,6 +74,17 @@ func (s *settingsPage) show(selection int) {
 		}
 	})
 
+	s.addText("Startup sound delay", bgm.FormatDelay(s.staged.BootDelay), func(value string) error {
+		if _, err := bgm.ParseBootDelay(value); err != nil {
+			return fmt.Errorf("invalid startup delay: %w", err)
+		}
+		return nil
+	}, func(value string) {
+		if parsed, err := bgm.ParseBootDelay(value); err == nil {
+			s.staged.BootDelay = parsed
+		}
+	})
+
 	s.list.AddHeader("Volume")
 	s.addVolume("Menu volume", menuVolumeHelp, &s.staged.MenuVolume, true)
 	s.addVolume("Default volume", defaultVolumeHelp, &s.staged.DefaultVolume, false)

--- a/cmd/bgm/settings_help.go
+++ b/cmd/bgm/settings_help.go
@@ -20,6 +20,7 @@
 package main
 
 var settingsHelp = map[string]string{
+	"Startup sound delay": "Seconds before initial audio; applies next time BGM starts.",
 	"Start on boot":       "Start the BGM service automatically when MiSTer boots.",
 	"Play music in cores": "Keep playing music while a core is running instead of only in the menu.",
 	"Core boot delay":     "Seconds to wait before a core boot sound plays, for slow display sync.",

--- a/cmd/bgm/ui_test.go
+++ b/cmd/bgm/ui_test.go
@@ -242,6 +242,28 @@ func TestRefreshDiscardsStatusFetchedBeforeACommand(t *testing.T) {
 	player.StopPlaylist()
 }
 
+func TestStartupDelaySettingsAreStagedAndSaved(t *testing.T) {
+	view, _ := newWorkflowUI(t)
+	page := newSettingsPage(view)
+	page.show(0)
+	page.staged.BootDelay = 1.25
+	if view.cfg.BootDelay != 0 {
+		t.Fatal("unsaved delay applied")
+	}
+	page.back()
+	if !view.pages.HasPage("tui_confirm_modal") {
+		t.Fatal("discard confirmation missing")
+	}
+	if strings.Contains(readINI(t, view), "bootdelay = 1.25") {
+		t.Fatal("unsaved delay persisted")
+	}
+	page.show(0)
+	page.save()
+	if view.cfg.BootDelay != 1.25 || !strings.Contains(readINI(t, view), "bootdelay = 1.25\n") {
+		t.Fatal("saved startup delay not applied and persisted")
+	}
+}
+
 func TestSettingsSaveWritesINIAndUpdatesService(t *testing.T) {
 	view, player := newWorkflowUI(t)
 	view.startSettings()

--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -41,6 +41,7 @@ Intentional differences:
 - A socket file left behind by a crashed service is removed automatically instead of blocking BGM until reboot. `restart` waits for the old service to exit before starting the new one.
 - Stopping a playlist waits for the running track to be killed, so a stopped playlist can never start one more track. Unknown command-line arguments print usage instead of opening the menu.
 - Playlist folders are listed alphabetically in the menu.
+- Optional `bootdelay` waits before initial automatic audio on each service start. It defaults to zero, preserving immediate startup playback. Shutdown cancels the wait.
 
 ## Music folder
 
@@ -78,6 +79,10 @@ Create a subfolder in `music` and fill it with tracks; it appears in the control
 
 Prefix a file with `_` to mark it as a boot sound (for example `_Startup.mp3`). One boot sound is picked at random from the active playlist's top level when MiSTer starts, and `_` files are excluded from normal playback. Files placed directly in `music/boot` are global boot sounds that apply to every playlist and need no prefix.
 
+To allow a display to sync before initial audio, set `bootdelay = 2.5` in `[bgm]`, or edit **Startup sound delay** in Settings and Save. The value is seconds; fractional values and zero are supported. Negative, non-finite, invalid, or timer-overflowing values in the INI fall back to zero.
+
+The delay applies on every BGM service start, including a manual restart, before startup sounds and the initial playlist (even when no boot sound exists). It does not repeat on later core/menu changes, and does not change `corebootdelay`. Saved changes apply the next time BGM starts. The control socket remains available during the wait; explicit playback commands can start audio sooner. Shutdown cancels the wait without playing the startup sound.
+
 ### Core boot sounds
 
 Create a folder inside `music/boot` named after a core, such as `music/boot/SNES`, and add tracks. One is played when that core launches. The match is case-insensitive and also triggers for `.mgl` launches of the core. `corebootdelay` in `bgm.ini` waits the given number of seconds (decimals allowed) before playing, to allow a display to sync.
@@ -108,6 +113,7 @@ playlist = none
 startup = yes
 playincore = no
 corebootdelay = 0
+bootdelay = 0
 menuvolume = -1
 defaultvolume = -1
 debug = no
@@ -118,6 +124,7 @@ debug = no
 - `startup`: start the service from `user-startup.sh` on boot.
 - `playincore`: keep playing music while a core runs.
 - `corebootdelay`: seconds to wait before core boot sounds.
+- `bootdelay`: seconds before initial automatic audio on service start; defaults to `0`.
 - `menuvolume`, `defaultvolume`: `-1` to `7`, see Volume control.
 - `debug`: print service output and append it to `/tmp/bgm.log`. Re-read on every log line, so it can be toggled while the service runs.
 
@@ -135,13 +142,13 @@ crt_mode = yes
 on_screen_keyboard = yes
 ```
 
-Available themes: `default`, `high_contrast`, `dracula`, `nord`, `gruvbox`, `monogreen`. `crt_mode` uses MiSTer's 75×15 layout. `on_screen_keyboard` enables controller-friendly text entry for the core boot delay.
+Available themes: `default`, `high_contrast`, `dracula`, `nord`, `gruvbox`, `monogreen`. `crt_mode` uses MiSTer's 75×15 layout. `on_screen_keyboard` enables controller-friendly text entry for both boot delays.
 
 ## Control screen
 
 The main screen shows the current track, playback type and playlist, followed by `Skip current track`, `Start playing`/`Stop playing`, the playback types and the playlists. The active playback type and playlist are marked `[ACTIVE]`. Up and Down select a row, Left and Right select `Select`, `Settings` or `Exit`, and Enter activates the selected button. The screen refreshes itself while music plays.
 
-`Settings` opens a staged page for start on boot, play music in cores, core boot delay, menu and default volume, debug logging, theme, mouse, CRT mode and the on-screen keyboard. Changing the menu volume applies it to MiSTer immediately so it can be heard. Nothing is written until `Save`; `Cancel` or Escape asks before discarding changes.
+`Settings` opens a staged page for start on boot, play music in cores, startup sound delay, core boot delay, menu and default volume, debug logging, theme, mouse, CRT mode and the on-screen keyboard. Changing the menu volume applies it to MiSTer immediately so it can be heard. Nothing is written until `Save`; `Cancel` or Escape asks before discarding changes.
 
 ## Commands
 

--- a/pkg/bgm/config.go
+++ b/pkg/bgm/config.go
@@ -28,12 +28,12 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
-// DefaultINI is written byte-for-byte when bgm.ini is missing, exactly as the
-// Python script did.
+// DefaultINI is written only when bgm.ini is missing.
 const DefaultINI = "[bgm]\nplayback = random\nplaylist = none\nstartup = yes\nplayincore = no\n" +
-	"corebootdelay = 0\nmenuvolume = -1\ndefaultvolume = -1\ndebug = no\n"
+	"corebootdelay = 0\nbootdelay = 0\nmenuvolume = -1\ndefaultvolume = -1\ndebug = no\n"
 
 const (
 	iniSectionBGM = "bgm"
@@ -100,6 +100,7 @@ type Config struct {
 	Playlist      Playlist
 	TUI           TUIOptions
 	CoreBootDelay float64
+	BootDelay     float64
 	MenuVolume    int
 	DefaultVolume int
 	Startup       bool
@@ -173,6 +174,11 @@ func ConfigFromDocument(doc *Document) Config {
 	if value, ok := doc.Get(iniSectionBGM, "corebootdelay"); ok {
 		if parsed, valid := parsePythonFloat(value); valid {
 			cfg.CoreBootDelay = parsed
+		}
+	}
+	if value, ok := doc.Get(iniSectionBGM, "bootdelay"); ok {
+		if parsed, err := ParseBootDelay(value); err == nil {
+			cfg.BootDelay = parsed
 		}
 	}
 	if value, ok := doc.Get(iniSectionTUI, "theme"); ok && strings.TrimSpace(value) != "" {
@@ -278,6 +284,7 @@ func SavePlaylist(path string, playlist Playlist) error {
 type Settings struct {
 	Theme            string
 	CoreBootDelay    float64
+	BootDelay        float64
 	MenuVolume       int
 	DefaultVolume    int
 	Startup          bool
@@ -293,6 +300,7 @@ func SettingsFromConfig(cfg *Config) Settings {
 	return Settings{
 		Theme:            cfg.TUI.Theme,
 		CoreBootDelay:    cfg.CoreBootDelay,
+		BootDelay:        cfg.BootDelay,
 		MenuVolume:       cfg.MenuVolume,
 		DefaultVolume:    cfg.DefaultVolume,
 		Startup:          cfg.Startup,
@@ -308,6 +316,7 @@ func SettingsFromConfig(cfg *Config) Settings {
 func (s *Settings) ApplyTo(cfg *Config) {
 	cfg.TUI.Theme = s.Theme
 	cfg.CoreBootDelay = s.CoreBootDelay
+	cfg.BootDelay = s.BootDelay
 	cfg.MenuVolume = s.MenuVolume
 	cfg.DefaultVolume = s.DefaultVolume
 	cfg.Startup = s.Startup
@@ -331,6 +340,9 @@ func (s *Settings) Validate() error {
 	if s.CoreBootDelay < 0 || math.IsInf(s.CoreBootDelay, 0) || math.IsNaN(s.CoreBootDelay) {
 		return errors.New("bgm.corebootdelay must be zero or a positive number of seconds")
 	}
+	if _, err := bootDelayDuration(s.BootDelay); err != nil {
+		return err
+	}
 	for name, volume := range map[string]int{"menuvolume": s.MenuVolume, "defaultvolume": s.DefaultVolume} {
 		if volume < -1 || volume > 7 {
 			return fmt.Errorf("bgm.%s must be between -1 and 7", name)
@@ -349,6 +361,7 @@ func SaveSettings(path string, settings *Settings) error {
 		doc.Set(iniSectionBGM, "startup", formatYesNo(settings.Startup))
 		doc.Set(iniSectionBGM, "playincore", formatYesNo(settings.PlayInCore))
 		doc.Set(iniSectionBGM, "corebootdelay", FormatDelay(settings.CoreBootDelay))
+		doc.Set(iniSectionBGM, "bootdelay", FormatDelay(settings.BootDelay))
 		doc.Set(iniSectionBGM, "menuvolume", strconv.Itoa(settings.MenuVolume))
 		doc.Set(iniSectionBGM, "defaultvolume", strconv.Itoa(settings.DefaultVolume))
 		doc.Set(iniSectionBGM, "debug", formatYesNo(settings.Debug))
@@ -359,7 +372,7 @@ func SaveSettings(path string, settings *Settings) error {
 	})
 }
 
-// FormatDelay renders a core boot delay without trailing zeros.
+// FormatDelay renders a delay without trailing zeros.
 func FormatDelay(seconds float64) string {
 	return strconv.FormatFloat(seconds, 'f', -1, 64)
 }
@@ -371,6 +384,25 @@ func ParseDelay(value string) (float64, error) {
 		return 0, errors.New("enter zero or a positive number of seconds, such as 0 or 1.5")
 	}
 	return parsed, nil
+}
+
+// ParseBootDelay validates startup seconds, including the timer's duration limit.
+func ParseBootDelay(value string) (float64, error) {
+	parsed, err := ParseDelay(value)
+	if err != nil {
+		return 0, err
+	}
+	if _, err = bootDelayDuration(parsed); err != nil {
+		return 0, err
+	}
+	return parsed, nil
+}
+
+func bootDelayDuration(seconds float64) (time.Duration, error) {
+	if seconds < 0 || math.IsNaN(seconds) || seconds >= float64(math.MaxInt64)/float64(time.Second) {
+		return 0, errors.New("bgm.bootdelay must be finite, nonnegative, and within the supported timer range")
+	}
+	return time.Duration(seconds * float64(time.Second)), nil
 }
 
 func formatYesNo(value bool) string {

--- a/pkg/bgm/config_test.go
+++ b/pkg/bgm/config_test.go
@@ -126,18 +126,44 @@ func TestLoadConfigWritesDefaultOnlyWhenMusicFolderExists(t *testing.T) {
 	}
 }
 
+func TestBootDelayValidationAndDefaults(t *testing.T) {
+	for _, value := range []string{"-1", "NaN", "Inf", "1e99", "9223372036.854776", "invalid"} {
+		if _, err := ParseBootDelay(value); err == nil {
+			t.Fatalf("accepted %q", value)
+		}
+		cfg := ConfigFromDocument(ParseINI("[bgm]\nbootdelay = " + value + "\n"))
+		if cfg.BootDelay != 0 {
+			t.Fatalf("invalid delay did not fall back: %v", cfg.BootDelay)
+		}
+	}
+	cfg := ConfigFromDocument(ParseINI("[bgm]\nbootdelay = 1.25\ncorebootdelay = 3\n"))
+	if cfg.BootDelay != 1.25 || cfg.CoreBootDelay != 3 {
+		t.Fatalf("independent delays: %+v", cfg)
+	}
+	settings := SettingsFromConfig(&cfg)
+	settings.BootDelay = -1
+	if err := settings.Validate(); err == nil {
+		t.Fatal("invalid staged startup delay accepted")
+	}
+	settings.BootDelay = 0.5
+	settings.ApplyTo(&cfg)
+	if cfg.BootDelay != 0.5 || cfg.CoreBootDelay != 3 {
+		t.Fatal("startup delay changed core delay")
+	}
+}
+
 func TestSaveSettingsPreservesUnknownEntriesAndFormat(t *testing.T) {
 	paths := newTestPaths(t)
 	writeINI(t, &paths, "[bgm]\nplayback = loop\ncustom = keep\nstartup = yes\n[extra]\nfoo = bar\n")
 	settings := Settings{
-		Theme: "nord", CoreBootDelay: 0.5, MenuVolume: 5, DefaultVolume: -1,
+		Theme: "nord", CoreBootDelay: 0.5, BootDelay: 1.25, MenuVolume: 5, DefaultVolume: -1,
 		Startup: false, PlayInCore: true, Debug: true, Mouse: false, CRTMode: true, OnScreenKeyboard: true,
 	}
 	if err := SaveSettings(paths.IniFile, &settings); err != nil {
 		t.Fatal(err)
 	}
 	want := "[bgm]\nplayback = loop\ncustom = keep\nstartup = no\nplayincore = yes\ncorebootdelay = 0.5\n" +
-		"menuvolume = 5\ndefaultvolume = -1\ndebug = yes\n\n[extra]\nfoo = bar\n\n" +
+		"bootdelay = 1.25\nmenuvolume = 5\ndefaultvolume = -1\ndebug = yes\n\n[extra]\nfoo = bar\n\n" +
 		"[tui]\ntheme = nord\nmouse = no\ncrt_mode = yes\non_screen_keyboard = yes\n\n"
 	if got := readFile(t, paths.IniFile); got != want {
 		t.Fatalf("saved:\n%q\nwant:\n%q", got, want)

--- a/pkg/bgm/service.go
+++ b/pkg/bgm/service.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Service is the long-running "exec" process: boot sound, remote socket and
@@ -34,6 +35,7 @@ type Service struct {
 	player      *Player
 	remote      *Remote
 	watcher     *CoreWatcher
+	shutdown    chan struct{}
 	paths       Paths
 	cleanupOnce sync.Once
 }
@@ -42,10 +44,11 @@ type Service struct {
 func NewService(paths *Paths, logger *Logger) *Service {
 	cfg, _ := LoadConfig(paths)
 	return &Service{
-		paths:   *paths,
-		logger:  logger,
-		player:  NewPlayer(paths, logger, &cfg),
-		watcher: NewCoreWatcher(paths, logger),
+		paths:    *paths,
+		logger:   logger,
+		player:   NewPlayer(paths, logger, &cfg),
+		watcher:  NewCoreWatcher(paths, logger),
+		shutdown: make(chan struct{}),
 	}
 }
 
@@ -69,6 +72,9 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 	s.remote = remote
 
+	if err := s.waitBootDelay(ctx, cfg.BootDelay); err != nil {
+		return err
+	}
 	if cfg.ShouldChangeVolume() {
 		VolumeSet(&s.paths, s.logger, cfg.MenuVolume)
 		s.player.PlayBoot()
@@ -113,6 +119,35 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 }
 
+func (s *Service) waitBootDelay(ctx context.Context, seconds float64) error {
+	delay, err := bootDelayDuration(seconds)
+	if err != nil {
+		return err
+	}
+	if delay > 0 {
+		s.logger.Logf("Waiting %s before startup audio", delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("BGM startup stopped: %w", ctx.Err())
+	case <-s.shutdown:
+		return fmt.Errorf("BGM startup stopped: %w", context.Canceled)
+	case <-timer.C:
+	}
+	// Cancellation takes precedence when both timer and shutdown are ready.
+	select {
+	case <-s.shutdown:
+		return fmt.Errorf("BGM startup stopped: %w", context.Canceled)
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("BGM startup stopped: %w", err)
+	}
+	return nil
+}
+
 func (s *Service) enterMenu(cfg *Config) {
 	s.logger.Log("Switched to menu core, starting playlist...")
 	s.logger.Log("Grabbing mutex")
@@ -151,6 +186,7 @@ func (s *Service) enterCore(cfg *Config, core string) {
 // It is safe to call more than once and from a signal handler.
 func (s *Service) Cleanup() {
 	s.cleanupOnce.Do(func() {
+		close(s.shutdown)
 		s.player.StopPlaylist()
 		if s.remote != nil {
 			s.remote.Close()

--- a/pkg/bgm/service_test.go
+++ b/pkg/bgm/service_test.go
@@ -58,6 +58,74 @@ func setCore(t *testing.T, paths *Paths, core string) {
 	writeFile(t, paths.CoreNameFile, core)
 }
 
+func TestStartupDelayPrecedesBootAndOrdinaryAudio(t *testing.T) {
+	for _, boot := range []bool{true, false} {
+		name := "playlist"
+		if boot {
+			name = "boot"
+		}
+		t.Run(name, func(t *testing.T) {
+			paths := newTestPaths(t)
+			logPath := installStubPlayers(t)
+			playback := "loop"
+			track := "song.wav"
+			if boot {
+				playback = "disabled"
+				track = "_boot.wav"
+				t.Setenv("BGM_STUB_EXIT", "1")
+			}
+			writeINI(t, &paths, "[bgm]\nbootdelay = 0.1\nplayback = "+playback+"\n")
+			touchTracks(t, paths.MusicFolder, track)
+			setCore(t, &paths, MenuCore)
+			service, _ := newTestService(t, &paths)
+			started := time.Now()
+			cancel, errs := runService(t, service)
+			waitFor(t, func() bool { return len(stubInvocations(t, logPath)) > 0 })
+			if time.Since(started) < 100*time.Millisecond {
+				t.Fatal("audio started before delay")
+			}
+			cancel()
+			if err := <-errs; !errors.Is(err, context.Canceled) {
+				t.Fatalf("shutdown: %v", err)
+			}
+		})
+	}
+}
+
+func TestStartupDelayCancelsWithoutPlaying(t *testing.T) {
+	for _, cleanup := range []bool{false, true} {
+		name := "context"
+		if cleanup {
+			name = "cleanup"
+		}
+		t.Run(name, func(t *testing.T) {
+			paths := newTestPaths(t)
+			logPath := installStubPlayers(t)
+			writeINI(t, &paths, "[bgm]\nbootdelay = 3600\ndebug = yes\n")
+			touchTracks(t, paths.MusicFolder, "_boot.wav")
+			service, out := newTestService(t, &paths)
+			cancel, errs := runService(t, service)
+			waitFor(t, func() bool { return strings.Contains(out.String(), "before startup audio") })
+			if cleanup {
+				service.Cleanup()
+			} else {
+				cancel()
+			}
+			select {
+			case err := <-errs:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("shutdown: %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("shutdown waited for startup timer")
+			}
+			if len(stubInvocations(t, logPath)) != 0 {
+				t.Fatal("audio started during canceled delay")
+			}
+		})
+	}
+}
+
 func TestServiceFollowsCoreChanges(t *testing.T) {
 	paths := newTestPaths(t)
 	logPath := installStubPlayers(t)


### PR DESCRIPTION
## Summary
- Add default-zero bootdelay and staged Startup sound delay setting with fractional seconds.
- Delay initial automatic audio on each service start, including manual restart; preserve corebootdelay behavior.
- Cancel startup waiting on context cancellation or service cleanup.
- Document scope, validation, and next-start application.

## Validation
Full Go tests/lint, 85 BGM race tests, ARM build, and diff checks passed. No device testing.

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable startup sound delay for BGM playback.
  * Added a “Startup sound delay” option to the Playback settings.
  * Startup audio now waits for the configured delay and can be canceled during startup.
  * Added validation and persistence for the new setting, with a default delay of zero seconds.

* **Documentation**
  * Updated configuration and settings documentation with the new startup delay option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->