### PR TITLE
feat(favorites): support RetroAchievements alternate cores

### DIFF
--- a/cmd/favorites/settings.go
+++ b/cmd/favorites/settings.go
@@ -72,11 +72,12 @@ func (s *settingsPage) show(selection int) {
 	})
 
 	s.list.AddHeader("Cores")
-	modes := []string{"", "llapi", "yc"}
+	modes := []string{"", "llapi", "yc", "ra"}
 	s.addChoice("Alternate core", alternateCoreLabel(s.staged.AlternateCore), []tui.Choice{
 		{Label: "Standard", Help: "Use standard MiSTer cores."},
 		{Label: "LLAPI", Help: "Use installed LLAPI cores; otherwise use standard cores."},
 		{Label: "YC", Help: "Use installed YC cores; otherwise use standard cores."},
+		{Label: "RetroAchievements", Help: "Use installed RA cores; otherwise use standard cores."},
 	}, slices.Index(modes, s.staged.AlternateCore), func(index int) {
 		s.staged.AlternateCore = modes[index]
 	})
@@ -242,6 +243,8 @@ func alternateCoreLabel(mode string) string {
 		return "LLAPI"
 	case "yc":
 		return "YC"
+	case "ra":
+		return "RetroAchievements"
 	default:
 		return "Standard"
 	}

--- a/cmd/favorites/ui_test.go
+++ b/cmd/favorites/ui_test.go
@@ -317,18 +317,18 @@ func TestSettingsPageStagesAndSavesChanges(t *testing.T) {
 	page.actions[12]()
 	sendUIKey(view, tcell.KeyDown, 0)
 	sendUIKey(view, tcell.KeyEnter, 0)
-	if page.staged.HideRootFiles || page.staged.AlternateCore != "yc" || page.staged.Theme != "high_contrast" {
+	if page.staged.HideRootFiles || page.staged.AlternateCore != "ra" || page.staged.Theme != "high_contrast" {
 		t.Fatalf("staged settings = %#v", page.staged)
 	}
 	page.save()
-	if cfg.Favorites.HideRootFiles || cfg.FavoritesCores.All != "yc" || cfg.TUI.Theme != "high_contrast" {
+	if cfg.Favorites.HideRootFiles || cfg.FavoritesCores.All != "ra" || cfg.TUI.Theme != "high_contrast" {
 		t.Fatalf("applied settings = %#v", favorites.SettingsFromConfig(cfg))
 	}
 	loaded, err := favorites.LoadConfigAt(cfg.IniPath, cfg.AppPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loaded.Favorites.HideRootFiles || loaded.FavoritesCores.All != "yc" || loaded.TUI.Theme != "high_contrast" {
+	if loaded.Favorites.HideRootFiles || loaded.FavoritesCores.All != "ra" || loaded.TUI.Theme != "high_contrast" {
 		t.Fatalf("saved settings = %#v", favorites.SettingsFromConfig(loaded))
 	}
 }

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -33,6 +33,8 @@ The Go version preserves Python Favorites' folder discovery, top-level destinati
 
 Zaparoo's maintained MiSTer catalog now supplies system aliases, extensions, RBF paths, MGL slots, set names, and reset timing. Canonical definitions intentionally replace stale Python-table behavior: Genesis uses the current MegaDrive core path, Vectrex `.ovr` overlay files are not treated as games, and Atari 7800 images placed in the Atari 2600 folder are no longer accepted. NeoGeo ZIP support remains as an explicit compatibility extension until present in the standalone catalog.
 
+The new opt-in `ra` alternate-core mode adds RetroAchievements game shortcuts. Standard, LLAPI, and YC behavior remains unchanged; no existing favorites are migrated automatically.
+
 ## Settings screen
 
 Choose `Settings` from the main screen's bottom action bar. Up and Down select a setting; Left and Right select `Change`, `Save`, or `Cancel`. The footer shows one sentence explaining the selected setting. `Change` toggles boolean values, opens an alternate-core or theme picker, or opens the appropriate editor. Pickers highlight the current value and do not change it when canceled.
@@ -94,8 +96,15 @@ on_screen_keyboard = true
 - blank: standard cores
 - `llapi`: use matching LLAPI variants when installed
 - `yc`: use matching YC variants when installed
+- `ra`: use installed RetroAchievements variants from `_RA_Cores/Cores`
 
-Favorites falls back to standard catalog core when requested variant is unavailable.
+Favorites falls back to standard catalog core when requested variant is unavailable. Select **RetroAchievements** in Settings, or use `[cores]` with `all = ra`. This affects newly created game favorites; existing shortcuts are not rewritten.
+
+RA paths and setnames follow Zaparoo Core's MiSTer launcher mappings. Generated shortcuts include the appropriate `RA_*` setname and `same_dir` behavior, including separate FDS/GBC/Game Gear/Super Game Boy/NeoGeo CD/TurboGrafx-CD names. Atari 2600 uses the RA Atari7800 core's loading slot. Standard catalog data continues to supply media formats and loading parameters.
+
+Install and configure a compatible RetroAchievements MiSTer binary and RA cores first. Favorites does not install binaries, edit `MiSTer.ini`, or handle credentials. An installation that selects `MiSTer_RA` using `[RA_*]` must already have that rule configured. Availability of a core file does not prove that achievements or hardcore mode work on the device.
+
+The RA adaptation is sourced from Zaparoo Core `pkg/platforms/mister/launchers.go` (revision `7cae7f1f`); it can move to a shared library when Core exposes these variant mappings. Ordinary core-file favorites remain direct links to the file selected by the user.
 
 ### TUI settings
 

--- a/pkg/config/mister.go
+++ b/pkg/config/mister.go
@@ -55,6 +55,9 @@ const CoresRecentFile = CoreConfigFolder + "/cores_recent.cfg"
 
 const MenuCore = "MENU"
 
+// RACoresFolder is the isolated RetroAchievements core directory relative to SD root.
+const RACoresFolder = "_RA_Cores/Cores"
+
 const (
 	CmdInterface      = "/dev/MiSTer_cmd"
 	SSHConfigFolder   = "/root/.ssh"

--- a/pkg/favorites/config.go
+++ b/pkg/favorites/config.go
@@ -39,7 +39,7 @@ core_prefix =
 ; games_folder = /media/network
 
 [cores]
-; Supported values: llapi, yc, or blank for standard cores.
+; Supported values: llapi, yc, ra, or blank for standard cores.
 all =
 
 [tui]
@@ -115,7 +115,7 @@ func ValidateConfig(cfg *config.UserConfig) error {
 		}
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.FavoritesCores.All)) {
-	case "", "llapi", "yc":
+	case "", "llapi", "yc", "ra":
 	default:
 		return fmt.Errorf("unsupported cores.all value: %s", cfg.FavoritesCores.All)
 	}

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -769,6 +769,118 @@ func TestCanonicalCatalogCoversLegacyAndNewSystems(t *testing.T) {
 	}
 }
 
+func TestRACoreMappingsAndFallback(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	cfg.FavoritesCores.All = "ra"
+	cfg.Favorites.CorePrefix = "_Custom/"
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	for id, variant := range raCores {
+		t.Run(id, func(t *testing.T) {
+			source, err := games.GetSystem(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			corePath := filepath.Join(root, config.RACoresFolder, variant.name+"_20260101.rbf")
+			if err = os.MkdirAll(filepath.Dir(corePath), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.WriteFile(corePath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			resolved := *source
+			if err = manager.configureRACore(&resolved); err != nil {
+				t.Fatal(err)
+			}
+			if resolved.Rbf != filepath.Join(config.RACoresFolder, variant.name) ||
+				resolved.SetName != variant.setName || resolved.SetNameSameDir != variant.sameDir {
+				t.Fatalf("RA metadata: %+v", resolved)
+			}
+			if strings.HasPrefix(source.SetName, "RA_") {
+				t.Fatal("shared catalog mutated")
+			}
+			if err = os.Remove(corePath); err != nil {
+				t.Fatal(err)
+			}
+			fallback := *source
+			fallback.Rbf = manager.resolveCore(source)
+			if err = manager.configureRACore(&fallback); err != nil {
+				t.Fatal(err)
+			}
+			if fallback.Rbf != "_Custom/"+source.Rbf || fallback.SetName != source.SetName {
+				t.Fatalf("fallback changed metadata: %+v", fallback)
+			}
+		})
+	}
+}
+
+func TestRAIgnoresNonmatchingCoreFiles(t *testing.T) {
+	manager, cfg, root := newTestManager(t)
+	cfg.FavoritesCores.All = "ra"
+	folder := filepath.Join(root, config.RACoresFolder)
+	if err := os.MkdirAll(folder, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(folder, "NES2.rbf"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := *source
+	if err = manager.configureRACore(&resolved); err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Rbf != source.Rbf || resolved.SetName != source.SetName {
+		t.Fatal("selected unrelated RA core")
+	}
+}
+
+func TestRAGameFavoritesUseSetNamesAndCatalogSlots(t *testing.T) {
+	for _, tc := range []struct{ id, file, core, setname, slot string }{
+		{"NES", "game.nes", "NES", `<setname same_dir="1">RA_NES</setname>`, `type="f" index="1"`},
+		{"FDS", "game.fds", "NES", `<setname>RA_FDS</setname>`, `type="f" index="1"`},
+		{"GameboyColor", "game.gbc", "Gameboy", `<setname>RA_GBC</setname>`, `type="f" index="1"`},
+		{"Atari2600", "game.a26", "Atari7800", `<setname same_dir="1">RA_Atari7800</setname>`, `type="f" index="1"`},
+		{"Genesis", "game.md", "MegaDrive", `<setname same_dir="1">RA_MegaDrive</setname>`, `type="f" index="1"`},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			manager, cfg, root := newTestManager(t)
+			cfg.FavoritesCores.All = "ra"
+			folder := filepath.Join(root, "_@Favorites")
+			cores := filepath.Join(root, config.RACoresFolder)
+			for _, dir := range []string{folder, cores} {
+				if err := os.MkdirAll(dir, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(cores, tc.core+".rbf"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			system, err := games.GetSystem(tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			media := filepath.Join(root, "games", system.Folder[0], tc.file)
+			path, err := manager.CreateGameFavorite(system, media, folder, "RA game")
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, part := range []string{"<rbf>_RA_Cores/Cores/" + tc.core + "</rbf>", tc.setname, tc.slot, media} {
+				if !strings.Contains(string(data), part) {
+					t.Fatalf("missing %s in %s", part, data)
+				}
+			}
+		})
+	}
+}
+
 func TestAlternateCoreAndCorePrefix(t *testing.T) {
 	manager, cfg, root := newTestManager(t)
 	folder := filepath.Join(root, "_@Favorites")

--- a/pkg/favorites/launcher.go
+++ b/pkg/favorites/launcher.go
@@ -133,6 +133,11 @@ func (m *Manager) CreateGameFavorite(
 
 	resolvedSystem := *system
 	resolvedSystem.Rbf = m.resolveCore(&resolvedSystem)
+	if strings.EqualFold(strings.TrimSpace(m.cfg.FavoritesCores.All), "ra") {
+		if err := m.configureRACore(&resolvedSystem); err != nil {
+			return "", err
+		}
+	}
 	launcher, err := m.generateMGL(&resolvedSystem, mediaPath)
 	if err != nil {
 		return "", err

--- a/pkg/favorites/ra.go
+++ b/pkg/favorites/ra.go
@@ -1,0 +1,122 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package favorites
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/games"
+)
+
+type raCore struct {
+	name    string
+	setName string
+	sameDir bool
+}
+
+// Adapted from Zaparoo Core pkg/platforms/mister/launchers.go (7cae7f1f),
+// retroAchievementsSetName and RA launcher registrations. Keep these variant
+// overrides aligned until Core exposes them through a shared library. System
+// folders, extensions, and slot parameters still come from the shared catalog.
+var raCores = map[string]raCore{
+	"Atari2600":      {"Atari7800", "RA_Atari7800", true},
+	"Atari7800":      {"Atari7800", "RA_Atari7800", true},
+	"FDS":            {"NES", "RA_FDS", false},
+	"Gameboy":        {"Gameboy", "RA_Gameboy", true},
+	"GameboyColor":   {"Gameboy", "RA_GBC", false},
+	"GameGear":       {"SMS", "RA_GameGear", false},
+	"SuperGameboy":   {"Gameboy", "RA_SGB", false},
+	"GBA":            {"GBA", "RA_GBA", true},
+	"Genesis":        {"MegaDrive", "RA_MegaDrive", true},
+	"MegaCD":         {"MegaCD", "RA_MegaCD", true},
+	"MasterSystem":   {"SMS", "RA_SMS", true},
+	"NeoGeo":         {"NeoGeo", "RA_NeoGeo", true},
+	"NeoGeoCD":       {"NeoGeo", "RA_NeoGeoCD", false},
+	"NES":            {"NES", "RA_NES", true},
+	"Nintendo64":     {"N64", "RA_N64", true},
+	"PSX":            {"PSX", "RA_PSX", true},
+	"Sega32X":        {"S32X", "RA_S32X", true},
+	"SNES":           {"SNES", "RA_SNES", true},
+	"Saturn":         {"Saturn", "RA_Saturn", true},
+	"TurboGrafx16":   {"TurboGrafx16", "RA_TurboGrafx16", true},
+	"TurboGrafx16CD": {"TurboGrafx16", "RA_TurboGrafx16CD", false},
+}
+
+func (m *Manager) configureRACore(system *games.System) error {
+	variant, ok := raCores[system.Id]
+	if !ok {
+		return nil
+	}
+	folder := filepath.Join(m.paths.SDRoot, config.RACoresFolder)
+	entries, err := os.ReadDir(folder)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read RA cores: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".rbf") {
+			continue
+		}
+		core := games.ParseRBF(filepath.Join(folder, entry.Name()))
+		if !strings.EqualFold(core.ShortName, variant.name) {
+			continue
+		}
+		info, statErr := os.Stat(core.Path)
+		if statErr != nil {
+			return fmt.Errorf("inspect RA core: %w", statErr)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		// The RA Atari2600 launcher uses the Atari7800 core's loading slot,
+		// retaining Atari2600's accepted media extensions and identity.
+		if system.Id == "Atari2600" {
+			atari7800, lookupErr := games.GetSystem("Atari7800")
+			if lookupErr != nil {
+				return fmt.Errorf("get RA Atari7800 slot: %w", lookupErr)
+			}
+			params, slotErr := games.PathToMglDef(atari7800, "game.a78")
+			if slotErr != nil {
+				return fmt.Errorf("get RA Atari7800 slot parameters: %w", slotErr)
+			}
+			if params == nil {
+				return errors.New("RA Atari7800 catalog slot is missing")
+			}
+			slots := make([]games.Slot, len(system.Slots))
+			for i, slot := range system.Slots {
+				slots[i] = slot
+				slots[i].Mgl = params
+			}
+			system.Slots = slots
+		}
+		system.Rbf = filepath.Join(config.RACoresFolder, core.ShortName)
+		system.SetName = variant.setName
+		system.SetNameSameDir = variant.sameDir
+		return nil
+	}
+	return nil
+}

--- a/pkg/gamesmenu/gamesmenu_test.go
+++ b/pkg/gamesmenu/gamesmenu_test.go
@@ -145,6 +145,35 @@ func TestDiscoverKeysRootsCaseAndSelection(t *testing.T) {
 	}
 }
 
+func TestGenerate3DOAndJaguar(t *testing.T) {
+	for _, fixtureCase := range []struct{ folder, extension, slot, reset string }{
+		{"3DO", ".chd", `type="s" index="0"`, ""},
+		{"Jaguar", ".jag", `type="f" index="0"`, `<reset delay="1" hold="1"/>`},
+	} {
+		t.Run(fixtureCase.folder, func(t *testing.T) {
+			m := fixture(t)
+			media := filepath.Join(m.paths.SDRoot, "games", fixtureCase.folder, "Game"+fixtureCase.extension)
+			put(t, media, "fixture")
+			entries := discover(t, m)
+			if len(entries) != 1 || entries[0].Key != fixtureCase.folder || !entries[0].Selected {
+				t.Fatalf("discovery: %+v", entries)
+			}
+			result := generate(t, m, entries)
+			if result.Scan.Created != 1 {
+				t.Fatalf("generation: %+v", result)
+			}
+			data := read(t, filepath.Join(m.paths.MenuFolder, entries[0].MenuFolder, "Game.mgl"))
+			for _, fragment := range []string{
+				"<rbf>_Console/" + fixtureCase.folder + "</rbf>", fixtureCase.slot, fixtureCase.reset, media,
+			} {
+				if !strings.Contains(data, fragment) {
+					t.Fatalf("missing %q: %s", fragment, data)
+				}
+			}
+		})
+	}
+}
+
 func TestGenerateSharedFolderAndNeverOverwrite(t *testing.T) {
 	m := fixture(t)
 	folder := filepath.Join(m.paths.SDRoot, "games", "GAMEBOY")


### PR DESCRIPTION
## Summary
- Add RetroAchievements selector and cores.all=ra, adapting Core’s 21 RA mappings with attribution and a future shared-library extraction note.
- Preserve RA setnames, same-directory rules, Atari2600 slot selection, and standard-core fallback when a variant is absent.
- Leave installed MiSTer binaries, INI files, credentials, and existing favorites untouched.
- Include carried GamesMenu 3DO/Jaguar discovery and generation regressions for #187.

## Validation
Full Go tests/lint, 135 targeted race tests, Favorites and GamesMenu ARM builds, and diff checks passed. No device testing; upstream Core unchanged.

Closes #174
Ref #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional RetroAchievements alternate-core mode for creating game shortcuts.
  * Added RetroAchievements as a selectable option in Favorites settings.
  * Added support for system-specific core mappings, set names, media paths, and fallback to standard cores when needed.

* **Documentation**
  * Documented setup requirements, configuration, mappings, and compatibility details for RetroAchievements mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->