### PR TITLE
docs: resolve committed merge conflict markers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,26 @@ env:
   GOLANGCI_LINT_VERSION: v2.13.2
 
 jobs:
+  conflicts:
+    name: Merge conflict markers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check for merge conflict markers
+        run: go run github.com/magefile/mage checkConflicts
+
   web:
     name: Remote web UI
     runs-on: ubuntu-latest

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -26,9 +26,8 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/last
 
 Once installed, run `lastplayed` from the MiSTer `Scripts` menu, and a prompt will offer to enable LastPlayed as a startup service.
 
-<<<<<<< HEAD
 Service status and stop commands verify the recorded PID's executable and daemon arguments before trusting it, so an unrelated process reusing a stale PID is not treated as LastPlayed. The PID-file format is unchanged.
-=======
+
 ## Arcade games
 
 LastPlayed creates `.mra` links for arcade games in Last Played and Recently Played, including MRAs in nested installed arcade folders. The shared tracker uses Arcade Database to recognize the active set name, then confirms it against each candidate MRA's `<setname>`; display names alone do not select a launcher. Symlink aliases to the same file count once. Multiple distinct matching MRAs are treated as ambiguous rather than choosing one arbitrarily.
@@ -38,18 +37,6 @@ If Arcade Database is unavailable, or no unique readable MRA can be found, exist
 Arcade shortcuts are `.mra` links, so the Last Played shortcut becomes `Last Played.mra` after an arcade game and `Last Played.mgl` after any other game. Only one is kept: the other extension is removed so a stale shortcut cannot linger in the menu or be launched by `bootcore`. Set `bootcore` to the extension you actually use.
 
 Recently Played numbers `.mra` and `.mgl` shortcuts together. Replaying a game refreshes its entry without deleting the newly numbered shortcut. `/tmp/ACTIVEGAME` continues to contain the legacy arcade set name; tracker events carry the resolved launchable path separately. This works on stock MiSTer without Zaparoo Core.
-
-## Uninstall
-
-Remove LastPlayed's Downloader subscription if configured, so updates do not reinstall it.
-
-1. Run `/media/fat/Scripts/lastplayed.sh -service stop` and wait for shutdown. Remove the `# mrext/lastplayed` block and its `lastplayed.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
-2. If `bootcore` in any MiSTer INI points at the Last Played shortcut, disable or change that setting before removing the shortcut. Do not delete the INI or disable `recents` just to uninstall LastPlayed; other apps may use it.
-3. Delete `/media/fat/Scripts/lastplayed.sh`. Optionally back up and remove `/media/fat/Scripts/lastplayed.ini` to discard settings.
-4. Optionally remove `/media/fat/Last Played.mgl` and generated entries in `/media/fat/_Recently Played/`. Use the actual configured names (`last_played_name`, legacy `name`, and `recent_folder_name`) if customized. Inspect the folder for user-added files before deleting anything. Keeping the shortcuts is allowed; they will stop updating.
-
-LastPlayed has no separate database. Keep MiSTer's recents files under `config/` and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/lastplayed.pid`, `/tmp/lastplayed.log`, and `/tmp/lastplayed.sh` are optional cleanup.
->>>>>>> origin/main
 
 ## Configuration
 
@@ -116,3 +103,14 @@ By using the `bootcore` feature in MiSTer, you can make the last played game lau
 In your `MiSTer.ini` file, look for the line starting with `bootcore=` and change it to `bootcore=Last Played.mgl`. If you can't find this line, just add it to the end of the file.
 
 If you configured a custom name for the shortcut, use that instead of `Last Played.mgl`.
+
+## Uninstall
+
+Remove LastPlayed's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Run `/media/fat/Scripts/lastplayed.sh -service stop` and wait for shutdown. Remove the `# mrext/lastplayed` block and its `lastplayed.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
+2. If `bootcore` in any MiSTer INI points at the Last Played shortcut, disable or change that setting before removing the shortcut. Do not delete the INI or disable `recents` just to uninstall LastPlayed; other apps may use it.
+3. Delete `/media/fat/Scripts/lastplayed.sh`. Optionally back up and remove `/media/fat/Scripts/lastplayed.ini` to discard settings.
+4. Optionally remove `/media/fat/Last Played.mgl` and generated entries in `/media/fat/_Recently Played/`. Use the actual configured names (`last_played_name`, legacy `name`, and `recent_folder_name`) if customized. Inspect the folder for user-added files before deleting anything. Keeping the shortcuts is allowed; they will stop updating.
+
+LastPlayed has no separate database. Keep MiSTer's recents files under `config/` and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/lastplayed.pid`, `/tmp/lastplayed.log`, and `/tmp/lastplayed.sh` are optional cleanup.

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -35,19 +35,7 @@ db_url = https://raw.githubusercontent.com/wizzomafizzo/mrext/main/releases/play
 
 From this point, PlayLog will always run on boot and silently track game playing stats in the background. At any point you can run `playlog` again and see a summary report of the stats.
 
-<<<<<<< HEAD
 Service status and stop commands verify the recorded PID's executable and daemon arguments before trusting it, so an unrelated process reusing a stale PID is not treated as PlayLog. The PID-file format is unchanged.
-=======
-## Uninstall
-
-Remove PlayLog's Downloader subscription if configured, so updates do not reinstall it.
-
-1. Run `/media/fat/Scripts/playlog.sh -service stop` and wait for shutdown and database writes to finish. Remove the `# mrext/playlog` block and its `playlog.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
-2. Delete `/media/fat/Scripts/playlog.sh`. Optionally back up and remove `/media/fat/Scripts/playlog.ini` to discard settings and hook configuration.
-3. **Preserve `/media/fat/playlog.db` unless you intend to erase your play history and totals.** After the service stops, back up the database together with any `playlog.db-wal`, `playlog.db-shm`, or `playlog.db-journal` sidecars present. Keep that set together; do not delete sidecars independently. Only discard the database and remaining sidecars when intentionally removing all history.
-
-PlayLog generates no menu folder. Custom scripts referenced by its state hooks belong to you and may be shared; removing PlayLog does not require deleting them. Keep MiSTer recents/configuration and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/playlog.pid`, `/tmp/playlog.log`, and `/tmp/playlog.sh` are optional cleanup.
->>>>>>> origin/main
 
 ## Configuration
 
@@ -97,3 +85,13 @@ These can be configured in the `playlog.ini` file by setting the same key name a
 When the hook's condition is met, PlayLog will run the given executable with either a core's internal name or a game's absolute path as its first argument.
 
 Be aware that stop hooks will be unreliable when an end user shuts down their MiSTer via power switch.
+
+## Uninstall
+
+Remove PlayLog's Downloader subscription if configured, so updates do not reinstall it.
+
+1. Run `/media/fat/Scripts/playlog.sh -service stop` and wait for shutdown and database writes to finish. Remove the `# mrext/playlog` block and its `playlog.sh -service $1` command from `/media/fat/linux/user-startup.sh`.
+2. Delete `/media/fat/Scripts/playlog.sh`. Optionally back up and remove `/media/fat/Scripts/playlog.ini` to discard settings and hook configuration.
+3. **Preserve `/media/fat/playlog.db` unless you intend to erase your play history and totals.** After the service stops, back up the database together with any `playlog.db-wal`, `playlog.db-shm`, or `playlog.db-journal` sidecars present. Keep that set together; do not delete sidecars independently. Only discard the database and remaining sidecars when intentionally removing all history.
+
+PlayLog generates no menu folder. Custom scripts referenced by its state hooks belong to you and may be shared; removing PlayLog does not require deleting them. Keep MiSTer recents/configuration and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/playlog.pid`, `/tmp/playlog.log`, and `/tmp/playlog.sh` are optional cleanup.

--- a/magefile.go
+++ b/magefile.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"bytes"
 	"crypto/md5"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	_ "github.com/joho/godotenv/autoload"
 
@@ -351,4 +353,50 @@ func Coverage() {
 func GenSystemsDoc() {
 	mg.Deps(GenerateSystemMetadata)
 	_ = sh.RunV("go", "run", "./internal/gensystemsdoc")
+}
+
+// conflictMarkers are the markers git leaves in a file when a merge is not
+// finished. One reached main once already, so this is checked, not trusted.
+var conflictMarkers = []string{"<<<<<<< ", "=======", ">>>>>>> "}
+
+// CheckConflicts fails when a tracked text file still contains merge conflict
+// markers. Only "=======" paired with one of the other two counts, so tables
+// and setext headings in Markdown do not trip it.
+func CheckConflicts() error {
+	tracked, err := sh.Output("git", "ls-files", "-z")
+	if err != nil {
+		return fmt.Errorf("list tracked files: %w", err)
+	}
+
+	var found []string
+	for _, name := range strings.Split(tracked, "\x00") {
+		if name == "" {
+			continue
+		}
+		contents, readErr := os.ReadFile(name)
+		if readErr != nil {
+			// Unreadable or removed from the work tree; nothing to check.
+			continue
+		}
+		if bytes.IndexByte(contents, 0) >= 0 {
+			continue
+		}
+		var opened, separated bool
+		for index, line := range strings.Split(string(contents), "\n") {
+			switch {
+			case strings.HasPrefix(line, conflictMarkers[0]):
+				opened = true
+			case opened && strings.TrimRight(line, "\r") == conflictMarkers[1]:
+				separated = true
+			case separated && strings.HasPrefix(line, conflictMarkers[2]):
+				found = append(found, fmt.Sprintf("%s:%d", name, index+1))
+				opened, separated = false, false
+			}
+		}
+	}
+
+	if len(found) > 0 {
+		return fmt.Errorf("merge conflict markers in tracked files: %s", strings.Join(found, ", "))
+	}
+	return nil
 }


### PR DESCRIPTION
## Problem

`docs/lastplayed.md` and `docs/playlog.md` contain committed, unresolved merge conflict markers. They were introduced by the #203 merge (`a44f025`) and carried forward through every merge since, so both files render broken on GitHub and both swallow their Uninstall sections.

## Fix

Keep both sides — nothing was wrong with either half:

- The PID-verification paragraph stays in the install/usage prose where `HEAD` had it.
- LastPlayed's `## Arcade games` section follows it.
- Both `## Uninstall` sections move to the end of their documents, matching the layout every other app's doc already uses.

## Guard

Adds a `mage checkConflicts` target and a CI job so this fails the build rather than shipping. It walks `git ls-files`, skips binary files, and only reports a `>>>>>>>` line that follows a `<<<<<<<` and a `=======` — so Markdown tables and setext headings do not trip it.

Verified it catches a planted marker and passes on a clean tree.

## Validation

`mage test`, `mage lint` (0 issues), `actionlint .github/workflows/lint.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Resolved formatting issues in the LastPlayed and PlayLog documentation.
  - Added clear uninstall guidance, including service removal, startup configuration cleanup, data preservation, custom hooks, and optional runtime cleanup.

- **Chores**
  - Added automated checks to detect unresolved merge-conflict markers before changes are integrated, helping keep published documentation and project files clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->