### PR TITLE
fix(remote): keep menu file operations inside the SD root

### DIFF
--- a/cmd/remote/menu/files.go
+++ b/cmd/remote/menu/files.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
@@ -34,11 +33,11 @@ import (
 
 const CreateTypeFolder = "folder"
 
-func cleanPath(path string) string {
-	path = filepath.Clean(path)
-	path = removeRoot.ReplaceAllLiteralString(path, "")
-	path = filepath.Join(config.SdFolder, path)
-	return path
+// rejectBadPath reports a path that does not resolve inside the menu root, or
+// names something MiSTer needs to boot, and answers the request.
+func rejectBadPath(w http.ResponseWriter, logger *service.Logger, action string, err error) {
+	http.Error(w, err.Error(), http.StatusBadRequest)
+	logger.Error("rejected %s request: %s", action, err)
 }
 
 func HandleCreateFile(logger *service.Logger) http.HandlerFunc {
@@ -59,7 +58,11 @@ func HandleCreateFile(logger *service.Logger) http.HandlerFunc {
 		}
 
 		if args.Type == CreateTypeFolder {
-			folder := cleanPath(args.Folder)
+			folder, pathErr := resolveMenuPath(args.Folder)
+			if pathErr != nil {
+				rejectBadPath(w, logger, "create menu file", pathErr)
+				return
+			}
 			name := "_" + utils.StripBadFileChars(args.Name)
 			path := filepath.Join(folder, name)
 			logger.Info("creating folder: %s", path)
@@ -90,8 +93,16 @@ func HandleRenameFile(logger *service.Logger) http.HandlerFunc {
 			return
 		}
 
-		fromPath := cleanPath(args.FromPath)
-		toPath := cleanPath(args.ToPath)
+		fromPath, pathErr := resolveMenuPath(args.FromPath)
+		if pathErr != nil {
+			rejectBadPath(w, logger, "rename menu file", pathErr)
+			return
+		}
+		toPath, pathErr := resolveMenuPath(args.ToPath)
+		if pathErr != nil {
+			rejectBadPath(w, logger, "rename menu file", pathErr)
+			return
+		}
 
 		toParent := filepath.Dir(toPath)
 		toFilename := filepath.Base(toPath)
@@ -153,7 +164,11 @@ func HandleDeleteFile(logger *service.Logger) http.HandlerFunc {
 			return
 		}
 
-		path := cleanPath(args.Path)
+		path, pathErr := resolveMenuPath(args.Path)
+		if pathErr != nil {
+			rejectBadPath(w, logger, "delete menu file", pathErr)
+			return
+		}
 
 		file, err := os.Stat(path)
 		if err != nil {
@@ -166,13 +181,13 @@ func HandleDeleteFile(logger *service.Logger) http.HandlerFunc {
 			return
 		}
 
+		// resolveMenuPath has already rejected anything outside the SD root
+		// and every protected boot file. What is left is the root itself,
+		// which resolves cleanly, and the rule that only menu folders may be
+		// removed as a tree.
 		invalidPath := false
 		switch {
 		case path == "", path == config.SdFolder, path == config.SdFolder+"/":
-			invalidPath = true
-		case strings.HasPrefix(path, config.SdFolder+"/MiSTer"):
-			invalidPath = true
-		case path == config.SdFolder+"/menu.rbf":
 			invalidPath = true
 		case file.IsDir() && file.Name() != "" && file.Name()[0] != '_':
 			invalidPath = true

--- a/cmd/remote/menu/menu.go
+++ b/cmd/remote/menu/menu.go
@@ -205,26 +205,16 @@ func ListFolder(logger *service.Logger) http.HandlerFunc {
 			return
 		}
 
-		args.Path = removeRoot.ReplaceAllString(args.Path, "")
-
-		var path string
-		if args.Path == "" {
-			path = config.SdFolder
-		} else {
-			parts := filepath.SplitList(args.Path)
-			cleaned := make([]string, 0)
-			cleaned = append(cleaned, config.SdFolder)
-
-			for _, part := range parts {
-				if part == "." || part == ".." {
-					continue
-				}
-
-				cleaned = append(cleaned, part)
-			}
-
-			path = filepath.Join(cleaned...)
+		// The previous filter here split on filepath.SplitList, which uses the
+		// PATH list separator, not "/". It saw one element for any ordinary
+		// path, so its ".." check never fired.
+		path, pathErr := resolveMenuPath(args.Path)
+		if pathErr != nil {
+			http.Error(w, pathErr.Error(), http.StatusBadRequest)
+			logger.Error("rejected list menu folder request: %s", pathErr)
+			return
 		}
+		args.Path = relativeMenuPath(args.Path)
 
 		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
 			http.Error(w, statErr.Error(), http.StatusNotFound)

--- a/cmd/remote/menu/paths.go
+++ b/cmd/remote/menu/paths.go
@@ -1,0 +1,120 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package menu
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// errOutsideMenuRoot is returned for any request path that does not resolve
+// inside the SD root. Handlers turn it into a 400.
+var errOutsideMenuRoot = errors.New("path is outside the menu root")
+
+// errProtectedPath is returned for paths MiSTer needs to boot. The menu API
+// manages shortcuts; it has no reason to touch these, and a mistake here
+// leaves a device that will not start.
+var errProtectedPath = errors.New("path is protected")
+
+// protectedNames are SD-root entries the menu API must never create over,
+// rename or delete, matched against the first path component so naming a
+// directory once covers everything inside it.
+var protectedNames = []string{
+	"menu.rbf",
+	"u-boot.img",
+	"u-boot.txt",
+	"linux",
+	"config",
+}
+
+// protectedPrefixes cover the dated and suffixed variants MiSTer ships, so
+// MiSTer, MiSTer.ini and MiSTer_20240101.rbf are all matched. The delete
+// handler already guarded this prefix; the others are new.
+var protectedPrefixes = []string{
+	"MiSTer",
+}
+
+// relativeMenuPath normalises a client-supplied path to one relative to the SD
+// root. Clients send either an absolute path under the root or one already
+// relative to it, and both have always been accepted.
+//
+// The empty path is kept empty rather than becoming ".", because the listing
+// response uses it verbatim for parent and next links.
+func relativeMenuPath(path string) string {
+	path = removeRoot.ReplaceAllLiteralString(path, "")
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+// resolveMenuPath turns a client-supplied path into an absolute one under the
+// SD root, or reports why it cannot.
+//
+// The containment check is lexical and runs on the cleaned path, so "..", an
+// absolute path elsewhere, and a path that only looks rooted are all rejected
+// before any filesystem call. Cleaning before joining is what previously let
+// leading ".." survive: filepath.Join cleans again, so a relative path with
+// leading ".." escaped the root it was joined to.
+func resolveMenuPath(path string) (string, error) {
+	relative := relativeMenuPath(path)
+	if filepath.IsAbs(relative) {
+		return "", fmt.Errorf("%w: %s", errOutsideMenuRoot, path)
+	}
+
+	resolved := filepath.Join(config.SdFolder, relative)
+	inside, err := filepath.Rel(config.SdFolder, resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve menu path: %w", err)
+	}
+	if inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s", errOutsideMenuRoot, path)
+	}
+
+	if inside != "." && isProtectedPath(inside) {
+		return "", fmt.Errorf("%w: %s", errProtectedPath, path)
+	}
+
+	return resolved, nil
+}
+
+// isProtectedPath reports whether a root-relative path names a protected entry
+// or anything inside one.
+func isProtectedPath(relative string) bool {
+	first := relative
+	if separator := strings.IndexRune(relative, filepath.Separator); separator >= 0 {
+		first = relative[:separator]
+	}
+	for _, name := range protectedNames {
+		if strings.EqualFold(first, name) {
+			return true
+		}
+	}
+	for _, prefix := range protectedPrefixes {
+		if len(first) >= len(prefix) && strings.EqualFold(first[:len(prefix)], prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/remote/menu/paths_test.go
+++ b/cmd/remote/menu/paths_test.go
@@ -1,0 +1,169 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package menu
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/service"
+)
+
+func TestResolveMenuPathRejectsTraversal(t *testing.T) {
+	// Every one of these resolved outside the SD root before the fix, because
+	// cleanPath cleaned the relative path first and then joined it, so leading
+	// ".." survived into the join.
+	escapes := []string{
+		"../../etc/passwd",
+		"..",
+		"../",
+		"_Arcade/../../../etc/passwd",
+		"/etc/passwd",
+		"/media/usb0/games",
+		"./../../etc/passwd",
+		config.SdFolder + "/../../etc/passwd",
+	}
+	for _, path := range escapes {
+		resolved, err := resolveMenuPath(path)
+		if err == nil {
+			t.Errorf("%q resolved to %q, want rejection", path, resolved)
+			continue
+		}
+		if !errors.Is(err, errOutsideMenuRoot) {
+			t.Errorf("%q: got %v, want an outside-root error", path, err)
+		}
+	}
+}
+
+func TestResolveMenuPathRejectsProtectedPaths(t *testing.T) {
+	// Deleting any of these leaves a MiSTer that will not boot, or wipes every
+	// core configuration. Only the MiSTer prefix was guarded before, and only
+	// in the delete handler.
+	protected := []string{
+		"MiSTer",
+		"MiSTer.ini",
+		"MiSTer_20240101.rbf",
+		"menu.rbf",
+		"u-boot.img",
+		"u-boot.txt",
+		"linux",
+		"linux/user-startup.sh",
+		"config",
+		"config/NES.cfg",
+		"MISTER.INI",
+		config.SdFolder + "/linux/user-startup.sh",
+	}
+	for _, path := range protected {
+		resolved, err := resolveMenuPath(path)
+		if err == nil {
+			t.Errorf("%q resolved to %q, want rejection", path, resolved)
+			continue
+		}
+		if !errors.Is(err, errProtectedPath) {
+			t.Errorf("%q: got %v, want a protected-path error", path, err)
+		}
+	}
+}
+
+func TestResolveMenuPathAcceptsMenuPaths(t *testing.T) {
+	accepted := map[string]string{
+		"":                           config.SdFolder,
+		".":                          config.SdFolder,
+		"_Arcade":                    filepath.Join(config.SdFolder, "_Arcade"),
+		"_Arcade/Pac-Man.mra":        filepath.Join(config.SdFolder, "_Arcade", "Pac-Man.mra"),
+		"_Console/_NES/Game [!].mgl": filepath.Join(config.SdFolder, "_Console", "_NES", "Game [!].mgl"),
+		config.SdFolder:              config.SdFolder,
+		config.SdFolder + "/_Arcade": filepath.Join(config.SdFolder, "_Arcade"),
+		"_Games/_NES/../_SNES":       filepath.Join(config.SdFolder, "_Games", "_SNES"),
+		"configuration-notes.mgl":    filepath.Join(config.SdFolder, "configuration-notes.mgl"),
+		"linux-tips.mgl":             filepath.Join(config.SdFolder, "linux-tips.mgl"),
+	}
+	for path, want := range accepted {
+		resolved, err := resolveMenuPath(path)
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", path, err)
+			continue
+		}
+		if resolved != want {
+			t.Errorf("%q resolved to %q, want %q", path, resolved, want)
+		}
+	}
+}
+
+func TestRelativeMenuPathKeepsListingLinksStable(t *testing.T) {
+	// ListFolder puts this value straight into the parent, next and up links,
+	// so an empty path must stay empty rather than becoming ".".
+	cases := map[string]string{
+		"":                           "",
+		".":                          ".",
+		"_Arcade":                    "_Arcade",
+		config.SdFolder:              "",
+		config.SdFolder + "/_Arcade": "_Arcade",
+		"_Arcade/":                   "_Arcade",
+	}
+	for path, want := range cases {
+		if got := relativeMenuPath(path); got != want {
+			t.Errorf("relativeMenuPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestDeleteHandlerRejectsTraversalBeforeTouchingDisk(t *testing.T) {
+	// The handler used to reach os.RemoveAll for any ordinary file anywhere on
+	// the device. The traversal targets here point into a temp dir rather than
+	// a real system path, so a regression in the guard deletes a throwaway file
+	// instead of something that matters.
+	logger := service.NewLogger("mrext-menu-path-test")
+	handler := HandleDeleteFile(logger)
+
+	bait := filepath.Join(t.TempDir(), "bait")
+	if err := os.WriteFile(bait, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	escape, err := filepath.Rel(config.SdFolder, bait)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths := []string{escape, bait, "u-boot.img", "linux/user-startup.sh", "MiSTer.ini"}
+	for _, path := range paths {
+		body := strings.NewReader(`{"path":` + strconv.Quote(path) + `}`)
+		request := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "/api/menu/files/delete", body)
+		recorder := httptest.NewRecorder()
+
+		handler(recorder, request)
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("delete %q returned %d, want %d", path, recorder.Code, http.StatusBadRequest)
+		}
+	}
+
+	if _, err := os.Stat(bait); err != nil {
+		t.Fatalf("delete request escaped the menu root: %v", err)
+	}
+}

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1141,6 +1141,10 @@ Arguments (JSON):
 |-----------|--------|----------|--------------------------------------------|
 | `path`    | string | Yes      | Path of menu folder (relative to SD card). |
 
+Paths must resolve inside the SD card root. A path that escapes it, or that
+names a file MiSTer needs to boot (`MiSTer*`, `menu.rbf`, `u-boot.img`,
+`u-boot.txt`, `linux/`, `config/`), returns `400`.
+
 On success, returns `200` and object:
 
 | Attribute | Type   | Description                       |
@@ -1214,6 +1218,10 @@ Arguments (JSON):
 
 On success, returns `200`.
 
+Paths must resolve inside the SD card root. A path that escapes it, or that
+names a file MiSTer needs to boot (`MiSTer*`, `menu.rbf`, `u-boot.img`,
+`u-boot.txt`, `linux/`, `config/`), returns `400`.
+
 Example request:
 
 ```shell
@@ -1237,6 +1245,10 @@ Arguments (JSON):
 
 On success, returns `200`.
 
+Paths must resolve inside the SD card root. A path that escapes it, or that
+names a file MiSTer needs to boot (`MiSTer*`, `menu.rbf`, `u-boot.img`,
+`u-boot.txt`, `linux/`, `config/`), returns `400`.
+
 Example request:
 
 ```shell
@@ -1258,6 +1270,10 @@ Arguments (JSON):
 | `path`    | string | Yes      | Path of file (relative to SD card). |
 
 On success, returns `200`.
+
+Paths must resolve inside the SD card root. A path that escapes it, or that
+names a file MiSTer needs to boot (`MiSTer*`, `menu.rbf`, `u-boot.img`,
+`u-boot.txt`, `linux/`, `config/`), returns `400`.
 
 Example request:
 


### PR DESCRIPTION
## Problem

`cleanPath` in `cmd/remote/menu/files.go` cleaned the client-supplied path *before* joining it to the SD root. `filepath.Join` cleans again, so a relative path with leading `..` resolved outside `/media/fat`.

The delete handler's guards only covered the SD root itself, the `MiSTer*` prefix, `menu.rbf`, and directories not starting with `_`. Any ordinary file elsewhere on the device passed all four and reached `os.RemoveAll`. `/media/fat/u-boot.img` and `/media/fat/linux/user-startup.sh` were both reachable, and deleting either leaves a device that will not boot.

`ListFolder` in `menu.go` had its own `..` filter, but it split with `filepath.SplitList`, which uses the PATH list separator (`:`) rather than `/`. It saw a single element for any ordinary path, so the check never fired.

Remote's API is unauthenticated on the LAN by design, so this was reachable by anything on the network.

## Fix

New `resolveMenuPath` (`cmd/remote/menu/paths.go`) normalises the path, joins it to the SD root, and verifies containment with `filepath.Rel` before any filesystem call. All four handlers — view, create, rename, delete — go through it.

It also refuses files MiSTer needs to boot. The existing `MiSTer*` prefix guard now applies to every operation rather than delete alone, and `menu.rbf`, `u-boot.img`, `u-boot.txt`, `linux/` and `config/` join it.

Rejected paths return `400`, documented in `docs/remote-api.md` for all four endpoints.

## No effect on the menu browser

`isValidMenuFile` only surfaces underscore-prefixed folders and `.mra`/`.rbf`/`.mgl` files, so none of the newly protected entries were listable or navigable. Response shapes are unchanged — `relativeMenuPath` keeps an empty path empty so the parent, next and up links stay exactly as they were.

## Tests

`cmd/remote/menu/paths_test.go` covers traversal rejection, protected paths, accepted menu paths (including names that merely start with `config`/`linux`, and ROM names containing `[!]`), listing-link stability, and a handler-level test asserting a `400` with no filesystem write.

Checked against the old implementation: 26 assertions fail, including `"../../etc/passwd" resolved to "/etc/passwd"`. The traversal targets in the handler test point into `t.TempDir()` rather than a real system path, so a future regression deletes something throwaway.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister remote`.