### PR TITLE
fix(favorites,gamesmenu): stop deleting entries for detached drives

### DIFF
--- a/cmd/gamesmenu/ui.go
+++ b/cmd/gamesmenu/ui.go
@@ -285,6 +285,9 @@ func (u *ui) cleanUp() {
 		}
 		text := fmt.Sprintf("Checked: %d\nRemoved: %d\nEmpty folders pruned: %d\nUnreadable: %d",
 			result.Checked, result.Removed, result.PrunedFolders, result.Unreadable)
+		if result.Unavailable > 0 {
+			text += fmt.Sprintf("\nSkipped (storage not attached): %d", result.Unavailable)
+		}
 		text += errorSummary(result.Errors, result.ErrorsDropped)
 		tui.ShowInfoModal(u.pages, u.app, "Clean Up complete", tview.Escape(text), u.mustShowMain)
 	})

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -172,7 +172,7 @@ Favorites preserves non-interactive startup behavior:
 /media/fat/Scripts/favorites.sh refresh
 ```
 
-Refresh repairs shortcuts whose target is a dated core (such as `NES_20260101.rbf`), even when the favorite has a custom name such as `Nintendo.rbf`. Custom names are preserved; dated favorite names follow the replacement core's date. Both absolute and relative symlink targets are supported. Broken shortcuts without a replacement are removed. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
+Refresh repairs shortcuts whose target is a dated core (such as `NES_20260101.rbf`), even when the favorite has a custom name such as `Nintendo.rbf`. Custom names are preserved; dated favorite names follow the replacement core's date. Both absolute and relative symlink targets are supported. Broken shortcuts without a replacement are removed, unless the target lives on a removable or network drive that is not attached: refresh also runs at boot, before USB and network mounts settle, so favorites pointing at an unplugged drive or a powered-off NAS are left alone rather than deleted. Interactive launch adds the same command to an existing `linux/user-startup.sh` only when no Favorites startup entry exists.
 
 ## Uninstall
 

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -52,7 +52,9 @@ Clean Up asks for confirmation, then checks `.mgl` targets. It removes shortcuts
 
 Malformed, unreadable or ambiguous shortcuts, invalid/unreadable archives, and core-only launchers are kept. Cleanup checks every file target in custom multi-file MGLs; an unknown target prevents deletion. Menu symlinks are not traversed. The summary reports checked and removed shortcuts, pruned folders and unreadable paths.
 
-**Reconnect removable drives and mount network libraries before cleanup.** A disconnected library can look like missing games. Cleanup is never automatic and has no undo; back up custom shortcuts first.
+Shortcuts pointing at a removable or network drive that is not attached are skipped, not removed, and counted in the summary as "Skipped (storage not attached)". An unmounted drive leaves its mount point behind as an empty directory, so a missing target there means the drive is absent rather than the game deleted.
+
+**Reconnect removable drives and mount network libraries before cleanup** if you want those libraries checked. Cleanup is never automatic and has no undo; back up custom shortcuts first.
 
 ## Settings and configuration
 

--- a/pkg/config/mister.go
+++ b/pkg/config/mister.go
@@ -75,6 +75,21 @@ const NamesFile = SdFolder + "/names.txt"
 // GamesMenuFolder is the stock-menu folder GamesMenu mirrors game libraries into.
 const GamesMenuFolder = SdFolder + "/_Games"
 
+// StorageRoots are the removable and network mount points games can live
+// under. Everything below one of these is only reachable while that storage is
+// attached; an unmounted mount point is left behind as an empty directory.
+// Paths on the SD card are not listed because it is always present.
+var StorageRoots = []string{
+	"/media/usb0",
+	"/media/usb1",
+	"/media/usb2",
+	"/media/usb3",
+	"/media/usb4",
+	"/media/usb5",
+	"/media/network",
+	"/media/fat/cifs",
+}
+
 // TODO: not the order mister actually checks, it does games folders second, but this is simpler for checking prefix
 var GamesFolders = []string{
 	"/media/usb0/games",

--- a/pkg/favorites/favorites_test.go
+++ b/pkg/favorites/favorites_test.go
@@ -1124,3 +1124,47 @@ func createZip(path string, files map[string]string) error {
 	}
 	return nil
 }
+
+func TestRefreshKeepsFavoritesWhenStorageIsDetached(t *testing.T) {
+	manager, _, root := newTestManager(t)
+	folder := filepath.Join(root, "_@Favorites")
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Refresh also runs from user-startup.sh, before USB and network mounts
+	// settle, so a favorite pointing at an unplugged drive must survive.
+	media := t.TempDir()
+	attached := filepath.Join(media, "usb0")
+	detached := filepath.Join(media, "usb1")
+	if err := os.MkdirAll(filepath.Join(attached, "games"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(detached, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := config.StorageRoots
+	config.StorageRoots = []string{attached, detached}
+	t.Cleanup(func() { config.StorageRoots = previous })
+
+	onDetached := filepath.Join(folder, "Unplugged.mgl")
+	if err := os.Symlink(filepath.Join(detached, "games", "game.mgl"), onDetached); err != nil {
+		t.Fatal(err)
+	}
+	onAttached := filepath.Join(folder, "Deleted.mgl")
+	if err := os.Symlink(filepath.Join(attached, "games", "gone.mgl"), onAttached); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.Refresh(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Lstat(onDetached); err != nil {
+		t.Errorf("favorite on an unplugged drive was removed: %v", err)
+	}
+	if _, err := os.Lstat(onAttached); !os.IsNotExist(err) {
+		t.Errorf("favorite for a genuinely deleted game survived: %v", err)
+	}
+}

--- a/pkg/favorites/manager.go
+++ b/pkg/favorites/manager.go
@@ -550,6 +550,13 @@ func (m *Manager) Refresh() error {
 		} else if !os.IsNotExist(statErr) {
 			return fmt.Errorf("inspect favorite target: %w", statErr)
 		}
+		// A target on detached storage is out of reach, not deleted. Refresh
+		// also runs from user-startup.sh, before USB and network mounts
+		// settle, so removing here would wipe every favorite pointing at a
+		// drive that is merely unplugged or a NAS that is powered off.
+		if !mister.TargetAvailable(resolvedTarget) {
+			continue
+		}
 		if err := os.Remove(favorite.Path); err != nil {
 			return fmt.Errorf("remove broken favorite: %w", err)
 		}

--- a/pkg/gamesmenu/cleanup.go
+++ b/pkg/gamesmenu/cleanup.go
@@ -31,16 +31,21 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
 )
 
 type CleanupProgress struct{ Checked, Removed int }
 
 type CleanupResult struct {
-	Errors                                      []error
-	Checked, Removed, Unreadable, PrunedFolders int
-	ErrorsDropped                               int
+	Errors                                                   []error
+	Checked, Removed, Unreadable, PrunedFolders, Unavailable int
+	ErrorsDropped                                            int
 }
+
+// errStorageUnavailable marks a shortcut whose target lives on storage that is
+// not attached. The game is out of reach, not gone, so the shortcut stays.
+var errStorageUnavailable = errors.New("target storage is not available")
 
 func (r *CleanupResult) unreadable(err error) {
 	r.Unreadable++
@@ -94,9 +99,14 @@ func (m *Manager) CleanUp(progress func(CleanupProgress)) (CleanupResult, error)
 		}
 		result.Checked++
 		missing, checkErr := checkShortcut(root, name, archives)
-		if checkErr != nil {
+		switch {
+		case errors.Is(checkErr, errStorageUnavailable):
+			// A drive that is merely unplugged must not cost the user their
+			// shortcuts. Count it so the summary can say what was skipped.
+			result.Unavailable++
+		case checkErr != nil:
 			result.unreadable(fmt.Errorf("check shortcut %s: %w", name, checkErr))
-		} else if missing {
+		case missing:
 			if removeErr := root.Remove(name); removeErr != nil {
 				result.unreadable(fmt.Errorf("remove shortcut %s: %w", name, removeErr))
 			} else {
@@ -198,6 +208,9 @@ func missingTarget(target string, archives map[string]zipContents) (bool, error)
 		if !ok {
 			info, err := os.Stat(archive)
 			if errors.Is(err, fs.ErrNotExist) {
+				if !mister.TargetAvailable(archive) {
+					return false, fmt.Errorf("%w: %s", errStorageUnavailable, archive)
+				}
 				return true, nil
 			}
 			if err != nil {
@@ -225,6 +238,9 @@ func missingTarget(target string, archives map[string]zipContents) (bool, error)
 	}
 	_, err := os.Stat(target)
 	if errors.Is(err, fs.ErrNotExist) {
+		if !mister.TargetAvailable(target) {
+			return false, fmt.Errorf("%w: %s", errStorageUnavailable, target)
+		}
 		return true, nil
 	}
 	if err != nil {

--- a/pkg/gamesmenu/cleanup_test.go
+++ b/pkg/gamesmenu/cleanup_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 )
 
@@ -134,5 +135,55 @@ func TestCleanUpStatErrorsAreNotMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(output); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCleanUpKeepsShortcutsWhenStorageIsDetached(t *testing.T) {
+	m := fixture(t)
+
+	// Two removable drives: one attached with the game deleted from it, one
+	// unplugged. An unmounted mount point is left behind as an empty directory,
+	// so both targets stat as ENOENT and only the attached one is a real
+	// deletion.
+	media := t.TempDir()
+	attached := filepath.Join(media, "usb0")
+	detached := filepath.Join(media, "usb1")
+	put(t, filepath.Join(attached, "games", "NES", "kept.nes"), "")
+	if err := os.Mkdir(detached, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := config.StorageRoots
+	config.StorageRoots = []string{attached, detached}
+	t.Cleanup(func() { config.StorageRoots = previous })
+
+	output := filepath.Join(m.paths.MenuFolder, "_NES")
+	shortcut := func(name, target string) string {
+		path := filepath.Join(output, name+".mgl")
+		put(t, path, `<mistergamedescription><rbf>_Console/NES</rbf><file path="`+target+`"/></mistergamedescription>`)
+		return path
+	}
+	onDetached := shortcut("detached", filepath.Join(detached, "games", "NES", "game.nes"))
+	onAttached := shortcut("deleted", filepath.Join(attached, "games", "NES", "gone.nes"))
+
+	result, err := m.CleanUp(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, statErr := os.Stat(onDetached); statErr != nil {
+		t.Errorf("shortcut for an unplugged drive was removed: %v", statErr)
+	}
+	if _, statErr := os.Stat(onAttached); !os.IsNotExist(statErr) {
+		t.Errorf("shortcut for a genuinely deleted game survived: %v", statErr)
+	}
+	if result.Removed != 1 {
+		t.Errorf("Removed = %d, want 1", result.Removed)
+	}
+	if result.Unavailable != 1 {
+		t.Errorf("Unavailable = %d, want 1", result.Unavailable)
+	}
+	if result.Unreadable != 0 {
+		t.Errorf("Unreadable = %d, want 0: %v", result.Unreadable, result.Errors)
 	}
 }

--- a/pkg/mister/storage.go
+++ b/pkg/mister/storage.go
@@ -1,0 +1,66 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// StorageRootFor returns the removable or network mount point a path lives
+// under, or "" for paths that are not on removable storage. The longest match
+// wins so /media/fat/cifs is not mistaken for the SD card.
+func StorageRootFor(path string) string {
+	cleaned := filepath.Clean(path)
+	best := ""
+	for _, root := range config.StorageRoots {
+		if cleaned != root && !strings.HasPrefix(cleaned, root+string(filepath.Separator)) {
+			continue
+		}
+		if len(root) > len(best) {
+			best = root
+		}
+	}
+	return best
+}
+
+// TargetAvailable reports whether the storage holding path is attached.
+//
+// A missing file on attached storage was deleted by the user. A missing file
+// on detached storage is only out of reach, and treating the two the same
+// destroys shortcuts and favorites that took real effort to build: a USB drive
+// left unplugged, or a NAS powered off, would otherwise wipe every entry
+// pointing at it. Callers must consult this before acting on os.IsNotExist.
+func TargetAvailable(path string) bool {
+	root := StorageRootFor(path)
+	if root == "" {
+		return true
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		// The mount point itself is gone or unreadable.
+		return false
+	}
+	// An unmounted mount point is an empty directory.
+	return len(entries) > 0
+}

--- a/pkg/mister/storage_test.go
+++ b/pkg/mister/storage_test.go
@@ -1,0 +1,85 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+func TestStorageRootForPrefersTheLongestMatch(t *testing.T) {
+	previous := config.StorageRoots
+	config.StorageRoots = []string{"/media/usb0", "/media/network", "/media/fat/cifs"}
+	t.Cleanup(func() { config.StorageRoots = previous })
+
+	cases := map[string]string{
+		"/media/usb0/games/NES/game.nes": "/media/usb0",
+		"/media/usb0":                    "/media/usb0",
+		"/media/network/games/x.bin":     "/media/network",
+		// The SD card is always present, so nothing under it is removable.
+		"/media/fat/games/NES/game.nes": "",
+		"/media/fat":                    "",
+		// cifs lives under the SD card; the longer root has to win.
+		"/media/fat/cifs/games/x.bin": "/media/fat/cifs",
+		// A sibling that merely shares a prefix is not on that storage.
+		"/media/usb00/games/x.bin": "",
+		"/media/usb0extra":         "",
+	}
+	for path, want := range cases {
+		if got := StorageRootFor(path); got != want {
+			t.Errorf("StorageRootFor(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestTargetAvailableDistinguishesDetachedFromDeleted(t *testing.T) {
+	media := t.TempDir()
+	attached := filepath.Join(media, "usb0")
+	unmounted := filepath.Join(media, "usb1")
+	absent := filepath.Join(media, "usb2")
+
+	if err := os.MkdirAll(filepath.Join(attached, "games"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// An unmounted mount point is left behind as an empty directory.
+	if err := os.Mkdir(unmounted, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := config.StorageRoots
+	config.StorageRoots = []string{attached, unmounted, absent}
+	t.Cleanup(func() { config.StorageRoots = previous })
+
+	if !TargetAvailable(filepath.Join(attached, "games", "gone.nes")) {
+		t.Error("a deleted file on attached storage must count as available")
+	}
+	if TargetAvailable(filepath.Join(unmounted, "games", "game.nes")) {
+		t.Error("an empty mount point means the drive is not attached")
+	}
+	if TargetAvailable(filepath.Join(absent, "games", "game.nes")) {
+		t.Error("a missing mount point means the drive is not attached")
+	}
+	if !TargetAvailable("/media/fat/games/NES/gone.nes") {
+		t.Error("the SD card is always available")
+	}
+}


### PR DESCRIPTION
## Problem

Both apps treated any `ENOENT` on a target as proof the game was deleted. An unmounted drive leaves its mount point behind as an empty directory, so a USB drive left unplugged or a NAS powered off stats identically to a deleted file — and the entries pointing at it were destroyed.

- **GamesMenu** (`pkg/gamesmenu/cleanup.go`): Clean Up removed every shortcut for that library. Recovering means a full re-scan with the drive attached.
- **Favorites** (`pkg/favorites/manager.go`): worse, because `Refresh()` also runs from `user-startup.sh`, *before* USB and network mounts settle. Favorites pointing at external storage were deleted on the next boot, without the user asking for a refresh.

## Fix

New `mister.TargetAvailable` (`pkg/mister/storage.go`) resolves the removable or network mount point a path lives under and reports whether it is attached. The roots live in `config.StorageRoots`, beside the existing `GamesFolders` list. Paths on the SD card are always available, so nothing changes for the common case.

Both apps consult it before acting on `os.IsNotExist`. A genuinely deleted file on attached storage is still cleaned up exactly as before.

Clean Up counts skipped shortcuts and reports them as `Skipped (storage not attached)` in its summary, so the difference is visible rather than a silent no-op.

`docs/gamesmenu.md` already told users to reconnect drives before cleanup; that is now enforced rather than left to memory. Both docs updated.

## Tests

- `pkg/mister/storage_test.go` — longest-prefix root matching (so `/media/fat/cifs` is not read as the SD card, and `/media/usb00` is not read as `/media/usb0`), and the three storage states: attached with the file deleted, unmounted empty mount point, missing mount point.
- `pkg/gamesmenu/cleanup_test.go` and `pkg/favorites/favorites_test.go` — one entry on an attached drive whose game was deleted, one on an unplugged drive. Asserts the first is removed and the second survives.

Checked against the pre-fix behaviour: both end-to-end tests fail with `shortcut for an unplugged drive was removed` and `favorite on an unplugged drive was removed`.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister favorites`, `mage mister gamesmenu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup now preserves shortcuts whose removable or network storage is not attached, while still removing shortcuts for genuinely missing games.
  * Favorites refresh now keeps links to games on temporarily unavailable storage and removes only confirmed missing targets.
  * Cleanup summaries report shortcuts skipped because storage was unavailable.

* **Documentation**
  * Clarified how disconnected removable drives and network libraries affect cleanup and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->