### PR TITLE
fix(playlog): stop recording menu navigation on every cursor move

### DIFF
--- a/cmd/playlog/db.go
+++ b/cmd/playlog/db.go
@@ -88,6 +88,30 @@ func (p *playLogDb) setupDb() error {
 		return fmt.Errorf("create game-times table: %w", err)
 	}
 
+	return p.pruneMenuNavigation()
+}
+
+// pruneMenuNavigation drops menu navigation rows written by older versions.
+// Every query in this file selects on core and game actions only, so these
+// rows are unreachable, and there can be hundreds of thousands of them.
+// Reclaiming the space is worth one delete on open; play history and totals
+// live in core_times and game_times and are untouched.
+func (p *playLogDb) pruneMenuNavigation() error {
+	result, err := p.db.ExecContext(
+		context.Background(),
+		"delete from events where action = ?",
+		tracker.EventActionMenuNavigation,
+	)
+	if err != nil {
+		return fmt.Errorf("prune menu navigation events: %w", err)
+	}
+	if removed, rowsErr := result.RowsAffected(); rowsErr == nil && removed > 0 {
+		// VACUUM outside a transaction, so the file actually shrinks rather
+		// than leaving free pages behind on the card.
+		if _, vacuumErr := p.db.ExecContext(context.Background(), "vacuum"); vacuumErr != nil {
+			return fmt.Errorf("compact play log database: %w", vacuumErr)
+		}
+	}
 	return nil
 }
 
@@ -156,7 +180,15 @@ func (p *playLogDb) UpdateGame(game tracker.GameTime) error {
 	return nil
 }
 
+// AddEvent records a play event. Menu navigation is deliberately not stored:
+// the tracker emits it on every write to /tmp/CURRENTPATH, so a minute of
+// browsing the menu was hundreds of inserts into a database on the SD card,
+// for rows nothing ever read back. Remote still receives those events and
+// broadcasts them over its websocket; only persistence is skipped.
 func (p *playLogDb) AddEvent(event *tracker.EventAction) error {
+	if event.Action == tracker.EventActionMenuNavigation {
+		return nil
+	}
 	_, err := p.db.ExecContext(
 		context.Background(),
 		"insert into events (timestamp, action, target, total_time) values (?, ?, ?, ?)",

--- a/cmd/playlog/db_test.go
+++ b/cmd/playlog/db_test.go
@@ -136,3 +136,95 @@ func TestPlayLogReadsLegacyGoSQLiteTimestamp(t *testing.T) {
 		t.Fatal("expected legacy timestamp event to be recovered")
 	}
 }
+
+func TestMenuNavigationIsNotPersisted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "playlog.db")
+	db, err := openPlayLogDbAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.db.Close() })
+
+	// The tracker emits menu navigation on every write to /tmp/CURRENTPATH.
+	// Persisting it put an SD-card write behind every cursor move, for rows no
+	// query in this file ever selects.
+	for range 50 {
+		event := tracker.EventAction{
+			Timestamp: time.Now(),
+			Action:    tracker.EventActionMenuNavigation,
+			Target:    "Console/NES",
+		}
+		if addErr := db.AddEvent(&event); addErr != nil {
+			t.Fatal(addErr)
+		}
+	}
+	played := tracker.EventAction{
+		Timestamp: time.Now(),
+		Action:    tracker.EventActionGameStart,
+		Target:    "Super Mario Bros",
+	}
+	if addErr := db.AddEvent(&played); addErr != nil {
+		t.Fatal(addErr)
+	}
+
+	if got := countEvents(t, db); got != 1 {
+		t.Fatalf("events table holds %d rows, want only the game start", got)
+	}
+}
+
+func TestExistingMenuNavigationRowsArePrunedOnOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "playlog.db")
+	db, err := openPlayLogDbAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a database written by an older version, which stored these.
+	for range 20 {
+		if _, execErr := db.db.ExecContext(
+			t.Context(),
+			"insert into events (timestamp, action, target, total_time) values (?, ?, ?, ?)",
+			time.Now(), tracker.EventActionMenuNavigation, "Console/NES", 0,
+		); execErr != nil {
+			t.Fatal(execErr)
+		}
+	}
+	keep := tracker.EventAction{
+		Timestamp: time.Now(),
+		Action:    tracker.EventActionCoreStart,
+		Target:    "NES",
+	}
+	if addErr := db.AddEvent(&keep); addErr != nil {
+		t.Fatal(addErr)
+	}
+	if closeErr := db.db.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	reopened, err := openPlayLogDbAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.db.Close() })
+
+	if got := countEvents(t, reopened); got != 1 {
+		t.Fatalf("events table holds %d rows after pruning, want only the core start", got)
+	}
+	// Play history and totals must survive the prune untouched.
+	last, err := reopened.lastEvent(tracker.EventActionCoreStart, tracker.EventActionCoreStop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last.Target != "NES" {
+		t.Fatalf("last core event target = %q, want NES", last.Target)
+	}
+}
+
+func countEvents(t *testing.T, db *playLogDb) int {
+	t.Helper()
+	var count int
+	if err := db.db.QueryRowContext(t.Context(), "select count(*) from events").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -49,6 +49,8 @@ Remove PlayLog's Downloader subscription if configured, so updates do not reinst
 PlayLog generates no menu folder. Custom scripts referenced by its state hooks belong to you and may be shared; removing PlayLog does not require deleting them. Keep MiSTer recents/configuration and shared `/tmp/ACTIVEGAME`. After shutdown, `/tmp/playlog.pid`, `/tmp/playlog.log`, and `/tmp/playlog.sh` are optional cleanup.
 >>>>>>> origin/main
 
+PlayLog does not record menu navigation. Earlier versions wrote a database row for every cursor movement in the MiSTer menu, which put an SD card write behind each one and grew the `events` table without bound, for rows PlayLog never read back. Those rows are deleted and the database compacted the first time this version opens it; play history and totals are untouched. Remote still receives menu navigation over its websocket, which is the only place it was ever used.
+
 ## Configuration
 
 PlayLog can be configured by creating a `playlog.ini` file in the `/media/fat/Scripts` folder where you put `playlog.sh`. For example:


### PR DESCRIPTION
## Problem

`pkg/tracker` emits `EventActionMenuNavigation` on every write to `/tmp/CURRENTPATH` — that is, every cursor movement in the MiSTer menu. PlayLog's `AddEvent` turned each one into an `INSERT` into `/media/fat/playlog.db`.

A minute of browsing the menu was hundreds of SD card writes and hundreds of rows, in a table nothing prunes. `docs/playlog.md` warns users about the *five-minute* save interval as an SD-wear concern, which makes this particularly unfortunate.

Nothing read the rows back: `lastEvent` is the only reader and it selects on core/game start and stop actions only.

## Fix

Skipped in PlayLog's `AddEvent`, **not** in the tracker.

This matters: `cmd/remote/games/tracker.go` handles `EventActionMenuNavigation` by broadcasting `menuNavigation:` over Remote's websocket. Dropping the event upstream in `tracker.addEvent` would have broken Remote's live menu tracking. Only persistence was wrong.

Rows accumulated by older versions are deleted when the database is opened, followed by a `VACUUM` so the card actually gets the space back. `core_times` and `game_times` hold the play history and totals and are untouched.

## Tests

- `TestMenuNavigationIsNotPersisted` — 50 navigation events and one game start leave a single row.
- `TestExistingMenuNavigationRowsArePrunedOnOpen` — a database seeded with old navigation rows is pruned on reopen, and the surviving core event is still readable through `lastEvent`.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister playlog`.