### PR TITLE
fix(gamesdb): survive dangling symlinks and report a busy indexer

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -54,11 +55,18 @@ func generateIndexWindow(cfg *config.UserConfig) error {
 			}
 			update(tui.ProgressUpdate{Text: text, Current: status.Step, Total: status.Total})
 		})
+		if errors.Is(err, gamesdb.ErrIndexBusy) {
+			return fmt.Errorf("%w", err)
+		}
 		if err != nil {
 			return fmt.Errorf("build game-name index: %w", err)
 		}
 		return nil
 	})
+	if errors.Is(err, gamesdb.ErrIndexBusy) {
+		// Already a complete sentence, and the cause is not this window.
+		return fmt.Errorf("%w", err)
+	}
 	if err != nil {
 		return fmt.Errorf("show index progress: %w", err)
 	}

--- a/docs/search.md
+++ b/docs/search.md
@@ -33,6 +33,10 @@ The current shared index is `/media/fat/Scripts/.config/mrext/games.db`, not the
 
 Full rebuilds remove stale game names and system metadata only after a successful scan. They stage bounded batches on SD before publishing the replacement, leaving an existing working index intact if regeneration fails. Mount all desired game libraries first and allow enough free space for a second index. Leave the adjacent `games.db.lock` in place while any app is indexing; it is shared writer-coordination state.
 
+Only one indexer can write at a time. If Remote is already rebuilding the index, Search reports that another indexer is running instead of waiting; try again once it finishes.
+
+A game folder that cannot be reached, such as a symlink into a drive that is not attached, is skipped rather than failing the whole run. Broken symlinks inside a library are skipped the same way, so one dead link no longer prevents indexing.
+
 ## Uninstall
 
 Remove Search's Downloader subscription if configured, so updates do not reinstall it.

--- a/pkg/games/walk.go
+++ b/pkg/games/walk.go
@@ -68,13 +68,19 @@ func WalkFiles(systemID, root string, visit func(string) error) error {
 				return nil
 			}
 			if entry.Type()&os.ModeSymlink != 0 {
+				// A symlink that does not resolve points at something that is
+				// not there: a drive left unplugged, or a game since deleted.
+				// That is not a scan failure. Treating it as one meant a single
+				// dangling link anywhere in a library aborted the whole index,
+				// so nothing at all got indexed and the user had no way to see
+				// which link was at fault.
 				target, resolveErr := filepath.EvalSymlinks(path)
 				if resolveErr != nil {
-					return fmt.Errorf("resolve game symlink: %w", resolveErr)
+					return nil //nolint:nilerr // A broken link is an absent file, not an error.
 				}
 				targetInfo, statErr := os.Stat(target)
 				if statErr != nil {
-					return fmt.Errorf("stat game symlink: %w", statErr)
+					return nil //nolint:nilerr // As above: unreachable target, not a scan failure.
 				}
 				if targetInfo.IsDir() {
 					return walk(target, display)

--- a/pkg/gamesdb/gamesdb.go
+++ b/pkg/gamesdb/gamesdb.go
@@ -118,6 +118,10 @@ type IndexStatus struct {
 	Total    int
 	Step     int
 	Files    int
+	// Skipped counts game roots that could not be scanned, such as a folder
+	// on a drive that is not attached. Those roots are reported rather than
+	// failing the whole run.
+	Skipped int
 }
 
 type SearchResult struct {

--- a/pkg/gamesdb/gamesdb_test.go
+++ b/pkg/gamesdb/gamesdb_test.go
@@ -327,3 +327,105 @@ func TestEmptyFullRebuildClearsIndex(t *testing.T) {
 		t.Fatalf("empty metadata = %v, %v", indexed, err)
 	}
 }
+
+func TestSecondIndexerReportsBusyInsteadOfHanging(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+	ctx, release := context.WithCancel(context.Background())
+	defer release()
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := indexNames(db, systems[:1], paths[:1], func(_, path string, visit func(string) error) error {
+			close(started)
+			<-ctx.Done()
+			return visit(filepath.Join(path, "new.nes"))
+		}, nil, true)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first writer did not start")
+	}
+
+	previous := indexLockTimeout
+	indexLockTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { indexLockTimeout = previous })
+
+	// bbolt's zero default timeout waits forever, so this call used to block
+	// before its first progress callback: Remote's rebuild and search.sh at the
+	// same time left one of them on a frozen screen with nothing to explain it.
+	progressed := false
+	_, err := indexNames(db, systems[:1], paths[:1],
+		func(_, path string, visit func(string) error) error { return visit(filepath.Join(path, "other.nes")) },
+		func(IndexStatus) { progressed = true }, true)
+	if !errors.Is(err, ErrIndexBusy) {
+		t.Fatalf("second indexer error = %v, want ErrIndexBusy", err)
+	}
+	if progressed {
+		t.Error("second indexer reported progress it never made")
+	}
+
+	release()
+	select {
+	case buildErr := <-done:
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("first writer did not finish")
+	}
+}
+
+func TestDanglingSymlinksDoNotAbortTheIndex(t *testing.T) {
+	db, systems, paths := indexFixture(t)
+
+	// One broken link in a library used to abort the whole run with
+	// "resolve game symlink", so nothing was indexed at all, including every
+	// system that would have scanned cleanly.
+	broken := filepath.Join(paths[0].Path, "unplugged.nes")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "never-existed.nes"), broken); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := indexNames(db, systems, paths, games.WalkFiles, nil, true)
+	if err != nil {
+		t.Fatalf("a dangling symlink aborted the index: %v", err)
+	}
+	names := namesSnapshot(t, db)
+	if len(names) == 0 {
+		t.Fatal("nothing was indexed")
+	}
+	for _, name := range names {
+		if strings.Contains(name, "unplugged") {
+			t.Errorf("a broken link was indexed as a game: %s", name)
+		}
+	}
+	if files == 0 {
+		t.Fatal("no files counted")
+	}
+}
+
+func TestUnresolvableRootsAreSkippedAndCounted(t *testing.T) {
+	root := t.TempDir()
+	present := filepath.Join(root, "NES")
+	if err := os.Mkdir(present, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	system, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := []games.PathResult{
+		{System: *system, Path: present},
+		{System: *system, Path: filepath.Join(root, "not-mounted")},
+	}
+
+	unique, skipped := uniquePaths(paths)
+	if skipped != 1 {
+		t.Errorf("skipped = %d, want 1", skipped)
+	}
+	if got := len(unique["NES"]); got != 1 {
+		t.Errorf("kept %d roots, want the one that resolves", got)
+	}
+}

--- a/pkg/gamesdb/index.go
+++ b/pkg/gamesdb/index.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/games"
@@ -67,6 +68,14 @@ func generateNamesIndex(
 	return indexNames(config.GamesDB, unique, games.GetSystemPaths(cfg, unique), games.WalkFiles, update, replaceAll)
 }
 
+// indexLockTimeout bounds the wait for another indexer to finish. Long enough
+// to ride out a handover, short enough to tell the user what is happening.
+// A variable so tests need not wait it out.
+var indexLockTimeout = 5 * time.Second
+
+// ErrIndexBusy reports that another process is already writing the index.
+var ErrIndexBusy = errors.New("another indexer is already running; wait for it to finish and try again")
+
 // indexNames stages bounded batches beside the live database, never in /tmp.
 // A separate persistent lock serializes writers across atomic file replacement;
 // readers keep using the previous inode until they close their connection.
@@ -80,16 +89,20 @@ func indexNames(
 	if err := os.MkdirAll(filepath.Dir(filename), 0o750); err != nil {
 		return 0, fmt.Errorf("create index directory: %w", err)
 	}
-	lock, err := bolt.Open(filename+config.GamesDBLockSuffix, 0o600, nil)
+	// bbolt's default flock timeout is zero, which means wait forever. Two
+	// indexers, such as Remote's rebuild button and search.sh, would leave the
+	// second one blocked here before its first progress callback, so its UI
+	// sat on the opening message with nothing to show and no way to know why.
+	lock, err := bolt.Open(filename+config.GamesDBLockSuffix, 0o600, &bolt.Options{Timeout: indexLockTimeout})
 	if err != nil {
+		if errors.Is(err, bolt.ErrTimeout) {
+			return 0, ErrIndexBusy
+		}
 		return 0, fmt.Errorf("lock index writer: %w", err)
 	}
 	defer func() { _ = lock.Close() }()
-	systemPaths, err := uniquePaths(paths)
-	if err != nil {
-		return 0, err
-	}
-	status := IndexStatus{Total: len(systemPaths) + 2, Step: 1}
+	systemPaths, skipped := uniquePaths(paths)
+	status := IndexStatus{Total: len(systemPaths) + 2, Step: 1, Skipped: skipped}
 	update(status)
 	temporary, err := os.CreateTemp(filepath.Dir(filename), ".games-index-*")
 	if err != nil {
@@ -151,22 +164,27 @@ func indexNames(
 	return status.Files, nil
 }
 
-func uniquePaths(paths []games.PathResult) (map[string][]string, error) {
-	result := make(map[string][]string)
+// uniquePaths deduplicates game roots by their resolved location. A root that
+// cannot be resolved, such as a symlink into a drive that is not attached, is
+// skipped and counted: one bad symlink used to abort the run before anything
+// was indexed, including the systems that would have scanned cleanly.
+func uniquePaths(paths []games.PathResult) (roots map[string][]string, skippedRoots int) {
+	roots = make(map[string][]string)
 	seen := make(map[string]bool)
 	for i := range paths {
 		path := &paths[i]
 		resolved, err := filepath.EvalSymlinks(path.Path)
 		if err != nil {
-			return nil, fmt.Errorf("resolve index root %s: %w", path.Path, err)
+			skippedRoots++
+			continue
 		}
 		key := path.System.Id + ":" + resolved
 		if !seen[key] {
 			seen[key] = true
-			result[path.System.Id] = append(result[path.System.Id], path.Path)
+			roots[path.System.Id] = append(roots[path.System.Id], path.Path)
 		}
 	}
-	return result, nil
+	return roots, skippedRoots
 }
 
 func copyUnselected(filename string, systems []games.System, writer *indexWriter, indexed map[string]bool) error {


### PR DESCRIPTION
## Problem

Two ways game indexing failed with nothing on screen to explain it.

**The writer lock waited forever.** `bolt.Open` was given `nil` options, so bbolt used its default zero flock timeout, which means block indefinitely. Start a rebuild from Remote's web UI, then run `search.sh`: the second one blocked inside `bolt.Open`, *before* its first progress callback, so its screen sat on "Finding games folders…" with no way to know why.

**One dangling symlink aborted the whole index.** `pkg/games/walk.go` returned `resolve game symlink: no such file or directory` for any link that did not resolve, which propagated all the way up. Nothing got indexed — including every system that would have scanned cleanly — and the message did not say which link was at fault. Same for a game root that could not be resolved, which failed in `uniquePaths` before any scanning started.

## Fix

- Pass `Timeout: indexLockTimeout` (5s) and return `ErrIndexBusy` when another writer holds the lock. Search reports it as its own sentence rather than wrapping it in "show index progress: …".
- A symlink that does not resolve points at something that is not there — a drive left unplugged, a game since deleted. That is an absent file, not a scan failure, so it is skipped. Unresolvable game roots are skipped too, and counted in the new `IndexStatus.Skipped`.

## What did not change

Genuine scan and write failures still abort the whole build and leave the previous index in place. `TestFailedRebuildRollsBackNamesAndMetadata` encodes that guarantee deliberately — publishing a half-built index would mean Search silently cannot find games that exist.

I initially made all scan failures non-fatal and that test caught it. Only the cases that mean "not there" were changed.

## Tests

- `TestSecondIndexerReportsBusyInsteadOfHanging` — a second indexer returns `ErrIndexBusy` and reports no progress it did not make. `indexLockTimeout` is a var so the test does not wait it out.
- `TestDanglingSymlinksDoNotAbortTheIndex` — a broken link in a library indexes everything else and is not itself indexed as a game.
- `TestUnresolvableRootsAreSkippedAndCounted` — `uniquePaths` keeps the root that resolves and counts the one that does not.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for search, launchsync and remote.