### PR TITLE
fix(tracker,remote): keep tracking alive across restarts and dead webhooks

### DIFF
--- a/cmd/lastplayed/main.go
+++ b/cmd/lastplayed/main.go
@@ -315,7 +315,7 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		}
 	}
 
-	watcher, err := tracker.StartFileWatch(tr)
+	watcher, err := tracker.StartFileWatchWithRetry(tr)
 	if err != nil {
 		tr.Logger.Error("error starting file watch: %s", err)
 		os.Exit(1)

--- a/cmd/playlog/main.go
+++ b/cmd/playlog/main.go
@@ -58,7 +58,7 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 		}
 	}
 
-	watcher, err := tracker.StartFileWatch(tr)
+	watcher, err := tracker.StartFileWatchWithRetry(tr)
 	if err != nil {
 		tr.Logger.Error("error starting file watch: %s", err)
 		os.Exit(1)

--- a/cmd/remote/games/tracker.go
+++ b/cmd/remote/games/tracker.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/wizzomafizzo/mrext/cmd/remote/websocket"
@@ -159,7 +160,57 @@ type AnnounceGamePayload struct {
 	GameName     string `json:"gameName"`
 }
 
+// announceQueueSize bounds the backlog of pending webhook posts. Dropping the
+// oldest news is better than growing without limit behind a dead endpoint.
+const announceQueueSize = 16
+
+type announceRequest struct {
+	logger *service.Logger
+	url    string
+	body   []byte
+}
+
+var (
+	announceOnce  sync.Once
+	announceQueue chan announceRequest
+)
+
+func announceWorker() {
+	for request := range announceQueue {
+		postAnnounce(request)
+	}
+}
+
+func postAnnounce(request announceRequest) {
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, request.url, bytes.NewReader(request.body),
+	)
+	if err != nil {
+		request.logger.Error("error creating announce request: %s", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		request.logger.Error("error sending announce payload: %s", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// SendAnnounceGame queues the configured webhook and returns immediately.
+//
+// It is called from tracker.addEvent with the tracker mutex held. Posting
+// inline meant an announce_game_url pointing at a host that had gone offline
+// froze all core and game tracking for the full 15-second HTTP timeout on
+// every core change: /api/games/playing hung and websocket updates stalled.
 func SendAnnounceGame(cfg *config.UserConfig, logger *service.Logger, ev *tracker.EventAction) {
+	url := cfg.Remote.AnnounceGameURL
+	if url == "" {
+		return
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = ""
@@ -176,28 +227,20 @@ func SendAnnounceGame(cfg *config.UserConfig, logger *service.Logger, ev *tracke
 		GameName:     ev.ActiveGame.Name,
 	}
 
-	url := cfg.Remote.AnnounceGameURL
 	data, err := json.Marshal(announce)
 	if err != nil {
 		logger.Error("error marshalling announce payload: %s", err)
 		return
 	}
 
-	if url != "" {
-		req, requestErr := http.NewRequestWithContext(
-			context.Background(), http.MethodPost, url, bytes.NewReader(data),
-		)
-		if requestErr != nil {
-			logger.Error("error creating announce request: %s", requestErr)
-			return
-		}
-		req.Header.Set("Content-Type", "application/json")
-		client := &http.Client{Timeout: 15 * time.Second}
-		resp, requestErr := client.Do(req)
-		if requestErr != nil {
-			logger.Error("error sending announce payload: %s", requestErr)
-			return
-		}
-		_ = resp.Body.Close()
+	announceOnce.Do(func() {
+		announceQueue = make(chan announceRequest, announceQueueSize)
+		go announceWorker()
+	})
+
+	select {
+	case announceQueue <- announceRequest{logger: logger, url: url, body: data}:
+	default:
+		logger.Warn("announce endpoint is not keeping up, dropping event for %s", url)
 	}
 }

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -38,6 +38,8 @@ Arcade shortcuts are `.mra` links, so the Last Played shortcut becomes `Last Pla
 
 Recently Played numbers `.mra` and `.mgl` shortcuts together. Replaying a game refreshes its entry without deleting the newly numbered shortcut. `/tmp/ACTIVEGAME` continues to contain the legacy arcade set name; tracker events carry the resolved launchable path separately. This works on stock MiSTer without Zaparoo Core.
 
+LastPlayed waits for MiSTer's state files to appear when it starts, so launching it from `user-startup.sh` before MiSTer main has created them no longer makes the service exit. It also recovers when another script replaces `/tmp/ACTIVEGAME` or `/tmp/CORENAME` instead of writing over them, which previously left tracking silent until a restart.
+
 ## Configuration
 
 LastPlayed can be configured by creating a `lastplayed.ini` file in the `/media/fat/Scripts` folder where you put `lastplayed.sh`. For example:

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -39,6 +39,8 @@ Service status and stop commands verify the recorded PID's executable and daemon
 
 PlayLog does not record menu navigation. Earlier versions wrote a database row for every cursor movement in the MiSTer menu, which put an SD card write behind each one and grew the `events` table without bound, for rows PlayLog never read back. Those rows are deleted and the database compacted the first time this version opens it; play history and totals are untouched. Remote still receives menu navigation over its websocket, which is the only place it was ever used.
 
+PlayLog waits for MiSTer's state files to appear when it starts, so launching it from `user-startup.sh` before MiSTer main has created them no longer makes the service exit. It also recovers when another script replaces `/tmp/ACTIVEGAME` or `/tmp/CORENAME` instead of writing over them, which previously left tracking silent until a restart.
+
 ## Configuration
 
 PlayLog can be configured by creating a `playlog.ini` file in the `/media/fat/Scripts` folder where you put `playlog.sh`. For example:

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -97,6 +97,8 @@ Each settings page shows the file being edited. Save targets that loaded filenam
 
 Remote retains its first observed slot layout and refuses further access if it detects a change. **After adding, removing, or renaming alternate INIs, restart both MiSTer and Remote before editing.** MiSTer caches its mapping internally; Remote cannot reconstruct a different mapping cached before Remote started. Older firmware with different ordering is not verified. No INI files are renamed to force an order.
 
+The `announce_game_url` webhook is sent in the background. Earlier versions posted it inline while the tracker was locked, so an endpoint that had gone offline froze core and game tracking for the full 15-second timeout on every core change. Requests are queued; if the endpoint cannot keep up, events are dropped and logged rather than delaying tracking.
+
 ## Uninstall
 
 Remove Remote's Downloader subscription if configured, so updates do not reinstall it.

--- a/pkg/tracker/files.go
+++ b/pkg/tracker/files.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -103,35 +104,106 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 		}
 	}
 
-	go func() {
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return
-				}
-				if event.Op&fsnotify.Write == fsnotify.Write {
-					switch {
-					case event.Name == config.CurrentPathFile:
-						tr.trackMenu()
-					case event.Name == config.CoreNameFile:
-						tr.LoadCore()
-					case event.Name == config.ActiveGameFile:
-						tr.loadGame()
-					case strings.HasPrefix(event.Name, config.CoreConfigFolder):
-						if recentErr := loadRecent(event.Name); recentErr != nil {
-							tr.Logger.Error("error loading recent file: %s", recentErr)
-						}
-					}
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					return
-				}
-				tr.Logger.Error("error in watcher: %s", err)
+	watch := &fileWatch{
+		watcher: watcher,
+		logger:  tr.Logger,
+		files: map[string]func(){
+			config.CurrentPathFile: tr.trackMenu,
+			config.CoreNameFile:    tr.LoadCore,
+			config.ActiveGameFile:  tr.loadGame,
+		},
+		folder: config.CoreConfigFolder,
+		onFolderEvent: func(name string) {
+			if recentErr := loadRecent(name); recentErr != nil {
+				tr.Logger.Error("error loading recent file: %s", recentErr)
 			}
-		}
-	}()
+		},
+	}
+	go watch.run()
 
 	return watcher, nil
+}
+
+const (
+	rewatchAttempts = 5
+	rewatchDelay    = 200 * time.Millisecond
+)
+
+// fileWatch dispatches fsnotify events. It is separate from StartFileWatch so
+// tests can drive it against temporary paths.
+//
+//nolint:govet // Field order groups the watch targets with their handlers.
+type fileWatch struct {
+	watcher       *fsnotify.Watcher
+	logger        trackerLogger
+	files         map[string]func()
+	folder        string
+	onFolderEvent func(string)
+	// attempts and delay bound the re-watch retry; zero selects the defaults.
+	attempts int
+	delay    time.Duration
+}
+
+func (f *fileWatch) run() {
+	for {
+		select {
+		case event, ok := <-f.watcher.Events:
+			if !ok {
+				return
+			}
+			f.dispatch(event)
+		case err, ok := <-f.watcher.Errors:
+			if !ok {
+				return
+			}
+			f.logger.Error("error in watcher: %s", err)
+		}
+	}
+}
+
+func (f *fileWatch) dispatch(event fsnotify.Event) {
+	// Create matters as much as Write: MiSTer tooling and other scripts
+	// replace these files rather than truncating them, and the first content
+	// of a newly created file arrives as Create.
+	if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+		if handle, ok := f.files[event.Name]; ok {
+			handle()
+			return
+		}
+		if f.folder != "" && strings.HasPrefix(event.Name, f.folder) {
+			f.onFolderEvent(event.Name)
+		}
+		return
+	}
+	// inotify watches follow the inode, so a file that is removed and
+	// recreated leaves the watch on a dead one and the tracker goes silent
+	// until the service restarts. Re-add the path and re-read it.
+	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		if _, ok := f.files[event.Name]; ok {
+			go f.rewatch(event.Name)
+		}
+	}
+}
+
+func (f *fileWatch) rewatch(name string) {
+	attempts, delay := f.attempts, f.delay
+	if attempts <= 0 {
+		attempts = rewatchAttempts
+	}
+	if delay <= 0 {
+		delay = rewatchDelay
+	}
+	for attempt := range attempts {
+		if err := f.watcher.Add(name); err == nil {
+			// The replacement may already hold new content.
+			if handle, ok := f.files[name]; ok {
+				handle()
+			}
+			return
+		}
+		if attempt < attempts-1 {
+			time.Sleep(delay)
+		}
+	}
+	f.logger.Error("gave up re-watching %s after %d attempts", name, attempts)
 }

--- a/pkg/tracker/files_test.go
+++ b/pkg/tracker/files_test.go
@@ -1,0 +1,136 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type recordingLogger struct {
+	messages []string
+	mu       sync.Mutex
+}
+
+func (l *recordingLogger) record(format string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, format)
+}
+
+func (l *recordingLogger) Info(format string, v ...any)  { l.record(format, v...) }
+func (l *recordingLogger) Warn(format string, v ...any)  { l.record(format, v...) }
+func (l *recordingLogger) Error(format string, v ...any) { l.record(format, v...) }
+
+// waitFor polls until condition holds, so the tests do not depend on inotify
+// delivery timing.
+func waitFor(t *testing.T, what string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func newWatchFixture(t *testing.T) (*fileWatch, string, *int32Counter) {
+	t.Helper()
+	dir := t.TempDir()
+	tracked := filepath.Join(dir, "CORENAME")
+	if err := os.WriteFile(tracked, []byte("MENU"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+	if err := watcher.Add(tracked); err != nil {
+		t.Fatal(err)
+	}
+
+	hits := &int32Counter{}
+	watch := &fileWatch{
+		watcher:  watcher,
+		logger:   &recordingLogger{},
+		files:    map[string]func(){tracked: hits.inc},
+		attempts: 20,
+		delay:    10 * time.Millisecond,
+	}
+	go watch.run()
+	return watch, tracked, hits
+}
+
+type int32Counter struct {
+	count int
+	mu    sync.Mutex
+}
+
+func (c *int32Counter) inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.count++
+}
+
+func (c *int32Counter) value() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.count
+}
+
+func TestFileWatchReactsToWrites(t *testing.T) {
+	_, tracked, hits := newWatchFixture(t)
+
+	if err := os.WriteFile(tracked, []byte("NES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "a write to be handled", func() bool { return hits.value() > 0 })
+}
+
+func TestFileWatchSurvivesTheFileBeingReplaced(t *testing.T) {
+	_, tracked, hits := newWatchFixture(t)
+
+	// inotify watches follow the inode. Another tool replacing the file rather
+	// than truncating it used to leave the watch on a dead inode, and the
+	// tracker went silent until the service was restarted.
+	if err := os.Remove(tracked); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tracked, []byte("SNES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "the replaced file to be picked up", func() bool { return hits.value() > 0 })
+
+	before := hits.value()
+	if err := os.WriteFile(tracked, []byte("GBA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "a write after replacement to be handled", func() bool { return hits.value() > before })
+}


### PR DESCRIPTION
Three ways core and game tracking stopped working with nothing to show for it.

## The watcher only acted on `Write`

`pkg/tracker/files.go` filtered on `fsnotify.Write` alone. inotify watches follow the inode, so another tool (SAM, Zaparoo, a custom script) replacing `/tmp/ACTIVEGAME` or `/tmp/CORENAME` rather than writing over it left the watch on a dead inode. The tracker went permanently deaf, with no log line, until the service restarted.

Now `Create` is handled alongside `Write`, and `Remove`/`Rename` on a watched path re-adds the watch and re-reads the replacement. The dispatch loop moves into a `fileWatch` type so it can be driven against temporary paths in tests.

## PlayLog and LastPlayed did not use the retrying watcher

Both called `tracker.StartFileWatch`, which requires `/tmp/CORENAME` to already exist. Started from `user-startup.sh` before MiSTer main creates it, the daemon logged an error and `os.Exit(1)`d — play time was never recorded until the user ran the script by hand.

`pkg/tracker/retry.go` exists for exactly this case and only Remote was using it. Both now call `StartFileWatchWithRetry`.

## A dead webhook froze the tracker

`SendAnnounceGame` posted inline from `tracker.addEvent`, which runs with the tracker mutex held, using a 15-second HTTP timeout. An `announce_game_url` whose host went offline froze all core and game tracking for 15 seconds on every core change: `/api/games/playing` hung and websocket updates stalled.

Requests are now queued to a worker with a bounded buffer. A backlog is dropped and logged rather than growing behind a dead endpoint or delaying tracking.

## Tests

`pkg/tracker/files_test.go` covers a plain write, and the replacement case: remove the watched file, recreate it, and assert both that the replacement is picked up and that subsequent writes are still seen.

Checked against the old behaviour — with the re-watch removed, `TestFileWatchSurvivesTheFileBeingReplaced` times out waiting for the replaced file, which is the bug.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for playlog, lastplayed and remote, plus `go test -race` over `pkg/tracker` and `cmd/remote/...` for the new goroutine work.