### PR TITLE
fix(mister): stop rewriting the startup script shebang and allow an empty save

### DIFF
--- a/cmd/remote/gui.go
+++ b/cmd/remote/gui.go
@@ -37,7 +37,10 @@ import (
 func tryAddStartup() error {
 	var startup mister.Startup
 	if err := startup.Load(); err != nil {
+		// Continuing with a zero-value Startup would rewrite user-startup.sh
+		// from scratch and drop every other entry in it.
 		logger.Error("failed to load startup file: %s", err)
+		return fmt.Errorf("load startup configuration: %w", err)
 	}
 	if startup.Exists("mrext/" + appName) {
 		return nil

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -97,6 +97,8 @@ Each settings page shows the file being edited. Save targets that loaded filenam
 
 Remote retains its first observed slot layout and refuses further access if it detects a change. **After adding, removing, or renaming alternate INIs, restart both MiSTer and Remote before editing.** MiSTer caches its mapping internally; Remote cannot reconstruct a different mapping cached before Remote started. Older firmware with different ordering is not verified. No INI files are renamed to force an order.
 
+Adding or removing a startup entry preserves whatever `#!` line `user-startup.sh` already has, so a `#!/bin/bash` script is not rewritten to `#!/bin/sh`. Uninstalling when Remote is the only entry now succeeds; it previously reported "no startup entries to save" and left the entry in place, so the service returned on the next boot.
+
 ## Uninstall
 
 Remove Remote's Downloader subscription if configured, so updates do not reinstall it.

--- a/pkg/mister/startup.go
+++ b/pkg/mister/startup.go
@@ -20,7 +20,6 @@
 package mister
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -31,8 +30,27 @@ import (
 // TODO: delete entry from startup
 // TODO: enable/disable entry in startup
 
+// defaultShebang is used only when the script does not exist yet or has none.
+// It stays as it has always been; the fix here is to stop overwriting the one
+// a user already has, not to pick a different one for them.
+const defaultShebang = "#!/bin/sh"
+
+//nolint:govet // Entries stays first: it is the field callers construct.
 type Startup struct {
 	Entries []StartupEntry
+	// Path overrides config.StartupFile, so tests can work on a temp root.
+	Path string
+	// shebang is whatever the file already began with. MiSTer's own docs use
+	// #!/bin/bash and the generated entries use bash-only [[ ]] tests, so
+	// rewriting it to #!/bin/sh on every save could break a user's script.
+	shebang string
+}
+
+func (s *Startup) path() string {
+	if s.Path != "" {
+		return s.Path
+	}
+	return config.StartupFile
 }
 
 type StartupEntry struct {
@@ -44,7 +62,7 @@ type StartupEntry struct {
 func (s *Startup) Load() error {
 	var entries []StartupEntry
 
-	contents, err := os.ReadFile(config.StartupFile)
+	contents, err := os.ReadFile(s.path())
 	if os.IsNotExist(err) {
 		contents = []byte{}
 	} else if err != nil {
@@ -57,6 +75,7 @@ func (s *Startup) Load() error {
 	section := make([]string, 0)
 	for i, line := range lines {
 		if i == 0 && strings.HasPrefix(line, "#!") {
+			s.shebang = line
 			continue
 		}
 
@@ -103,13 +122,17 @@ func (s *Startup) Load() error {
 	return nil
 }
 
+// Save rewrites the startup script. An empty entry list is a valid state:
+// removing the last entry is what uninstalling the final mrext app does, and
+// refusing it left the entry in place while reporting a failure.
 func (s *Startup) Save() error {
-	if len(s.Entries) == 0 {
-		return errors.New("no startup entries to save")
+	shebang := s.shebang
+	if shebang == "" {
+		shebang = defaultShebang
 	}
 
 	var contents strings.Builder
-	_, _ = contents.WriteString("#!/bin/sh\n\n")
+	_, _ = fmt.Fprintf(&contents, "%s\n\n", shebang)
 	for i := range s.Entries {
 		entry := &s.Entries[i]
 		if entry.Name != "" {
@@ -122,7 +145,7 @@ func (s *Startup) Save() error {
 	}
 
 	// #nosec G306 -- MiSTer startup script must remain readable by system tooling.
-	if err := os.WriteFile(config.StartupFile, []byte(contents.String()), 0o644); err != nil {
+	if err := os.WriteFile(s.path(), []byte(contents.String()), 0o644); err != nil {
 		return fmt.Errorf("write startup script: %w", err)
 	}
 	return nil

--- a/pkg/mister/startup_test.go
+++ b/pkg/mister/startup_test.go
@@ -1,0 +1,119 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func startupFixture(t *testing.T, contents string) (startup *Startup, path string) {
+	t.Helper()
+	path = filepath.Join(t.TempDir(), "user-startup.sh")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	startup = &Startup{Path: path}
+	if err := startup.Load(); err != nil {
+		t.Fatal(err)
+	}
+	return startup, path
+}
+
+func TestSaveKeepsTheExistingShebang(t *testing.T) {
+	// MiSTer's own docs use #!/bin/bash, and the entries written here use
+	// bash-only [[ ]] tests. Rewriting the line to #!/bin/sh whenever any
+	// mrext app touched the file could stop a user's script working.
+	startup, path := startupFixture(t, "#!/bin/bash\n\n# existing\n/media/fat/Scripts/other.sh\n")
+
+	if err := startup.AddService("mrext/remote"); err != nil {
+		t.Fatal(err)
+	}
+	if err := startup.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := readStartup(t, path)
+	if !strings.HasPrefix(saved, "#!/bin/bash\n") {
+		t.Errorf("shebang was rewritten:\n%s", saved)
+	}
+	if !strings.Contains(saved, "/media/fat/Scripts/other.sh") {
+		t.Errorf("an unrelated entry was lost:\n%s", saved)
+	}
+}
+
+func TestSaveWritesTheDefaultShebangForANewFile(t *testing.T) {
+	startup, path := startupFixture(t, "")
+
+	if err := startup.AddService("mrext/remote"); err != nil {
+		t.Fatal(err)
+	}
+	if err := startup.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	if saved := readStartup(t, path); !strings.HasPrefix(saved, defaultShebang+"\n") {
+		t.Errorf("new file shebang = %q, want %q", saved, defaultShebang)
+	}
+}
+
+func TestRemovingTheLastEntrySaves(t *testing.T) {
+	// Uninstalling the only mrext app leaves no entries. Refusing to save left
+	// the entry in the file while reporting a failure, so the service came
+	// back on the next boot.
+	startup, path := startupFixture(t, "#!/bin/sh\n\n# mrext/remote\n/media/fat/Scripts/remote.sh -service $1\n")
+
+	if !startup.Exists("mrext/remote") {
+		t.Fatal("fixture entry was not parsed")
+	}
+	if err := startup.Remove("mrext/remote"); err != nil {
+		t.Fatal(err)
+	}
+	if err := startup.Save(); err != nil {
+		t.Fatalf("removing the last entry failed: %v", err)
+	}
+
+	saved := readStartup(t, path)
+	if strings.Contains(saved, "remote.sh") {
+		t.Errorf("entry survived removal:\n%s", saved)
+	}
+
+	reloaded := &Startup{Path: path}
+	if err := reloaded.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.Entries) != 0 {
+		t.Errorf("reloaded %d entries, want none", len(reloaded.Entries))
+	}
+}
+
+func readStartup(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
Three problems in `user-startup.sh` handling, all reachable from ordinary use.

## The shebang was silently rewritten

`Load()` skipped whatever `#!` line the file started with and `Save()` wrote `#!/bin/sh` unconditionally. MiSTer's own docs use `#!/bin/bash`, and the entries written here use bash-only `[[ ]]` tests — so the first time *any* mrext app added or removed an entry, a user's `#!/bin/bash` script was downgraded.

The shebang the file already has is now preserved. The default is unchanged (`#!/bin/sh`) and applies only when creating the file; the fix is to stop overwriting the one a user has, not to pick a different one for them.

The `[[ ]]` syntax in generated entries is deliberately left alone — startup hook lines are a contract with installed systems.

## Uninstalling the last entry failed

`Save()` returned an error for an empty entry list. Removing the last entry is exactly what uninstalling the final mrext app does, so `remote.sh -uninstall` on a system where Remote was the only entry printed `no startup entries to save`, exited 1, and left the entry in place — the service came back on the next boot.

An empty list is a valid state and now saves.

## A read failure could wipe the file

`tryAddStartup` in `cmd/remote/gui.go` logged a failed `Load()` and carried on with a zero-value `Startup`. `Exists()` then returned false, the entry was appended, and `Save()` wrote a file containing only the shebang and Remote's entry — dropping every other startup entry the user had. It now bails out, matching `tryNonInteractiveAddToStartup`, which already did.

## Tests

`Startup` gains a `Path` override so this is testable against a temp root. `pkg/mister/startup_test.go` covers shebang preservation alongside an unrelated entry, the default for a new file, and removing the last entry then reloading to confirm it is gone.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for remote, playlog and lastplayed.