### PR TITLE
fix(samindex,utils): stop destroying files when a write fails

### DIFF
--- a/cmd/samindex/main.go
+++ b/cmd/samindex/main.go
@@ -90,23 +90,39 @@ func gamelistFilename(systemID string) string {
 }
 
 // Generate a gamelist file for a system with given results.
-func writeGamelist(gamelistDir, systemID string, files []string) {
+//
+// Every write, sync and close is checked. Discarding them meant a full /tmp,
+// which is easy to hit on MiSTer's small tmpfs with a large library, produced
+// a truncated gamelist that was copied over the good one and reported as
+// success, leaving SAM with no games for that system. cmd/contool has always
+// done this correctly; only this copy did not.
+func writeGamelist(gamelistDir, systemID string, files []string) error {
 	gamelistPath := filepath.Join(gamelistDir, gamelistFilename(systemID))
 	tmpPath, err := os.CreateTemp("", "gamelist-*.txt")
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("create temporary game list: %w", err)
 	}
+	defer func() {
+		_ = tmpPath.Close()
+		// Harmless once MoveFile has taken it; matters when we return early.
+		_ = os.Remove(tmpPath.Name())
+	}()
 
 	for _, file := range files {
-		_, _ = tmpPath.WriteString(file + "\n")
+		if _, writeErr := tmpPath.WriteString(file + "\n"); writeErr != nil {
+			return fmt.Errorf("write temporary game list: %w", writeErr)
+		}
 	}
-	_ = tmpPath.Sync()
-	_ = tmpPath.Close()
-
-	err = utils.MoveFile(tmpPath.Name(), gamelistPath)
-	if err != nil {
-		panic(err)
+	if syncErr := tmpPath.Sync(); syncErr != nil {
+		return fmt.Errorf("sync temporary game list: %w", syncErr)
 	}
+	if closeErr := tmpPath.Close(); closeErr != nil {
+		return fmt.Errorf("close temporary game list: %w", closeErr)
+	}
+	if moveErr := utils.MoveFile(tmpPath.Name(), gamelistPath); moveErr != nil {
+		return fmt.Errorf("install game list: %w", moveErr)
+	}
+	return nil
 }
 
 // Generate gamelists for all systems. Main workflow of app.
@@ -176,8 +192,11 @@ func createGamelists(
 		}
 
 		if len(systemFiles) > 0 {
+			if err := writeGamelist(gamelistDir, systemID, systemFiles); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "error writing game list for %s: %s\n", systemID, err)
+				continue
+			}
 			totalGames += len(systemFiles)
-			writeGamelist(gamelistDir, systemID, systemFiles)
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -64,6 +64,10 @@ func ListZip(path string) ([]string, error) {
 	return files, nil
 }
 
+// CopyFile copies a file, leaving the destination untouched if anything goes
+// wrong. It writes beside the destination and renames into place: os.Create
+// truncates first, so a copy that ran out of space part way through used to
+// destroy the previous contents and leave a partial file behind.
 func CopyFile(sourcePath, destPath string) error {
 	// #nosec G304 -- both paths are explicit inputs to this filesystem utility.
 	inputFile, err := os.Open(sourcePath)
@@ -72,12 +76,18 @@ func CopyFile(sourcePath, destPath string) error {
 	}
 	defer func() { _ = inputFile.Close() }()
 
-	// #nosec G304 -- both paths are explicit inputs to this filesystem utility.
-	outputFile, err := os.Create(destPath)
+	outputFile, err := os.CreateTemp(filepath.Dir(destPath), "."+filepath.Base(destPath)+"-*")
 	if err != nil {
 		return fmt.Errorf("create destination file: %w", err)
 	}
-	defer func() { _ = outputFile.Close() }()
+	temporary := outputFile.Name()
+	published := false
+	defer func() {
+		_ = outputFile.Close()
+		if !published {
+			_ = os.Remove(temporary)
+		}
+	}()
 
 	if _, err := io.Copy(outputFile, inputFile); err != nil {
 		return fmt.Errorf("copy file data: %w", err)
@@ -88,6 +98,16 @@ func CopyFile(sourcePath, destPath string) error {
 	if err := outputFile.Close(); err != nil {
 		return fmt.Errorf("close destination file: %w", err)
 	}
+	// CreateTemp makes the file 0600 and copies here are read by other MiSTer
+	// tooling, so widen it. Best effort on purpose: /media/fat is exFAT, where
+	// the mode comes from the mount and chmod reports EPERM. Failing here
+	// would break every copy on the device for a mode the filesystem ignores.
+	// #nosec G302 -- game lists and menu assets must stay world-readable.
+	_ = os.Chmod(temporary, 0o644)
+	if err := os.Rename(temporary, destPath); err != nil {
+		return fmt.Errorf("publish destination file: %w", err)
+	}
+	published = true
 
 	return nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -17,12 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with mrext. If not, see <http://www.gnu.org/licenses/>.
 
+//nolint:gosec // Tests only operate on temporary fixture paths.
 package utils
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -195,5 +198,65 @@ func TestMapKeys(t *testing.T) {
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("MapKeys(%v) = %v, want %v", tt.m, got, tt.want)
 		}
+	}
+}
+
+func TestCopyFileLeavesTheDestinationIntactOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "nes_gamelist.txt")
+	original := "the good game list\n"
+	if err := os.WriteFile(dest, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A source that cannot be read stands in for a copy that fails part way
+	// through. os.Create truncated the destination before the copy could fail,
+	// so a full /tmp used to leave a zero-length gamelist behind and report
+	// success.
+	unreadable := filepath.Join(dir, "source")
+	if err := os.Mkdir(unreadable, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(unreadable, dest); err == nil {
+		t.Fatal("copying a directory should fail")
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("destination was destroyed: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("destination = %q, want the original %q", got, original)
+	}
+}
+
+func TestCopyFileLeavesNoTemporaryFilesBehind(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.txt")
+	if err := os.WriteFile(source, []byte("contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, "dest.txt")
+
+	if err := CopyFile(source, dest); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyFile(filepath.Join(dir, "missing.txt"), dest); err == nil {
+		t.Fatal("copying a missing source should fail")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			t.Errorf("staged file left behind: %s", entry.Name())
+		}
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || string(got) != "contents" {
+		t.Fatalf("destination = %q, %v", got, err)
 	}
 }


### PR DESCRIPTION
## `samindex` discarded every write error

`writeGamelist` (`cmd/samindex/main.go`) ignored the result of every `WriteString`, the `Sync` and the `Close`, then copied the file over the good gamelist and reported success. Filling `/tmp` is easy on MiSTer's small tmpfs with a large library, and the result was a truncated gamelist — SAM with no games for that system, and nothing to say so.

`cmd/contool/main.go:79-102` is the same function written correctly with all errors checked, so this was an oversight rather than a decision. It also `panic`ed on failure, giving the user a Go stack trace, and left its temp file behind.

Now every error is checked and returned, the caller reports the system that failed and carries on with the rest, and the staged file is cleaned up on every path.

## `CopyFile` truncated the destination before it could fail

`os.Create` truncates. Any failure during `io.Copy` left the destination zero-length or partial, with the previous contents already gone — which is what turned the above into data loss rather than a no-op.

It now writes beside the destination and renames into place, removing the staged file on every failure path. `MoveFile` gets this for free, and the rename stays within one filesystem because the staging file is created in the destination's directory.

The `chmod` after staging is deliberately best effort: `/media/fat` is exFAT, where the mode comes from the mount and `chmod` reports `EPERM`. Failing there would break every copy on the device for a mode the filesystem ignores.

## Tests

- `TestCopyFileLeavesTheDestinationIntactOnFailure` — a failed copy leaves the original contents in place. Against the old implementation this fails with `destination = ""`, which is the bug.
- `TestCopyFileLeavesNoTemporaryFilesBehind` — no staged files survive a success or a failure.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister launchsync`.