### PR TITLE
fix(mister,remote): write boot-critical files without destroying them

### DIFF
--- a/cmd/remote/settings/ini.go
+++ b/cmd/remote/settings/ini.go
@@ -68,33 +68,48 @@ func HandleSaveIni(logger *service.Logger, reqID int) http.HandlerFunc {
 			return
 		}
 
+		// Report what did not apply. Logging and returning 200 told the user
+		// their hostname or MAC had been saved when it had not.
+		var failed []string
 		for key, value := range args {
 			// custom internal setting
 			if strings.HasPrefix(key, "__") {
 				switch key {
 				case hostnameKey:
-					err = mister.UpdateHostname(value, false)
-					if err != nil {
-						logger.Error("set hostname: %s", err)
+					if hostErr := mister.UpdateHostname(value, false); hostErr != nil {
+						logger.Error("set hostname: %s", hostErr)
+						failed = append(failed, "hostname")
 					}
 				case macAddressKey:
-					err = mister.UpdateConfiguredMacAddress(value)
-					if err != nil {
-						logger.Error("set mac address: %s", err)
+					if macErr := mister.UpdateConfiguredMacAddress(value); macErr != nil {
+						logger.Error("set mac address: %s", macErr)
+						failed = append(failed, "MAC address")
 					}
 				}
+				// Internal keys are not MiSTer INI settings; SetKey no-ops on
+				// them and only produced a misleading log line.
+				continue
 			}
 
-			setErr := mi.SetKey(key, value)
-			if setErr != nil {
+			if setErr := mi.SetKey(key, value); setErr != nil {
 				logger.Error("update mister.ini: %s", setErr)
+				failed = append(failed, key)
+				continue
 			}
 			logger.Info("update mister.ini: %s=%s", key, value)
 		}
 
+		// Persist whatever did apply before reporting, so a failure on one
+		// setting does not silently discard the others.
 		if err = saveAndRelaunch(&mi, mister.RelaunchIfInMenu); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			logger.Error("save settings: %s", err)
+			return
+		}
+
+		if len(failed) > 0 {
+			http.Error(w, "could not update: "+strings.Join(failed, ", "), http.StatusInternalServerError)
+			logger.Error("settings partially failed: %s", strings.Join(failed, ", "))
 			return
 		}
 	}

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -99,6 +99,10 @@ Remote retains its first observed slot layout and refuses further access if it d
 
 The `announce_game_url` webhook is sent in the background. Earlier versions posted it inline while the tracker was locked, so an endpoint that had gone offline froze core and game tracking for the full 15-second timeout on every core change. Requests are queued; if the endpoint cannot keep up, events are dropped and logged rather than delaying tracking.
 
+`MiSTer.ini` and `u-boot.txt` are written by staging the replacement beside the original and renaming over it, so losing power mid-save leaves the previous file intact rather than a truncated one. Each keeps a single `.backup` of its contents from before mrext first changed it; that backup is no longer overwritten on every save.
+
+Changing the MAC address preserves the rest of `u-boot.txt` exactly, including comments and line order, and the value must be a valid MAC. Saving settings now reports which ones could not be applied instead of returning success regardless.
+
 ## Uninstall
 
 Remove Remote's Downloader subscription if configured, so updates do not reinstall it.

--- a/pkg/config/ini.go
+++ b/pkg/config/ini.go
@@ -154,9 +154,10 @@ func WriteINIAtomically(path string, file *ini.File) error {
 	if err := temporary.Sync(); err != nil {
 		return fmt.Errorf("sync temporary configuration: %w", err)
 	}
-	if err := temporary.Chmod(0o644); err != nil {
-		return fmt.Errorf("set configuration permissions: %w", err)
-	}
+	// Best effort: /media/fat is exFAT, where the mode comes from the mount
+	// and chmod reports EPERM. Failing here would make every configuration
+	// save on the device fail over a mode the filesystem does not store.
+	_ = temporary.Chmod(0o644)
 	if err := temporary.Close(); err != nil {
 		return fmt.Errorf("close temporary configuration: %w", err)
 	}

--- a/pkg/mister/ini.go
+++ b/pkg/mister/ini.go
@@ -241,6 +241,16 @@ func (mi *MisterIni) Load() error {
 	return nil
 }
 
+// Save replaces the MiSTer INI, keeping one backup of the file as it was
+// before mrext first changed it.
+//
+// SaveTo truncates in place. This is the file that decides whether the board
+// produces a picture, and people turn a MiSTer off by pulling the power, so a
+// half-written one is a device that boots to a display it cannot show. Stage
+// the replacement and rename over it instead.
+//
+// The backup is written only when there is not one already: overwriting it on
+// every save meant two changes in a row lost the original.
 func (mi *MisterIni) Save() error {
 	if mi.File == nil {
 		return errors.New("ini file is not loaded")
@@ -249,23 +259,21 @@ func (mi *MisterIni) Save() error {
 	backupPath := mi.Path + ".backup"
 
 	backupData, err := os.ReadFile(mi.Path)
-	if os.IsNotExist(err) {
-		// skip backup if file doesn't exist
-		if saveErr := mi.File.SaveTo(mi.Path); saveErr != nil {
-			return fmt.Errorf("save MiSTer INI: %w", saveErr)
-		}
-		return nil
-	}
-	if err != nil {
+	switch {
+	case os.IsNotExist(err):
+		// Nothing to back up yet.
+	case err != nil:
 		return fmt.Errorf("read MiSTer INI for backup: %w", err)
+	default:
+		if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+			// #nosec G306,G703 -- discovered MiSTer INI backup must remain world-readable.
+			if writeErr := os.WriteFile(backupPath, backupData, 0o644); writeErr != nil {
+				return fmt.Errorf("write MiSTer INI backup: %w", writeErr)
+			}
+		}
 	}
 
-	// #nosec G306,G703 -- discovered MiSTer INI backup must remain world-readable.
-	if err := os.WriteFile(backupPath, backupData, 0o644); err != nil {
-		return fmt.Errorf("write MiSTer INI backup: %w", err)
-	}
-
-	if err := mi.File.SaveTo(mi.Path); err != nil {
+	if err := config.WriteINIAtomically(mi.Path, mi.File); err != nil {
 		return fmt.Errorf("save MiSTer INI: %w", err)
 	}
 	return nil

--- a/pkg/mister/uboot.go
+++ b/pkg/mister/uboot.go
@@ -21,7 +21,10 @@ package mister
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -29,10 +32,15 @@ import (
 
 const UBootMACParam = "ethaddr"
 
+// ubootPath is a test seam over config.UBootConfigFile so these functions can
+// be exercised without touching the real boot configuration.
+var ubootPath = config.UBootConfigFile
+
 func ReadUBootParams() (map[string]string, error) {
 	params := make(map[string]string)
 
-	data, err := os.ReadFile(config.UBootConfigFile)
+	// #nosec G304 -- ubootPath is a fixed configuration path, overridden only by tests.
+	data, err := os.ReadFile(ubootPath)
 	if os.IsNotExist(err) {
 		return params, nil
 	}
@@ -58,28 +66,113 @@ func ReadUBootParams() (map[string]string, error) {
 	return params, nil
 }
 
+// WriteUBootParams replaces the U-Boot configuration with the given
+// parameters. Keys are written in sorted order so repeated saves produce the
+// same file; map iteration order used to reshuffle the whole thing each time.
+//
+// Prefer UpdateUBootParam, which keeps comments and the original ordering.
 func WriteUBootParams(params map[string]string) error {
-	pairs := make([]string, 0, len(params))
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 
-	for key, value := range params {
-		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", key, params[key]))
 	}
 
-	content := strings.Join(pairs, "\n") + "\n"
+	return writeUBoot(strings.Join(pairs, "\n") + "\n")
+}
 
-	if _, err := os.Stat(config.UBootConfigFile); err == nil {
-		err = os.Rename(config.UBootConfigFile, config.UBootConfigFile+".backup")
-		if err != nil {
-			return fmt.Errorf("back up U-Boot configuration: %w", err)
+// UpdateUBootParam sets one parameter, leaving every other line of the file
+// exactly as it was. Rewriting from a parsed map dropped comments and every
+// line without an "=", which on the file that decides how the board boots is
+// not an acceptable side effect of changing a MAC address.
+func UpdateUBootParam(key, value string) error {
+	// #nosec G304 -- ubootPath is a fixed configuration path, overridden only by tests.
+	data, err := os.ReadFile(ubootPath)
+	if os.IsNotExist(err) {
+		return writeUBoot(fmt.Sprintf("%s=%s\n", key, value))
+	}
+	if err != nil {
+		return fmt.Errorf("read U-Boot configuration: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	trailingNewline := len(lines) > 0 && lines[len(lines)-1] == ""
+	if trailingNewline {
+		lines = lines[:len(lines)-1]
+	}
+
+	replaced := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if trimmed == "" || !strings.Contains(trimmed, "=") {
+			continue
+		}
+		if strings.TrimSpace(strings.SplitN(trimmed, "=", 2)[0]) != key {
+			continue
+		}
+		lines[i] = fmt.Sprintf("%s=%s", key, value)
+		replaced = true
+		break
+	}
+	if !replaced {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return writeUBoot(strings.Join(lines, "\n") + "\n")
+}
+
+// writeUBoot stages the replacement beside the original and renames over it.
+// The previous version renamed the original away first, so a write that then
+// failed left the board with no boot configuration at all.
+func writeUBoot(content string) error {
+	path := ubootPath
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create staged U-Boot configuration: %w", err)
+	}
+	staged := temporary.Name()
+	published := false
+	defer func() {
+		_ = temporary.Close()
+		if !published {
+			_ = os.Remove(staged)
+		}
+	}()
+
+	if _, err := temporary.WriteString(content); err != nil {
+		return fmt.Errorf("write staged U-Boot configuration: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync staged U-Boot configuration: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close staged U-Boot configuration: %w", err)
+	}
+	// Best effort: the SD card is exFAT, where the mode comes from the mount
+	// and chmod reports EPERM.
+	// #nosec G302 -- U-Boot configuration must stay readable by MiSTer services.
+	_ = os.Chmod(staged, 0o644)
+
+	// Keep one backup of the configuration as it was before mrext first
+	// touched it. Overwriting it on every save loses the original.
+	if _, err := os.Stat(path); err == nil {
+		if _, backupErr := os.Stat(path + ".backup"); os.IsNotExist(backupErr) {
+			// #nosec G304,G306,G703 -- path is the fixed U-Boot configuration path.
+			if data, readErr := os.ReadFile(path); readErr == nil {
+				_ = os.WriteFile(path+".backup", data, 0o644)
+			}
 		}
 	}
 
-	// #nosec G306 -- U-Boot configuration must remain readable by MiSTer services.
-	err := os.WriteFile(config.UBootConfigFile, []byte(content), 0o644)
-	if err != nil {
-		return fmt.Errorf("write U-Boot configuration: %w", err)
+	if err := os.Rename(staged, path); err != nil {
+		return fmt.Errorf("replace U-Boot configuration: %w", err)
 	}
-
+	published = true
 	return nil
 }
 
@@ -100,12 +193,13 @@ func GetConfiguredMacAddress() (string, error) {
 // UpdateConfiguredMacAddress updates the ethernet MAC address configured in the u-boot.txt file. Setting a new one if
 // it doesn't exist, or updating the existing one. Any existing u-boot.txt arguments are preserved.
 func UpdateConfiguredMacAddress(newMacAddress string) error {
-	params, err := ReadUBootParams()
-	if err != nil {
-		return err
+	// The value arrives from an unauthenticated HTTP request and is written
+	// straight into the file U-Boot reads. Without this, a value containing a
+	// newline injected arbitrary boot parameters.
+	address := strings.TrimSpace(newMacAddress)
+	if _, err := net.ParseMAC(address); err != nil {
+		return fmt.Errorf("invalid MAC address %q: %w", newMacAddress, err)
 	}
 
-	params[UBootMACParam] = newMacAddress
-
-	return WriteUBootParams(params)
+	return UpdateUBootParam(UBootMACParam, address)
 }

--- a/pkg/mister/uboot_test.go
+++ b/pkg/mister/uboot_test.go
@@ -1,0 +1,109 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateConfiguredMacAddressRejectsInjection(t *testing.T) {
+	// The value arrives from an unauthenticated HTTP request and is written
+	// into the file U-Boot reads, so a newline used to append arbitrary boot
+	// parameters.
+	rejected := []string{
+		"02:00:00:00:00:01\nbootargs=init=/bin/sh",
+		"not a mac",
+		"",
+		"02:00:00:00:00",
+		"02-00-00-00-00-01-extra",
+	}
+	for _, value := range rejected {
+		if err := UpdateConfiguredMacAddress(value); err == nil {
+			t.Errorf("accepted %q", value)
+		}
+	}
+}
+
+func TestUpdateUBootParamKeepsCommentsAndOrder(t *testing.T) {
+	original := "# board settings\nbootargs=console=ttyS0\nethaddr=02:00:00:00:00:01\n" +
+		"; keep me\nvideo=1280x720\n"
+	path := filepath.Join(t.TempDir(), "u-boot.txt")
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := ubootPath
+	ubootPath = path
+	t.Cleanup(func() { ubootPath = previous })
+
+	if err := UpdateUBootParam("ethaddr", "02:00:00:00:00:02"); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := readFileString(t, path)
+	want := "# board settings\nbootargs=console=ttyS0\nethaddr=02:00:00:00:00:02\n" +
+		"; keep me\nvideo=1280x720\n"
+	if saved != want {
+		t.Fatalf("saved:\n%q\nwant:\n%q", saved, want)
+	}
+
+	// The original is kept once, and not overwritten by later saves.
+	backup := readFileString(t, path+".backup")
+	if backup != original {
+		t.Fatalf("backup = %q, want the original", backup)
+	}
+	if err := UpdateUBootParam("ethaddr", "02:00:00:00:00:03"); err != nil {
+		t.Fatal(err)
+	}
+	if again := readFileString(t, path+".backup"); again != original {
+		t.Fatalf("a second save replaced the backup: %q", again)
+	}
+}
+
+func TestUpdateUBootParamAppendsAMissingKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "u-boot.txt")
+	if err := os.WriteFile(path, []byte("bootargs=quiet\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previous := ubootPath
+	ubootPath = path
+	t.Cleanup(func() { ubootPath = previous })
+
+	if err := UpdateUBootParam("ethaddr", "02:00:00:00:00:01"); err != nil {
+		t.Fatal(err)
+	}
+	saved := readFileString(t, path)
+	if !strings.HasPrefix(saved, "bootargs=quiet\n") || !strings.Contains(saved, "ethaddr=02:00:00:00:00:01") {
+		t.Fatalf("saved = %q", saved)
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
`MiSTer.ini` and `u-boot.txt` decide whether the board boots and produces a picture. Both were written in ways that could leave them unusable, and people turn a MiSTer off by pulling the power.

## `MiSTer.ini`

`MisterIni.Save` used `SaveTo`, which truncates in place — a power cut mid-save leaves a truncated INI and a board that boots to a display it cannot show. It now goes through `config.WriteINIAtomically`, which already existed and was not being used here.

Its `.backup` was also rewritten on every save, so two changes in a row lost the original. The backup is now written only when there is not one already, so it preserves the file as it was before mrext first touched it.

## `u-boot.txt`

`WriteUBootParams` renamed the original away *before* writing the replacement. A failure after that point left the board with no boot configuration at all. It also rebuilt the file from a `map[string]string`, which dropped every comment and every line without an `=`, and emitted keys in map iteration order — so a hand-tuned file was reshuffled on each save.

Now staged and renamed, keys sorted for a stable file, and a new `UpdateUBootParam` edits a single line and leaves everything else byte-identical. That is what `UpdateConfiguredMacAddress` uses.

## MAC address injection

The value reached `u-boot.txt` unvalidated from an unauthenticated HTTP request, so one containing a newline appended arbitrary boot parameters. Validated with `net.ParseMAC`.

## Settings reported success when they failed

`cmd/remote/settings/ini.go` logged errors from the hostname, MAC and INI updates and returned `200` regardless — the UI said "saved" when the hostname had not changed. It now collects what failed, saves what did apply, then reports. Internal `__` keys no longer fall through to `SetKey`, which no-ops on them and only produced a misleading log line.

## One change beyond the audit

The `chmod` in `WriteINIAtomically` was a hard failure. `/media/fat` is exFAT, where the mode comes from the mount and `chmod` reports `EPERM` — that would have made **every** config save on a real device fail, over a mode the filesystem does not store. It is now best effort, matching the same call in `CopyFile`.

I have not verified this on hardware; it is a latent risk either way and best effort is the safe side.

## Tests

`pkg/mister/uboot_test.go` covers MAC injection and malformed values, comment and line-order preservation through an edit, the backup surviving a second save, and appending a key that is not present. A `ubootPath` seam keeps it off the real boot configuration.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister remote`.