### PR TITLE
fix(service): survive a stale PID, a wedged daemon and a silent failure

### DIFF
--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -106,6 +106,8 @@ In your `MiSTer.ini` file, look for the line starting with `bootcore=` and chang
 
 If you configured a custom name for the shortcut, use that instead of `Last Played.mgl`.
 
+`-service start`, `stop` and `restart` print why they failed on the console as well as to `/tmp/lastplayed.log`; they previously exited 1 with no output at all. `restart` no longer waits forever for a wedged daemon: after 20 seconds it escalates to `SIGKILL` and starts the new one.
+
 ## Uninstall
 
 Remove LastPlayed's Downloader subscription if configured, so updates do not reinstall it.

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -90,6 +90,8 @@ When the hook's condition is met, PlayLog will run the given executable with eit
 
 Be aware that stop hooks will be unreliable when an end user shuts down their MiSTer via power switch.
 
+`-service start`, `stop` and `restart` print why they failed on the console as well as to `/tmp/playlog.log`; they previously exited 1 with no output at all. `restart` no longer waits forever for a wedged daemon: after 20 seconds it escalates to `SIGKILL` and starts the new one.
+
 ## Uninstall
 
 Remove PlayLog's Downloader subscription if configured, so updates do not reinstall it.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -101,6 +101,8 @@ The `announce_game_url` webhook is sent in the background. Earlier versions post
 
 Adding or removing a startup entry preserves whatever `#!` line `user-startup.sh` already has, so a `#!/bin/bash` script is not rewritten to `#!/bin/sh`. Uninstalling when Remote is the only entry now succeeds; it previously reported "no startup entries to save" and left the entry in place, so the service returned on the next boot.
 
+`-service start`, `stop` and `restart` print why they failed on the console as well as to `/tmp/remote.log`; they previously exited 1 with no output at all. `restart` no longer waits forever for a wedged daemon: after 20 seconds it escalates to `SIGKILL` and starts the new one.
+
 ## Uninstall
 
 Remove Remote's Downloader subscription if configured, so updates do not reinstall it.

--- a/pkg/service/identity_test.go
+++ b/pkg/service/identity_test.go
@@ -25,8 +25,10 @@ package service
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDaemonIdentityRejectsReusedPID(t *testing.T) {
@@ -90,5 +92,53 @@ func TestStopReportsNotRunningWithoutPIDFile(t *testing.T) {
 	err := svc.Stop()
 	if err == nil || !strings.Contains(err.Error(), "service not running") {
 		t.Fatalf("expected not-running error, got %v", err)
+	}
+}
+
+func TestKillIgnoresAProcessThatIsNotItsDaemon(t *testing.T) {
+	// Escalating to SIGKILL must be as careful as Stop is about PID reuse:
+	// the recorded PID may since belong to something else entirely.
+	svc := &Service{
+		Name:   "mrext-kill-" + filepath.Base(t.TempDir()),
+		Logger: NewLogger("mrext-kill-test"),
+	}
+
+	if err := svc.kill(); err != nil {
+		t.Fatalf("kill without a PID file should be a no-op, got %v", err)
+	}
+
+	// This test's own PID is live but is not the service daemon.
+	if err := os.WriteFile(svc.pidFilePath(), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(svc.pidFilePath()) })
+
+	if err := svc.kill(); err != nil {
+		t.Fatalf("kill on a foreign PID should be a no-op, got %v", err)
+	}
+	// Still here, so nothing signalled us.
+}
+
+func TestRestartWaitIsBounded(t *testing.T) {
+	// The wait used to be an unbounded "for s.Running() { sleep }".
+	if stopTimeout <= 0 {
+		t.Fatal("stopTimeout must bound the wait")
+	}
+	previous := stopTimeout
+	stopTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { stopTimeout = previous })
+
+	// Not running, so Restart goes straight to Start. Start fails here because
+	// the test binary is not a service; the point is that it returns at all.
+	svc := &Service{
+		Name:   "mrext-restart-" + filepath.Base(t.TempDir()),
+		Logger: NewLogger("mrext-restart-test"),
+	}
+	done := make(chan error, 1)
+	go func() { done <- svc.Restart() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Restart did not return")
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -238,13 +238,25 @@ func (s *Service) Start() error {
 	}
 	defer func() { _ = binFile.Close() }()
 
+	// Write the copy beside its final name and rename it into place. Opening
+	// the destination with O_TRUNC fails with ETXTBSY when a daemon is still
+	// running from it, which happens whenever the PID file went missing while
+	// the process lived, and reported "text file busy" rather than anything
+	// about the real cause. pkg/bgm/daemon.go already does it this way.
 	tempPath := filepath.Join(config.TempFolder, filepath.Base(binPath))
-	// #nosec G302,G304,G703 -- copied service binary must be executable at its controlled temp path.
-	tempFile, err := os.OpenFile(tempPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
+	// #nosec G304,G703 -- staged beside the controlled temp path above.
+	tempFile, err := os.CreateTemp(config.TempFolder, "."+filepath.Base(binPath)+"-*")
 	if err != nil {
 		return fmt.Errorf("error creating temp binary: %w", err)
 	}
-	defer func() { _ = tempFile.Close() }()
+	stagedPath := tempFile.Name()
+	published := false
+	defer func() {
+		_ = tempFile.Close()
+		if !published {
+			_ = os.Remove(stagedPath)
+		}
+	}()
 
 	_, err = io.Copy(tempFile, binFile)
 	if err != nil {
@@ -257,6 +269,15 @@ func (s *Service) Start() error {
 	if closeErr := binFile.Close(); closeErr != nil {
 		return fmt.Errorf("close source binary: %w", closeErr)
 	}
+	// #nosec G302 -- the copied service binary must be executable.
+	if chmodErr := os.Chmod(stagedPath, 0o755); chmodErr != nil {
+		return fmt.Errorf("make temporary binary executable: %w", chmodErr)
+	}
+	// #nosec G703 -- destination is the controlled temp path built above.
+	if renameErr := os.Rename(stagedPath, tempPath); renameErr != nil {
+		return fmt.Errorf("publish temporary binary: %w", renameErr)
+	}
+	published = true
 
 	// #nosec G204,G702 -- executable is controlled service copy created above.
 	cmd := exec.CommandContext(context.Background(), tempPath, "-service", "exec", "&")
@@ -310,24 +331,72 @@ func (s *Service) Stop() error {
 	return nil
 }
 
+// stopTimeout bounds how long Restart waits for the previous daemon to exit.
+// A variable so tests need not wait it out.
+var stopTimeout = 20 * time.Second
+
+// Restart stops the running service and starts it again.
+//
+// The wait used to be an unbounded "for s.Running() { sleep }", so a daemon
+// wedged in its own shutdown, such as a blocked listener or file watcher
+// close, meant restart never returned and never timed out. Give up waiting
+// politely after stopTimeout and escalate to SIGKILL.
 func (s *Service) Restart() error {
 	if s.Running() {
-		err := s.Stop()
-		if err != nil {
+		if err := s.Stop(); err != nil {
 			return err
 		}
 	}
 
+	deadline := time.Now().Add(stopTimeout)
 	for s.Running() {
-		time.Sleep(1 * time.Second)
+		if time.Now().After(deadline) {
+			if err := s.kill(); err != nil {
+				return err
+			}
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
 
-	err := s.Start()
+	return s.Start()
+}
+
+// kill sends SIGKILL to a daemon that did not honour SIGTERM, then clears the
+// PID file so the restart is not blocked by the corpse.
+func (s *Service) kill() error {
+	pid, err := s.Pid()
 	if err != nil {
-		return err
+		return fmt.Errorf("read service PID: %w", err)
 	}
-
+	if pid == 0 {
+		return nil
+	}
+	if !s.matchesDaemon(pid) {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find service process: %w", err)
+	}
+	defer func() { _ = process.Release() }()
+	s.Logger.Warn("%s did not stop in %s, killing it", s.Name, stopTimeout)
+	if err := process.Signal(syscall.SIGKILL); err != nil {
+		return fmt.Errorf("kill service process: %w", err)
+	}
 	return nil
+}
+
+// exitOnError reports a failed service command on the console as well as in
+// the log, then exits. Logging alone left the user with a silent exit 1 and no
+// way to know they had to read /tmp/<app>.log to find out why.
+func (s *Service) exitOnError(err error) {
+	if err != nil {
+		s.Logger.Error("%s", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s: %s\n", s.Name, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 func (s *Service) ServiceHandler(cmd *string) {
@@ -336,23 +405,11 @@ func (s *Service) ServiceHandler(cmd *string) {
 		s.startService()
 		os.Exit(0)
 	case "start":
-		if err := s.Start(); err != nil {
-			s.Logger.Error("%s", err)
-			os.Exit(1)
-		}
-		os.Exit(0)
+		s.exitOnError(s.Start())
 	case "stop":
-		if err := s.Stop(); err != nil {
-			s.Logger.Error("%s", err)
-			os.Exit(1)
-		}
-		os.Exit(0)
+		s.exitOnError(s.Stop())
 	case "restart":
-		if err := s.Restart(); err != nil {
-			s.Logger.Error("%s", err)
-			os.Exit(1)
-		}
-		os.Exit(0)
+		s.exitOnError(s.Restart())
 	case "status":
 		if s.Running() {
 			_, _ = fmt.Printf("%s service running\n", s.Name)


### PR DESCRIPTION
Three ways the service harness failed unhelpfully.

## `ETXTBSY` reported as "text file busy"

`Start` opened the `/tmp` copy with `O_TRUNC`. Linux returns `ETXTBSY` for a binary that is currently executing — so whenever the PID file went missing while the daemon was still alive (someone cleaned `/tmp`, a partial `stopService`), `Running()` returned false, `Start()` went ahead, and the user got `error creating temp binary: text file busy`, which says nothing about the real cause.

Staged and renamed into place instead. `pkg/bgm/daemon.go:64-103` already solves exactly this and documents why; `pkg/service` never got the fix.

## `restart` could hang forever

The wait was an unbounded `for s.Running() { time.Sleep(1s) }`, and `Stop` only ever sent `SIGTERM`. A daemon wedged in its own shutdown — a blocked listener close, a file watcher that will not close — meant `remote.sh -service restart` never returned and never timed out.

Now bounded by `stopTimeout` (20s), then escalated to `SIGKILL`. The kill path re-checks daemon identity first, so a PID that has since been reused by something else is not signalled.

## Failures were invisible

`ServiceHandler` reported `start`, `stop` and `restart` errors with `Logger.Error`, which writes only to `/tmp/<app>.log`, then exited 1. From the Scripts menu that is a command that fails with no output and no clue where to look. It now prints to stderr as well.

## Test coverage, honestly

- `TestKillIgnoresAProcessThatIsNotItsDaemon` — no PID file is a no-op, and a live PID that is not the daemon is not signalled (the test would die otherwise).
- `TestRestartWaitIsBounded` — `Restart` returns rather than hanging.

The staged-binary rename is **not** unit tested: exercising it means `Start()` spawning a real detached process. It mirrors the pattern in `pkg/bgm/daemon.go`, which is tested there. The 20-second timeout path is likewise not exercised end-to-end, because `Running()` depends on `/proc` identity checks that a test process cannot satisfy.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for remote, playlog and lastplayed.