### PR TITLE
fix(bgm,games,metadata,tracker): remove four long-standing traps

### DIFF
--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -208,6 +208,8 @@ The service listens on the unix socket `/tmp/bgm.sock`. Each connection carries 
 
 Commands are processed one at a time and wait while a core boot sound plays, exactly as before.
 
+A playlist stops itself if nothing will play. Tracks that return immediately, because the file is invalid or the player for its format is not installed, are retried with a pause and then abandoned after five in a row. Earlier versions looped on them as fast as the CPU allowed and filled the log.
+
 ## Logging
 
 With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players. Actionable radio failures are also logged with debug off, with identical repeated failures suppressed.

--- a/pkg/bgm/player.go
+++ b/pkg/bgm/player.go
@@ -528,17 +528,49 @@ func (p *Player) beginPlaylist() chan struct{} {
 	return done
 }
 
+// A track that cannot play returns from playTrack immediately: the file is
+// invalid, or the player binary for its format is not installed, or the music
+// folder has gone with an unplugged drive. Without these bounds the playlist
+// loops spun a CPU core flat and filled /tmp/bgm.log for as long as the
+// service ran.
+const (
+	playlistMinTrackTime = 250 * time.Millisecond
+	playlistRetryDelay   = 2 * time.Second
+	playlistMaxFailures  = 5
+)
+
+// playedTooFast reports a track that returned so quickly it cannot have
+// played, and paces the retry.
+func (p *Player) playedTooFast(started time.Time) bool {
+	if time.Since(started) >= playlistMinTrackTime {
+		return false
+	}
+	p.sleep(playlistRetryDelay)
+	return true
+}
+
 func (p *Player) startRandomPlaylist() {
 	p.logger.Log("Starting random playlist...")
 	done := p.beginPlaylist()
 	go func() {
 		defer close(done)
+		failures := 0
 		for p.InPlaylist() {
 			track, ok := p.randomTrack()
 			if !ok {
 				break
 			}
+			started := time.Now()
 			p.playTrack(track, true)
+			if !p.playedTooFast(started) {
+				failures = 0
+				continue
+			}
+			failures++
+			if failures >= playlistMaxFailures {
+				p.logger.Log("Random playlist stopped: no track would play")
+				break
+			}
 		}
 		p.logger.Log("Random playlist ended")
 	}()
@@ -550,8 +582,19 @@ func (p *Player) startLoopPlaylist() {
 	track, ok := p.randomTrack()
 	go func() {
 		defer close(done)
+		failures := 0
 		for p.InPlaylist() && ok {
+			started := time.Now()
 			p.playTrack(track, true)
+			if !p.playedTooFast(started) {
+				failures = 0
+				continue
+			}
+			failures++
+			if failures >= playlistMaxFailures {
+				p.logger.Log("Loop playlist stopped: " + track + " would not play")
+				break
+			}
 		}
 		p.logger.Log("Loop playlist ended")
 	}()

--- a/pkg/games/games.go
+++ b/pkg/games/games.go
@@ -20,9 +20,7 @@
 package games
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,187 +124,24 @@ func AllSystems() []System {
 	return systems
 }
 
-type resultsStack [][]string
-
-func (r *resultsStack) new() {
-	*r = append(*r, []string{})
-}
-
-func (r *resultsStack) pop() {
-	if len(*r) == 0 {
-		return
-	}
-	*r = (*r)[:len(*r)-1]
-}
-
-func (r *resultsStack) get() (*[]string, error) {
-	if len(*r) == 0 {
-		return nil, errors.New("nothing on stack")
-	}
-	return &(*r)[len(*r)-1], nil
-}
-
-// GetFiles searches for all valid games in a given path and return a list of
-// files. This function deep searches .zip files and handles symlinks at all
-// levels.
+// GetFiles searches for all valid games in a given path and returns a list of
+// files. It deep searches .zip files and handles symlinks at all levels.
+//
+// This used to walk the tree itself, calling os.Chdir so relative symlink
+// targets resolved. os.Chdir is process-global, and this runs inside Remote's
+// daemon alongside HTTP handlers and the tracker goroutine, so a random-game
+// launch could move the working directory out from under another request.
+// WalkFiles was written to do the same scan without that, and
+// TestWalkFilesMatchesGetFiles pinned the two to the same results.
 func GetFiles(systemID, path string) ([]string, error) {
-	var allResults []string
-	var stack resultsStack
-	visited := make(map[string]struct{})
-
-	system, err := GetSystem(systemID)
-	if err != nil {
-		return nil, err
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	defer func() { _ = os.Chdir(cwd) }()
-
-	var scanner func(path string, file fs.DirEntry, err error) error
-	scanner = func(path string, file fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return fmt.Errorf("scan game path: %w", walkErr)
-		}
-		// avoid recursive symlinks
-		if file.IsDir() {
-			if _, ok := visited[path]; ok {
-				return filepath.SkipDir
-			}
-			visited[path] = struct{}{}
-		}
-
-		// handle symlinked directories
-		if file.Type()&os.ModeSymlink != 0 {
-			err = os.Chdir(filepath.Dir(path))
-			if err != nil {
-				return fmt.Errorf("enter symlink parent directory: %w", err)
-			}
-
-			realPath, resolveErr := filepath.EvalSymlinks(path)
-			if resolveErr != nil {
-				return fmt.Errorf("resolve game symlink: %w", resolveErr)
-			}
-
-			file, statErr := os.Stat(realPath)
-			if statErr != nil {
-				return fmt.Errorf("stat game symlink target: %w", statErr)
-			}
-
-			if file.IsDir() {
-				err = os.Chdir(path)
-				if err != nil {
-					return fmt.Errorf("enter symlinked game directory: %w", err)
-				}
-
-				stack.new()
-				defer stack.pop()
-
-				err = filepath.WalkDir(realPath, scanner)
-				if err != nil {
-					return fmt.Errorf("scan symlinked game directory: %w", err)
-				}
-
-				results, stackErr := stack.get()
-				if stackErr != nil {
-					return stackErr
-				}
-
-				for i := range *results {
-					allResults = append(allResults, strings.Replace((*results)[i], realPath, path, 1))
-				}
-
-				return nil
-			}
-		}
-
-		results, stackErr := stack.get()
-		if stackErr != nil {
-			return stackErr
-		}
-
-		if strings.HasSuffix(strings.ToLower(path), ".zip") {
-			// zip files
-			zipFiles, zipErr := utils.ListZip(path)
-			if zipErr != nil {
-				// skip invalid zip files
-				return nil
-			}
-
-			for i := range zipFiles {
-				if MatchSystemFile(system, zipFiles[i]) {
-					abs := filepath.Join(path, zipFiles[i])
-					*results = append(*results, abs)
-				}
-			}
-		} else if MatchSystemFile(system, path) {
-			// regular files
-			*results = append(*results, path)
-		}
-
+	var results []string
+	if err := WalkFiles(systemID, path, func(file string) error {
+		results = append(results, file)
 		return nil
-	}
-
-	stack.new()
-	defer stack.pop()
-
-	root, err := os.Lstat(path)
-	if err != nil {
-		return nil, fmt.Errorf("inspect game root: %w", err)
-	}
-
-	err = os.Chdir(filepath.Dir(path))
-	if err != nil {
-		return nil, fmt.Errorf("enter game root parent: %w", err)
-	}
-
-	// handle symlinks on root game folder because WalkDir fails silently on them
-	var realPath string
-	if root.Mode()&os.ModeSymlink == 0 {
-		realPath = path
-	} else {
-		realPath, err = filepath.EvalSymlinks(path)
-		if err != nil {
-			return nil, fmt.Errorf("resolve game root: %w", err)
-		}
-	}
-
-	realRoot, err := os.Stat(realPath)
-	if err != nil {
-		return nil, fmt.Errorf("stat game root: %w", err)
-	}
-
-	if !realRoot.IsDir() {
-		return nil, errors.New("root is not a directory")
-	}
-
-	err = filepath.WalkDir(realPath, scanner)
-	if err != nil {
-		return nil, fmt.Errorf("scan game root: %w", err)
-	}
-
-	results, err := stack.get()
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
-
-	allResults = append(allResults, *results...)
-
-	// change root back to symlink
-	if realPath != path {
-		for i := range allResults {
-			allResults[i] = strings.Replace(allResults[i], realPath, path, 1)
-		}
-	}
-
-	err = os.Chdir(cwd)
-	if err != nil {
-		return nil, fmt.Errorf("restore working directory: %w", err)
-	}
-
-	return allResults, nil
+	return results, nil
 }
 
 func FilterUniqueFilenames(files []string) []string {

--- a/pkg/games/walk_test.go
+++ b/pkg/games/walk_test.go
@@ -29,7 +29,11 @@ import (
 	"testing"
 )
 
-func TestWalkFilesMatchesLegacyScanner(t *testing.T) {
+// GetFiles is now a thin wrapper over WalkFiles, so comparing the two would
+// prove nothing. Assert the expected set directly: a plain game, a game reached
+// through a symlinked directory that links back to the root, and the one
+// matching member of a ZIP.
+func TestWalkFilesFindsGamesThroughSymlinksAndArchives(t *testing.T) {
 	root, external := t.TempDir(), t.TempDir()
 	for _, path := range []string{filepath.Join(root, "game.nes"), filepath.Join(external, "linked.nes")} {
 		if err := os.WriteFile(path, nil, 0o600); err != nil {
@@ -59,9 +63,10 @@ func TestWalkFilesMatchesLegacyScanner(t *testing.T) {
 	if closeErr := file.Close(); closeErr != nil {
 		t.Fatal(closeErr)
 	}
-	want, err := GetFiles("NES", root)
-	if err != nil {
-		t.Fatal(err)
+	want := []string{
+		filepath.Join(root, "game.nes"),
+		filepath.Join(root, "linked", "linked.nes"),
+		filepath.Join(root, "pack.zip", "nested", "zip.nes"),
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -74,8 +79,17 @@ func TestWalkFilesMatchesLegacyScanner(t *testing.T) {
 	}
 	slices.Sort(got)
 	slices.Sort(want)
-	if !reflect.DeepEqual(got, want) || len(got) != 3 {
-		t.Fatalf("streamed paths = %v, legacy = %v", got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scanned paths = %v, want %v", got, want)
+	}
+	// GetFiles must agree, since it is the same scan collected into a slice.
+	legacy, err := GetFiles("NES", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(legacy)
+	if !reflect.DeepEqual(legacy, want) {
+		t.Fatalf("GetFiles = %v, want %v", legacy, want)
 	}
 	if after, cwdErr := os.Getwd(); cwdErr != nil || after != cwd {
 		t.Fatalf("scanner changed working directory: %q, %v", after, cwdErr)

--- a/pkg/metadata/arcadedb.go
+++ b/pkg/metadata/arcadedb.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gocarina/gocsv"
@@ -130,7 +131,12 @@ func UpdateArcadeDB() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("parse arcade database date: %w", err)
 	}
-	if latestFileDate.Before(dbAge) {
+	// Skip only when the local copy is already at least as new. This compares
+	// against the date stamped on the local file below, not its modification
+	// time: using mtime meant every download made the file look newer than any
+	// remote filename, so a copy truncated by a power cut or a full disk was
+	// never replaced and arcade names stayed blank for good.
+	if !latestFileDate.After(dbAge) {
 		return false, nil
 	}
 
@@ -138,11 +144,49 @@ func UpdateArcadeDB() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := os.WriteFile(config.ArcadeDBFile, body, 0o600); err != nil {
-		return false, fmt.Errorf("write arcade database: %w", err)
+	if err := writeArcadeDB(body, latestFileDate); err != nil {
+		return false, err
 	}
 
 	return true, nil
+}
+
+// writeArcadeDB stages the download beside the destination and renames it over,
+// then stamps it with the date the remote file carries so the freshness check
+// above has something truthful to compare against.
+func writeArcadeDB(body []byte, stamp time.Time) error {
+	path := config.ArcadeDBFile
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create staged arcade database: %w", err)
+	}
+	staged := temporary.Name()
+	published := false
+	defer func() {
+		_ = temporary.Close()
+		if !published {
+			_ = os.Remove(staged)
+		}
+	}()
+
+	if _, err := temporary.Write(body); err != nil {
+		return fmt.Errorf("write staged arcade database: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync staged arcade database: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close staged arcade database: %w", err)
+	}
+	if err := os.Chtimes(staged, stamp, stamp); err != nil {
+		return fmt.Errorf("stamp staged arcade database: %w", err)
+	}
+	// #nosec G703 -- destination is the fixed arcade database path.
+	if err := os.Rename(staged, path); err != nil {
+		return fmt.Errorf("publish arcade database: %w", err)
+	}
+	published = true
+	return nil
 }
 
 func ReadArcadeDB() ([]ArcadeDBEntry, error) {

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -506,8 +506,12 @@ func (tr *Tracker) processGame(activeGame string) {
 		tr.Logger.Error("error finding system for game: %s", err)
 	}
 
+	// The condition here was inverted: BestSystemMatch returns a zero System
+	// on error, so len(system.Folder) was only ever non-zero when err was nil,
+	// and folder stayed empty for every game ever recorded. It is written to
+	// playlog's game_times.folder column.
 	var folder string
-	if err != nil && len(system.Folder) > 0 {
+	if err == nil && len(system.Folder) > 0 {
 		folder = system.Folder[0]
 	}
 


### PR DESCRIPTION
The remaining second-tier findings from the audit.

## BGM could peg a CPU core indefinitely

`startRandomPlaylist` and `startLoopPlaylist` called `playTrack` in a bare loop with no pacing. `playTrack` returns immediately when the file is invalid or the player binary for its format is not installed — so a music folder on a drive that got unplugged, or a missing `mpg123`, spun a core flat and filled `/tmp/bgm.log` for as long as the service ran.

Tracks that return too fast to have played are now paced, and the playlist gives up after five in a row and says so.

## The arcade database could wedge itself permanently

The freshness check compared the remote *filename's* date against the local file's *modification time*. Every download therefore stamped the local copy as newer than any remote filename, so a copy truncated by a power cut or a full disk was never replaced — arcade names stayed blank in PlayLog, LastPlayed and Remote, forever, with only an `error reading arcade db` line in the log.

Now written atomically and stamped with the date it actually carries, and only a genuinely newer file is fetched.

## `game_times.folder` has always been empty

```go
system, err := games.BestSystemMatch(tr.Config, path)
...
if err != nil && len(system.Folder) > 0 {
```

`BestSystemMatch` returns a zero `System` on error, so `len(system.Folder)` was non-zero exactly when `err` was nil. The condition could never be true. The column has been empty for every game ever recorded.

## `GetFiles` moved the process working directory

It walked the tree calling `os.Chdir` so relative symlink targets resolved. `os.Chdir` is process-global, and this runs inside Remote's daemon alongside HTTP handlers and the tracker goroutine — a `**random:all` launch could move the working directory out from under another request mid-flight.

`pkg/games/walk.go` exists to do the same scan without that (its doc comment says so), and its test already pinned `WalkFiles` and `GetFiles` to identical results across symlinks, a symlink cycle, an external directory and a ZIP. `GetFiles` is now a thin wrapper over it, which also deletes ~160 lines and the `resultsStack` helper.

That test would now be comparing a function to itself, so it asserts the three expected paths directly instead, and separately checks `GetFiles` agrees.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for bgm, random, remote and playlog, plus `go test -race` over `pkg/bgm` and `pkg/games`.