### PR TITLE
fix(tui,remote): stop swallowing game names and hiding input prompts

### DIFF
--- a/cmd/favorites/settings_help.go
+++ b/cmd/favorites/settings_help.go
@@ -28,7 +28,7 @@ var settingsHelp = map[string]string{
 	"USB shortcut folder":     "Folder opened by the USB shortcut, normally /media/usb0.",
 	"Core prefix":             "Prefix standard RBF paths for custom setups; normally leave empty.",
 	"Additional game folders": "Extra game-library roots to recognize alongside SD and USB roots.",
-	"Alternate core":          "Choose Standard, LLAPI, or YC for newly created game favorites.",
+	"Alternate core":          "Choose Standard, LLAPI, YC or RetroAchievements for new game favorites.",
 	"Theme":                   "Choose a color palette to apply after saving.",
 	"Mouse":                   "Enable mouse input alongside keyboard and controller navigation.",
 	"CRT mode":                "Use a compact 75-column, 15-row layout for CRT displays.",

--- a/cmd/gamesmenu/ui.go
+++ b/cmd/gamesmenu/ui.go
@@ -159,7 +159,7 @@ func (u *ui) renderMain() {
 		SetButtonBar(bar).SetOnEscape(u.app.Stop)
 	help := func(index int) {
 		if index >= 0 && index < len(u.entries) {
-			frame.SetHelpText(tview.Escape(strings.Join(u.entries[index].Paths, ", ")))
+			frame.SetHelpText(strings.Join(u.entries[index].Paths, ", "))
 		} else {
 			frame.SetHelpText("Add games to a supported system folder, then restart GamesMenu.")
 		}
@@ -174,7 +174,7 @@ func (u *ui) renderMain() {
 }
 
 func (u *ui) showError(err error, onDismiss func()) {
-	tui.ShowErrorModal(u.pages, u.app, tview.Escape(err.Error()), onDismiss)
+	tui.ShowErrorModal(u.pages, u.app, err.Error(), onDismiss)
 }
 
 func (u *ui) startGenerate() {
@@ -202,7 +202,7 @@ func (u *ui) startGenerate() {
 	generate := func() { u.generate(selected) }
 	if len(removed) > 0 {
 		message := fmt.Sprintf("Generate will remove %d folders and everything inside them:\n", len(removed)) +
-			tview.Escape(strings.Join(removed, "\n"))
+			strings.Join(removed, "\n")
 		tui.ShowConfirmModal(u.pages, u.app, "Remove deselected folders", message, generate, u.renderMain)
 	} else {
 		generate()
@@ -242,7 +242,7 @@ func (u *ui) generate(selected []gamesmenu.Entry) {
 			text += "\n" + strings.Join(result.Removed, ", ")
 		}
 		text += errorSummary(result.Scan.Errors, result.Scan.ErrorsDropped)
-		tui.ShowInfoModal(u.pages, u.app, "Finished scanning", tview.Escape(text), u.mustShowMain)
+		tui.ShowInfoModal(u.pages, u.app, "Finished scanning", text, u.mustShowMain)
 	})
 }
 
@@ -289,6 +289,6 @@ func (u *ui) cleanUp() {
 			text += fmt.Sprintf("\nSkipped (storage not attached): %d", result.Unavailable)
 		}
 		text += errorSummary(result.Errors, result.ErrorsDropped)
-		tui.ShowInfoModal(u.pages, u.app, "Clean Up complete", tview.Escape(text), u.mustShowMain)
+		tui.ShowInfoModal(u.pages, u.app, "Clean Up complete", text, u.mustShowMain)
 	})
 }

--- a/cmd/lastplayed/main.go
+++ b/cmd/lastplayed/main.go
@@ -357,7 +357,7 @@ func tryAddStartup() error {
 }
 
 func main() {
-	svcOpt := flag.String("service", "", "manage playlog service (start, stop, restart, status)")
+	svcOpt := flag.String("service", "", "manage lastplayed service (start, stop, restart, status)")
 	flag.Parse()
 
 	logger := service.NewLogger(appName)

--- a/cmd/remote/gui.go
+++ b/cmd/remote/gui.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -185,21 +184,12 @@ func displayServiceInfo(svc *service.Service, cfg *config.UserConfig) (int, erro
 				switch selected {
 				case 0:
 					if svc.Running() {
-						err = svc.Stop()
+						runServiceAction(app, status, "Stopping service...", svc.Stop, draw)
 					} else {
-						err = svc.Start()
+						runServiceAction(app, status, "Starting service...", svc.Start, draw)
 					}
-					if err != nil {
-						logger.Error("could not toggle service: %s", err)
-					}
-					time.Sleep(time.Second)
-					draw()
 				case 1:
-					if err = svc.Restart(); err != nil {
-						logger.Error("could not restart service: %s", err)
-					}
-					time.Sleep(time.Second)
-					draw()
+					runServiceAction(app, status, "Restarting service...", svc.Restart, draw)
 				case 2:
 					action = displayUninstall
 					app.Stop()
@@ -217,6 +207,27 @@ func displayServiceInfo(svc *service.Service, cfg *config.UserConfig) (int, erro
 		return displayNothing, fmt.Errorf("show service controls: %w", err)
 	}
 	return action, nil
+}
+
+// runServiceAction runs a service command off the UI goroutine.
+//
+// The previous version called Stop, Start or Restart inline and then slept a
+// second on the UI goroutine before redrawing, so the screen was frozen and
+// unclickable with nothing to say why. A second is not long enough for a
+// restart either. Say what is happening, then redraw when it is really done.
+func runServiceAction(
+	app *tview.Application, status *tview.TextView, message string, action func() error, redraw func(),
+) {
+	status.SetText(message)
+	go func() {
+		err := action()
+		app.QueueUpdateDraw(func() {
+			if err != nil {
+				logger.Error("service action failed: %s", err)
+			}
+			redraw()
+		})
+	}()
 }
 
 func displayNonInteractiveServiceInfo(svc *service.Service) {

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -66,7 +66,7 @@ Changes remain staged until `Save` is selected. `Cancel` leaves the file untouch
 
 `USB shortcut folder` is the filesystem target of the browser's USB shortcut, normally `/media/usb0`. If that target contains a `games` folder, the shortcut opens it instead. This setting does not mount storage or change the destination of saved favorites; the INI key remains `external_folder`.
 
-The on-screen keyboard uses Zaparoo's compact 41×8 layout, with no separate prompt floating above it. Setting explanations stay in the settings page footer.
+The on-screen keyboard uses Zaparoo's compact 41×8 layout. Where an input has a prompt explaining what to enter, that line is shown above the keyboard; controller users could not see it otherwise, and they are the ones it is written for. Setting explanations stay in the settings page footer.
 
 ## Configuration
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -105,6 +105,8 @@ Adding or removing a startup entry preserves whatever `#!` line `user-startup.sh
 
 Changing the MAC address preserves the rest of `u-boot.txt` exactly, including comments and line order, and the value must be a valid MAC. Saving settings now reports which ones could not be applied instead of returning success regardless.
 
+Start, Stop and Restart on the Scripts-menu screen say what they are doing and redraw when the command finishes. They previously froze the screen for a fixed second and then redrew, which was both unresponsive and often too early to show the real state.
+
 ## Uninstall
 
 Remove Remote's Downloader subscription if configured, so updates do not reinstall it.

--- a/docs/search.md
+++ b/docs/search.md
@@ -5,8 +5,6 @@
 
 Search is an application to *search* for games on your MiSTer. It indexes all your games, lets you enter search queries without a keyboard, and then displays a list of results that can be launched directly.
 
-*NOTE: Search is still a work in progress. Core functionality of indexing and searching works great, but the GUI is missing a lot of features like filtering, sorting, re-indexing etc. which will come later. Feel free to use it now though.*
-
 <a href="https://github.com/wizzomafizzo/mrext/releases/latest/download/search.sh"><img src="images/download.svg" alt="Download Search" title="Download Search" width="140"></a>
 
 ## Install

--- a/pkg/tui/dialog.go
+++ b/pkg/tui/dialog.go
@@ -76,9 +76,14 @@ func NewDialog() *Dialog {
 	return dialog
 }
 
+// SetText sets the dialog body. The text is escaped: the view has dynamic
+// colours enabled, and dialog text here is nearly always a path or a file
+// name. tview reads a bracketed run of letters as a colour tag, so ROM-set
+// markers like [USA], [U], [Europe] and [hack] were swallowed -- "Delete
+// favorite Sonic (USA) [U].mgl?" rendered without the [U].
 func (d *Dialog) SetText(text string) *Dialog {
-	d.text = text
-	d.textView.SetText(text).ScrollToBeginning()
+	d.text = tview.Escape(text)
+	d.textView.SetText(d.text).ScrollToBeginning()
 	return d
 }
 

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -32,7 +32,7 @@ func TestKeyboardModalMatchesCompactZaparooLayout(t *testing.T) {
 	app := tview.NewApplication()
 	pages := tview.NewPages()
 	ShowInputModal(pages, app, InputOptions{
-		Title: "Name", Prompt: "Floating prompt must not appear", OnScreenKeyboard: true,
+		Title: "Name", OnScreenKeyboard: true,
 	}, func(string) {}, func() {})
 	screen := tcell.NewSimulationScreen("UTF-8")
 	if err := screen.Init(); err != nil {
@@ -57,9 +57,49 @@ func TestKeyboardModalMatchesCompactZaparooLayout(t *testing.T) {
 			_, _ = text.WriteString(value)
 		}
 	}
-	if strings.Contains(text.String(), "Floating prompt") || !strings.Contains(text.String(), "SPC") {
+	if !strings.Contains(text.String(), "SPC") {
 		t.Fatalf("unexpected keyboard rendering: %s", text.String())
 	}
+}
+
+func TestKeyboardModalShowsThePromptForControllerUsers(t *testing.T) {
+	// The prompt used to be rendered only on the physical-keyboard path, so
+	// the hint explaining what to type never reached controller users, who are
+	// the default on MiSTer and the audience it was written for.
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	ShowInputModal(pages, app, InputOptions{
+		Title:            "Startup sound delay",
+		Prompt:           "Enter the number of seconds to wait, such as 0 or 1.5.",
+		OnScreenKeyboard: true,
+	}, func(string) {}, func() {})
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	pages.SetRect(0, 0, 75, 15)
+	pages.Draw(screen)
+
+	if _, ok := app.GetFocus().(*VirtualKeyboard); !ok {
+		t.Fatal("keyboard not focused")
+	}
+	if !strings.Contains(screenText(screen, 75, 15), "seconds to wait") {
+		t.Fatalf("prompt not drawn:\n%s", screenText(screen, 75, 15))
+	}
+}
+
+func screenText(screen tcell.SimulationScreen, width, height int) string {
+	var text strings.Builder
+	for y := range height {
+		for x := range width {
+			value, _, _ := screen.Get(x, y)
+			_, _ = text.WriteString(value)
+		}
+		_ = text.WriteByte('\n')
+	}
+	return text.String()
 }
 
 func TestChoiceModalPreservesSelectionOnCancel(t *testing.T) {
@@ -429,5 +469,37 @@ func TestModalDismissalRestoresPageFocus(t *testing.T) {
 				t.Fatalf("focus after dismissal = %T", h.app.GetFocus())
 			}
 		})
+	}
+}
+
+func TestDialogAndHelpTextKeepBracketsInNames(t *testing.T) {
+	// tview reads square brackets as colour tags on these views. Its tag
+	// pattern matches a run of letters, so ROM-set markers like [USA], [U],
+	// [Europe] and [hack] were swallowed: "Delete favorite Sonic (USA) [U].mgl?"
+	// rendered as "Delete favorite Sonic (USA) .mgl?". Markers containing
+	// punctuation or digits, such as [!] or [b1], happen to survive.
+	const name = "Sonic The Hedgehog (USA) [U].mgl"
+
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	ShowConfirmModal(pages, app, "Favorites Manager", "Delete favorite "+name+"?", func() {}, func() {})
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	pages.SetRect(0, 0, 75, 15)
+	pages.Draw(screen)
+	if drawn := screenText(screen, 75, 15); !strings.Contains(drawn, "[U].mgl") {
+		t.Errorf("confirm dialog lost the brackets:\n%s", drawn)
+	}
+
+	frame := NewPageFrame(app).SetHelpText("/media/fat/games/NES/" + name)
+	frame.SetRect(0, 0, 75, 15)
+	frame.Draw(screen)
+	if drawn := screenText(screen, 75, 15); !strings.Contains(drawn, "[U].mgl") {
+		t.Errorf("help line lost the brackets:\n%s", drawn)
 	}
 }

--- a/pkg/tui/modals.go
+++ b/pkg/tui/modals.go
@@ -31,6 +31,9 @@ const (
 	errorModalPage   = "tui_error_modal"
 	confirmModalPage = "tui_confirm_modal"
 	inputModalPage   = "tui_input_modal"
+
+	keyboardModalWidth  = 41
+	keyboardModalHeight = 8
 )
 
 func ShowInfoModal(
@@ -143,7 +146,27 @@ func ShowInputModal(
 	if options.OnScreenKeyboard {
 		keyboard := NewVirtualKeyboard(options.InitialValue, submit, cancel)
 		keyboard.SetTitle(" " + options.Title + " ")
-		pages.AddPage(inputModalPage, Centered(41, 8, keyboard), true, true)
+		// The prompt used to be drawn only on the physical-keyboard path, so
+		// the one audience that cannot see the rest of the app -- controller
+		// users, which is the default on MiSTer -- never saw the hint that
+		// explains what to type.
+		if options.Prompt == "" {
+			pages.AddPage(inputModalPage, Centered(41, 8, keyboard), true, true)
+			app.SetFocus(keyboard)
+			return
+		}
+		prompt := tview.NewTextView().
+			SetText(tview.Escape(options.Prompt)).
+			SetWrap(true).
+			SetWordWrap(true).
+			SetTextAlign(tview.AlignCenter)
+		prompt.SetTextColor(CurrentTheme().SecondaryTextColor)
+		promptHeight := len(tview.WordWrap(options.Prompt, keyboardModalWidth))
+		content := tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(prompt, promptHeight, 0, false).
+			AddItem(keyboard, keyboardModalHeight, 0, true)
+		pages.AddPage(inputModalPage,
+			Centered(keyboardModalWidth, keyboardModalHeight+promptHeight, content), true, true)
 		app.SetFocus(keyboard)
 		return
 	}

--- a/pkg/tui/page_frame.go
+++ b/pkg/tui/page_frame.go
@@ -71,8 +71,12 @@ func (pf *PageFrame) SetFocusTarget(focus tview.Primitive) *PageFrame {
 	return pf
 }
 
+// SetHelpText sets the footer line. The text is escaped for the same reason
+// dialog text is: the view has dynamic colours enabled, and callers put paths
+// and file names here. The Favorites browser shows the current folder and
+// GamesMenu shows a row's source paths, so a bracketed name lost its marker.
 func (pf *PageFrame) SetHelpText(text string) *PageFrame {
-	pf.helpText.SetText(text)
+	pf.helpText.SetText(tview.Escape(text))
 	return pf
 }
 


### PR DESCRIPTION
The UI bug fixes from Stage 1 of the plan.

## Game names were disappearing from dialogs

tview reads a bracketed run of letters as a colour tag, and both `Dialog`'s body and `PageFrame`'s footer have dynamic colours enabled. Callers put paths and file names in both.

So ROM-set markers vanished: `Delete favorite Sonic (USA) [U].mgl?` asked about a *different file* than the one on disk. `[USA]`, `[U]`, `[Europe]`, `[hack]`, `[cr]` — all swallowed. The Favorites browser's folder line and GamesMenu's source-path line lost theirs too.

Escaped in `SetText` and `SetHelpText`, and the four hand-escaping call sites in GamesMenu removed since they would now double-escape.

Worth noting: markers with punctuation or digits (`[!]`, `[b1]`, `[T+Eng]`) were never affected — only letter-only ones match tview's tag pattern. My first version of the test used `[!]` and passed against the unfixed code, which is how I found that out.

## Controller users never saw input prompts

`ShowInputModal` drew `InputOptions.Prompt` only on the physical-keyboard path. The on-screen keyboard is the default on MiSTer, so BGM's *"Enter the number of seconds to wait, such as 0 or 1.5."* never reached the people it was written for.

**This reverses a documented decision.** `docs/favorites.md` recorded "no separate prompt floating above it" as an intentional deviation, and `TestKeyboardModalMatchesCompactZaparooLayout` asserted the prompt was absent. Silently discarding a caller's parameter is the part that reads as a defect — either the prompt should not be set or it should be shown. Both the doc and the test are updated rather than left contradicting the behaviour.

## Remote's service screen froze for a second

`time.Sleep(time.Second)` on the UI goroutine after Start, Stop and Restart. Unresponsive with nothing to explain it, and a second is not long enough for a restart to finish, so the state it then drew was often wrong. The command now runs off the UI goroutine, the screen says what it is doing, and it redraws when the command actually returns.

## Smaller ones

- `cmd/lastplayed/main.go` — the `-service` flag help said "manage **playlog** service".
- `cmd/favorites/settings_help.go` — alternate-core help predated RetroAchievements. Kept under the 73-character footer limit that `TestEverySettingHasContextualHelp` enforces.
- `docs/search.md` — still said re-indexing "will come later"; it is under Options.

## Tests

`TestDialogAndHelpTextKeepBracketsInNames` renders a confirm dialog and a help line through a simulation screen and asserts `[U].mgl` survives. With the escaping removed it fails on both.

`TestKeyboardModalShowsThePromptForControllerUsers` asserts the prompt is drawn above the keyboard.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for bgm, favorites, gamesmenu, lastplayed, remote and search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-screen keyboard prompts now appear above the keyboard, including for controller users.
  * Remote service actions show their current status and refresh when complete.

* **Bug Fixes**
  * Bracketed markers in filenames and paths now display correctly in dialogs and help text.
  * Updated “Alternate core” help to include RetroAchievements.
  * Corrected the lastplayed service flag description.

* **Documentation**
  * Clarified keyboard prompt placement and remote action behavior.
  * Removed the outdated work-in-progress disclaimer from Search documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->