### PR TITLE
feat(tui): unify the settings pages and share interface preferences

### DIFF
--- a/cmd/bgm/settings.go
+++ b/cmd/bgm/settings.go
@@ -95,15 +95,16 @@ func (s *settingsPage) show(selection int) {
 	s.list.AddHeader("Interface")
 	themes := make([]tui.Choice, 0, len(tui.ThemeNames))
 	for _, name := range tui.ThemeNames {
-		themes = append(themes, tui.Choice{Label: themeLabel(name), Help: "Applied after saving settings."})
+		themes = append(themes, tui.Choice{Label: tui.ThemeLabel(name), Help: "Applied after saving settings."})
 	}
 	themeIndex := slices.Index(tui.ThemeNames, s.staged.Theme)
-	s.addChoice("Theme", themeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
+	s.addChoice("Theme", tui.ThemeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
 		s.staged.Theme = tui.ThemeNames[index]
 	})
 	s.addToggle("Mouse", &s.staged.Mouse)
 	s.addToggle("CRT mode", &s.staged.CRTMode)
 	s.addToggle("On-screen keyboard", &s.staged.OnScreenKeyboard)
+	s.addShareRow()
 
 	s.list.SetCurrentItem(selection)
 	change := func() {
@@ -130,6 +131,31 @@ func (s *settingsPage) show(selection int) {
 	frame.SetupContentToButtonNavigation()
 	s.ui.pages.AddAndSwitchToPage(pageSettings, frame, true)
 	s.ui.app.SetFocus(s.list)
+}
+
+// addShareRow offers the staged interface settings to every other mrext app.
+func (s *settingsPage) addShareRow() {
+	index := s.list.GetItemCount()
+	s.list.AddRow(tui.ShareInterfaceSettingsLabel, tui.MenuRowAction)
+	s.help[index] = tui.ShareInterfaceSettingsHelp
+	s.actions[index] = func() {
+		selection := s.list.GetCurrentItem()
+		options := tui.ApplicationOptions{
+			Theme:            s.staged.Theme,
+			Mouse:            s.staged.Mouse,
+			CRTMode:          s.staged.CRTMode,
+			OnScreenKeyboard: s.staged.OnScreenKeyboard,
+		}
+		tui.ConfirmShareInterfaceSettings(s.ui.pages, s.ui.app, s.ui.paths.IniFile, options,
+			func(err error) {
+				if err != nil {
+					s.ui.showError(err, func() { s.show(selection) })
+					return
+				}
+				s.show(selection)
+			},
+			func() { s.show(selection) })
+	}
 }
 
 func (s *settingsPage) addRow(label, value string, action func()) {
@@ -266,14 +292,5 @@ func (s *settingsPage) save() {
 func (s *settingsPage) apply() {
 	s.staged.ApplyTo(&s.ui.cfg)
 	s.ui.options = s.ui.applicationOptions()
-	_ = tui.SetCurrentTheme(s.ui.options.Theme)
-	s.ui.app.EnableMouse(s.ui.options.Mouse)
-	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
-}
-
-func themeLabel(name string) string {
-	if theme := tui.AvailableThemes[name]; theme != nil {
-		return theme.DisplayName
-	}
-	return name
+	tui.ApplyOptions(s.ui.app, s.ui.pages, s.ui.options)
 }

--- a/cmd/bgm/settings_help.go
+++ b/cmd/bgm/settings_help.go
@@ -19,6 +19,8 @@
 
 package main
 
+import "github.com/wizzomafizzo/mrext/pkg/tui"
+
 var settingsHelp = map[string]string{
 	"Startup sound delay":     "Seconds before initial audio; applies next time BGM starts.",
 	"Boot sounds in rotation": "Add playlist and global boot sounds to normal playback after saving.",
@@ -28,8 +30,11 @@ var settingsHelp = map[string]string{
 	"Menu volume":             "MiSTer volume while the menu is open; needs Default volume too.",
 	"Default volume":          "MiSTer volume restored when a core runs; needs Menu volume too.",
 	"Debug logging":           "Write detailed service output to /tmp/bgm.log.",
-	"Theme":                   "Choose a color palette to apply after saving.",
-	"Mouse":                   "Enable mouse input alongside keyboard and controller navigation.",
-	"CRT mode":                "Use a compact 75-column, 15-row layout for CRT displays.",
-	"On-screen keyboard":      "Use controller-friendly text entry; Off needs a physical keyboard.",
+}
+
+func init() {
+	// The four interface settings read the same in every app.
+	for label, help := range tui.InterfaceSettingsHelp {
+		settingsHelp[label] = help
+	}
 }

--- a/cmd/favorites/settings.go
+++ b/cmd/favorites/settings.go
@@ -85,15 +85,16 @@ func (s *settingsPage) show(selection int) {
 	s.list.AddHeader("Interface")
 	themes := make([]tui.Choice, 0, len(tui.ThemeNames))
 	for _, name := range tui.ThemeNames {
-		themes = append(themes, tui.Choice{Label: themeLabel(name), Help: "Applied after saving settings."})
+		themes = append(themes, tui.Choice{Label: tui.ThemeLabel(name), Help: "Applied after saving settings."})
 	}
 	themeIndex := slices.Index(tui.ThemeNames, s.staged.Theme)
-	s.addChoice("Theme", themeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
+	s.addChoice("Theme", tui.ThemeLabel(s.staged.Theme), themes, themeIndex, func(index int) {
 		s.staged.Theme = tui.ThemeNames[index]
 	})
 	s.addToggle("Mouse", &s.staged.Mouse)
 	s.addToggle("CRT mode", &s.staged.CRTMode)
 	s.addToggle("On-screen keyboard", &s.staged.OnScreenKeyboard)
+	s.addShareRow()
 
 	s.list.SetCurrentItem(selection)
 	change := func() {
@@ -109,7 +110,7 @@ func (s *settingsPage) show(selection int) {
 		AddButtonWithHelp("Cancel", "Discard changes and return", back).
 		SetupNavigation(back)
 	frame := tui.NewPageFrame(s.ui.app).
-		SetTitle("Favorites Manager", "Settings").
+		SetTitle(appTitle, "Settings").
 		SetContent(s.list).
 		SetHelpText("Change settings, then save or cancel.").
 		SetButtonBar(bar).
@@ -120,6 +121,31 @@ func (s *settingsPage) show(selection int) {
 	frame.SetupContentToButtonNavigation()
 	s.ui.pages.AddAndSwitchToPage(pageSettings, frame, true)
 	s.ui.app.SetFocus(s.list)
+}
+
+// addShareRow offers the staged interface settings to every other mrext app.
+func (s *settingsPage) addShareRow() {
+	index := s.list.GetItemCount()
+	s.list.AddRow(tui.ShareInterfaceSettingsLabel, tui.MenuRowAction)
+	s.help[index] = tui.ShareInterfaceSettingsHelp
+	s.actions[index] = func() {
+		selection := s.list.GetCurrentItem()
+		options := tui.ApplicationOptions{
+			Theme:            s.staged.Theme,
+			Mouse:            s.staged.Mouse,
+			CRTMode:          s.staged.CRTMode,
+			OnScreenKeyboard: s.staged.OnScreenKeyboard,
+		}
+		tui.ConfirmShareInterfaceSettings(s.ui.pages, s.ui.app, s.ui.cfg.IniPath, options,
+			func(err error) {
+				if err != nil {
+					s.ui.showError(err, func() { s.show(selection) })
+					return
+				}
+				s.show(selection)
+			},
+			func() { s.show(selection) })
+	}
 }
 
 func (s *settingsPage) addRow(label, value string, action func()) {
@@ -232,9 +258,7 @@ func (s *settingsPage) apply() {
 		CRTMode:          s.ui.cfg.TUI.CRTMode,
 		OnScreenKeyboard: s.ui.cfg.TUI.OnScreenKeyboard,
 	}
-	_ = tui.SetCurrentTheme(s.ui.options.Theme)
-	s.ui.app.EnableMouse(s.ui.options.Mouse)
-	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
+	tui.ApplyOptions(s.ui.app, s.ui.pages, s.ui.options)
 }
 
 func alternateCoreLabel(mode string) string {
@@ -248,11 +272,4 @@ func alternateCoreLabel(mode string) string {
 	default:
 		return "Standard"
 	}
-}
-
-func themeLabel(name string) string {
-	if theme := tui.AvailableThemes[name]; theme != nil {
-		return theme.DisplayName
-	}
-	return name
 }

--- a/cmd/favorites/settings_help.go
+++ b/cmd/favorites/settings_help.go
@@ -19,6 +19,8 @@
 
 package main
 
+import "github.com/wizzomafizzo/mrext/pkg/tui"
+
 var settingsHelp = map[string]string{
 	"Default folder":          "Folder created at startup when no Favorites folders exist.",
 	"Folder name matches":     "Name fragments used to find Favorites folders, such as fav.",
@@ -29,8 +31,11 @@ var settingsHelp = map[string]string{
 	"Core prefix":             "Prefix standard RBF paths for custom setups; normally leave empty.",
 	"Additional game folders": "Extra game-library roots to recognize alongside SD and USB roots.",
 	"Alternate core":          "Choose Standard, LLAPI, YC or RetroAchievements for new game favorites.",
-	"Theme":                   "Choose a color palette to apply after saving.",
-	"Mouse":                   "Enable mouse input alongside keyboard and controller navigation.",
-	"CRT mode":                "Use a compact 75-column, 15-row layout for CRT displays.",
-	"On-screen keyboard":      "Use controller-friendly text entry; Off needs a physical keyboard.",
+}
+
+func init() {
+	// The four interface settings read the same in every app.
+	for label, help := range tui.InterfaceSettingsHelp {
+		settingsHelp[label] = help
+	}
 }

--- a/cmd/favorites/settings_list.go
+++ b/cmd/favorites/settings_list.go
@@ -92,19 +92,23 @@ func (s *settingsPage) editList(
 		values = slices.Delete(values, index, index+1)
 		rebuild()
 	}
+	// Every other page gives each button a help line and pipes it to the
+	// footer. This one used AddButton, so its footer never responded.
 	bar := tui.NewButtonBar(s.ui.app).
-		AddButton("Edit", func() { edit(false) }).
-		AddButton("Add", func() { edit(true) }).
-		AddButton("Remove", remove).
-		AddButton("Done", func() { apply(slices.Clone(values)); back() }).
-		AddButton("Cancel", back).
+		AddButtonWithHelp("Edit", "Change the selected entry", func() { edit(false) }).
+		AddButtonWithHelp("Add", "Add a new entry to the list", func() { edit(true) }).
+		AddButtonWithHelp("Remove", "Remove the selected entry", remove).
+		AddButtonWithHelp("Done", "Keep these entries and return to Settings",
+			func() { apply(slices.Clone(values)); back() }).
+		AddButtonWithHelp("Cancel", "Discard entry changes and return", back).
 		SetupNavigation(back)
 	frame := tui.NewPageFrame(s.ui.app).
-		SetTitle(label).
+		SetTitle(appTitle, "Settings", label).
 		SetContent(list).
 		SetHelpText("One entry per row. Done keeps edits; Save settings writes them.").
 		SetButtonBar(bar).
 		SetOnEscape(back)
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
 	list.SetSelectedFunc(func(int, string, string, rune) { edit(false) })
 	frame.SetupContentToButtonNavigation()
 	s.ui.pages.AddAndSwitchToPage(page, tui.Centered(73, 13, frame), true)

--- a/cmd/favorites/ui.go
+++ b/cmd/favorites/ui.go
@@ -32,7 +32,9 @@ import (
 )
 
 const (
-	pageMain    = "favorites_main"
+	pageMain = "favorites_main"
+	// appTitle is the first segment of every page title.
+	appTitle    = "Favorites Manager"
 	pageBrowser = "favorites_browser"
 	pageFolder  = "favorites_folder"
 	pageModify  = "favorites_modify"
@@ -132,7 +134,7 @@ func (u *ui) showMain() error {
 		AddButtonWithHelp("Exit", "Exit Favorites Manager", u.app.Stop).
 		SetupNavigation(u.app.Stop)
 	frame := tui.NewPageFrame(u.app).
-		SetTitle("Favorites Manager").
+		SetTitle(appTitle).
 		SetContent(list).
 		SetHelpText("Add a new favorite or select an existing one to modify.").
 		SetButtonBar(bar).
@@ -259,7 +261,7 @@ func (u *ui) showBrowser(folder string) {
 		AddButtonWithHelp("Cancel", "Return to Favorites Manager", u.mustShowMain).
 		SetupNavigation(back)
 	frame := tui.NewPageFrame(u.app).
-		SetTitle("Favorites Manager", "Select Favorite").
+		SetTitle(appTitle, "Select Favorite").
 		SetContent(list).
 		SetHelpText(folder).
 		SetButtonBar(bar).
@@ -352,7 +354,7 @@ func (u *ui) showFolderPicker(
 	bar.AddButtonWithHelp("Cancel", "Cancel folder selection", onCancel).
 		SetupNavigation(onCancel)
 	frame := tui.NewPageFrame(u.app).
-		SetTitle("Favorites Manager", title).
+		SetTitle(appTitle, title).
 		SetContent(list).
 		SetHelpText(title + ".").
 		SetButtonBar(bar).
@@ -406,7 +408,7 @@ func (u *ui) showModify(item *favorites.Favorite) {
 		AddItem(details, 7, 0, false).
 		AddItem(list, 0, 1, true)
 	frame := tui.NewPageFrame(u.app).
-		SetTitle("Favorites Manager", "Modify").
+		SetTitle(appTitle, "Modify").
 		SetContent(content).
 		SetFocusTarget(list).
 		SetHelpText("Select an action.").

--- a/cmd/favorites/ui_test.go
+++ b/cmd/favorites/ui_test.go
@@ -299,7 +299,7 @@ func TestSettingsPageStagesAndSavesChanges(t *testing.T) {
 		ui:       view,
 	}
 	page.show(0)
-	if !view.pages.HasPage(pageSettings) || page.list.GetItemCount() != 16 {
+	if !view.pages.HasPage(pageSettings) || page.list.GetItemCount() != 17 {
 		t.Fatalf("settings page rows = %d", page.list.GetItemCount())
 	}
 	screen := tcell.NewSimulationScreen("UTF-8")

--- a/cmd/gamesmenu/settings.go
+++ b/cmd/gamesmenu/settings.go
@@ -20,9 +20,6 @@
 package main
 
 import (
-	"fmt"
-	"sort"
-
 	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
 	"github.com/wizzomafizzo/mrext/pkg/tui"
 )
@@ -51,27 +48,44 @@ func (s *settingsPage) show(selection int) {
 	s.list.AddHeader("Interface")
 	s.actions = append(s.actions, nil)
 	s.help = append(s.help, "Controller-friendly interface and display options")
-	s.addRow("Theme", themeLabel(s.staged.Theme), func() {
-		names := make([]string, 0, len(tui.AvailableThemes))
-		for name := range tui.AvailableThemes {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		choices := make([]tui.Choice, len(names))
+	// tui.ThemeNames, not sorted map keys: the picker has to offer the themes
+	// in the same order here as it does in BGM and Favorites.
+	s.addRow("Theme", tui.ThemeLabel(s.staged.Theme), func() {
+		choices := make([]tui.Choice, len(tui.ThemeNames))
 		selected := 0
-		for index, name := range names {
-			choices[index] = tui.Choice{Label: themeLabel(name), Help: "Use the " + themeLabel(name) + " color theme"}
+		for index, name := range tui.ThemeNames {
+			choices[index] = tui.Choice{Label: tui.ThemeLabel(name), Help: "Applied after saving settings."}
 			if name == s.staged.Theme {
 				selected = index
 			}
 		}
 		tui.ShowChoiceModal(s.ui.pages, s.ui.app, "Theme", choices, selected, func(index int) {
-			s.staged.Theme = names[index]
+			s.staged.Theme = tui.ThemeNames[index]
 			s.show(1)
 		}, func() { s.show(1) })
 	})
-	s.addRow("Mouse", boolLabel(s.staged.Mouse), func() { s.staged.Mouse = !s.staged.Mouse; s.show(2) })
-	s.addRow("CRT mode", boolLabel(s.staged.CRTMode), func() { s.staged.CRTMode = !s.staged.CRTMode; s.show(3) })
+	s.addRow("Mouse", tui.BoolLabel(s.staged.Mouse), func() { s.staged.Mouse = !s.staged.Mouse; s.show(2) })
+	s.addRow("CRT mode", tui.BoolLabel(s.staged.CRTMode), func() { s.staged.CRTMode = !s.staged.CRTMode; s.show(3) })
+	// GamesMenu has no text entry, so it has no on-screen keyboard setting;
+	// sharing still carries the value it inherited so other apps keep theirs.
+	s.addRow(tui.ShareInterfaceSettingsLabel, "", func() {
+		row := s.list.GetCurrentItem()
+		options := tui.ApplicationOptions{
+			Theme:            s.staged.Theme,
+			Mouse:            s.staged.Mouse,
+			CRTMode:          s.staged.CRTMode,
+			OnScreenKeyboard: s.ui.cfg.TUI.OnScreenKeyboard,
+		}
+		tui.ConfirmShareInterfaceSettings(s.ui.pages, s.ui.app, s.ui.cfg.IniPath, options,
+			func(err error) {
+				if err != nil {
+					s.ui.showError(err, func() { s.show(row) })
+					return
+				}
+				s.show(row)
+			},
+			func() { s.show(row) })
+	})
 	activate := func() {
 		if action := s.actions[s.list.GetCurrentItem()]; action != nil {
 			action()
@@ -79,10 +93,10 @@ func (s *settingsPage) show(selection int) {
 	}
 	s.list.SetSelectedFunc(func(int, string, string, rune) { activate() })
 	bar := tui.NewButtonBar(s.ui.app).
-		AddButtonWithHelp("Change", "Change the selected setting", activate).
-		AddButtonWithHelp("Save", "Save settings and return to GamesMenu", s.save).
-		AddButtonWithHelp("Cancel", "Return without saving settings", s.back).SetupNavigation(s.back)
-	frame := tui.NewPageFrame(s.ui.app).SetTitle("GamesMenu Settings").
+		AddButtonWithHelp("Change", "Change selected setting", activate).
+		AddButtonWithHelp("Save", "Save settings and return", s.save).
+		AddButtonWithHelp("Cancel", "Discard changes and return", s.back).SetupNavigation(s.back)
+	frame := tui.NewPageFrame(s.ui.app).SetTitle(appTitle, "Settings").
 		SetContent(s.list).SetButtonBar(bar).SetOnEscape(s.back)
 	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
 	s.list.SetRowChangedFunc(func(index int) {
@@ -98,7 +112,11 @@ func (s *settingsPage) show(selection int) {
 }
 
 func (s *settingsPage) addRow(label, value string, action func()) {
-	s.list.AddRow(fmt.Sprintf("%s: %s", label, value), tui.MenuRowItem)
+	text := label
+	if value != "" {
+		text = label + ": " + value
+	}
+	s.list.AddRow(text, tui.MenuRowAction)
 	s.actions = append(s.actions, action)
 	s.help = append(s.help, settingHelp(label))
 }
@@ -123,22 +141,6 @@ func (s *settingsPage) save() {
 	s.ui.options = tui.ApplicationOptions{
 		Theme: s.ui.cfg.TUI.Theme, Mouse: s.ui.cfg.TUI.Mouse, CRTMode: s.ui.cfg.TUI.CRTMode,
 	}
-	_ = tui.SetCurrentTheme(s.ui.options.Theme)
-	s.ui.app.EnableMouse(s.ui.options.Mouse)
-	s.ui.app.SetRoot(tui.WrapRoot(s.ui.options, s.ui.pages), true)
+	tui.ApplyOptions(s.ui.app, s.ui.pages, s.ui.options)
 	s.ui.renderMain()
-}
-
-func themeLabel(name string) string {
-	if theme := tui.AvailableThemes[name]; theme != nil {
-		return theme.DisplayName
-	}
-	return name
-}
-
-func boolLabel(value bool) string {
-	if value {
-		return "Yes"
-	}
-	return "No"
 }

--- a/cmd/gamesmenu/settings_help.go
+++ b/cmd/gamesmenu/settings_help.go
@@ -19,15 +19,13 @@
 
 package main
 
+import "github.com/wizzomafizzo/mrext/pkg/tui"
+
+// settingHelp reads from the shared table so the interface settings are
+// described the same way here as in BGM and Favorites.
 func settingHelp(label string) string {
-	switch label {
-	case "Theme":
-		return "Choose interface colors; changes apply after Save"
-	case "Mouse":
-		return "Allow mouse navigation; controller navigation always works"
-	case "CRT mode":
-		return "Limit the interface to a centered 75 x 15 area on larger screens"
-	default:
-		return ""
+	if label == tui.ShareInterfaceSettingsLabel {
+		return tui.ShareInterfaceSettingsHelp
 	}
+	return tui.InterfaceSettingsHelp[label]
 }

--- a/cmd/gamesmenu/ui.go
+++ b/cmd/gamesmenu/ui.go
@@ -29,7 +29,11 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/tui"
 )
 
-const pageMain = "gamesmenu_main"
+const (
+	pageMain = "gamesmenu_main"
+	// appTitle is the first segment of every page title.
+	appTitle = "GamesMenu"
+)
 
 const welcomeText = "This script will generate a new folder in your main menu called Games, " +
 	"which will allow you to directly launch games without first opening a core. " +
@@ -155,7 +159,7 @@ func (u *ui) renderMain() {
 		AddButtonWithHelp("Settings", "Configure GamesMenu interface", remember(u.startSettings)).
 		AddButtonWithHelp("Exit", "Exit without changing the Games menu", u.app.Stop).
 		SetupNavigation(u.app.Stop)
-	frame := tui.NewPageFrame(u.app).SetTitle("GamesMenu").SetContent(list).
+	frame := tui.NewPageFrame(u.app).SetTitle(appTitle).SetContent(list).
 		SetButtonBar(bar).SetOnEscape(u.app.Stop)
 	help := func(index int) {
 		if index >= 0 && index < len(u.entries) {

--- a/cmd/gamesmenu/ui_test.go
+++ b/cmd/gamesmenu/ui_test.go
@@ -298,7 +298,7 @@ func TestSettingsStageSaveHelpAndDiscard(t *testing.T) {
 	view := newWorkflowUI(t, false)
 	settings := newSettingsPage(view)
 	settings.show(1)
-	if len(settings.actions) != 4 {
+	if len(settings.actions) != 5 {
 		t.Fatalf("rows: %d", len(settings.actions))
 	}
 	for index, help := range settings.help {

--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -210,6 +210,14 @@ Commands are processed one at a time and wait while a core boot sound plays, exa
 
 A playlist stops itself if nothing will play. Tracks that return immediately, because the file is invalid or the player for its format is not installed, are retried with a pause and then abandoned after five in a row. Earlier versions looped on them as fast as the CPU allowed and filled the log.
 
+### Shared interface settings
+
+Theme, mouse, CRT mode and on-screen keyboard can be set once for every mrext app instead of app by app.
+
+Each app reads these in order: its own `[tui]` section, then `/media/fat/Scripts/.config/mrext/tui.ini`, then the built-in defaults. An app's own INI still wins for any key it declares, so nothing changes until you ask for it.
+
+The settings screen has a **Use in all apps** row. It writes the current interface settings to the shared file and removes those four keys from this app's INI, so this app follows the shared file from then on. Other apps pick it up the next time they start, unless their own INI still sets those keys.
+
 ## Logging
 
 With `debug = yes`, every service message is printed and appended to `/tmp/bgm.log` with an ISO 8601 timestamp, including the output of the audio players. Actionable radio failures are also logged with debug off, with identical repeated failures suppressed.

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -68,6 +68,14 @@ Changes remain staged until `Save` is selected. `Cancel` leaves the file untouch
 
 The on-screen keyboard uses Zaparoo's compact 41×8 layout. Where an input has a prompt explaining what to enter, that line is shown above the keyboard; controller users could not see it otherwise, and they are the ones it is written for. Setting explanations stay in the settings page footer.
 
+### Shared interface settings
+
+Theme, mouse, CRT mode and on-screen keyboard can be set once for every mrext app instead of app by app.
+
+Each app reads these in order: its own `[tui]` section, then `/media/fat/Scripts/.config/mrext/tui.ini`, then the built-in defaults. An app's own INI still wins for any key it declares, so nothing changes until you ask for it.
+
+The settings screen has a **Use in all apps** row. It writes the current interface settings to the shared file and removes those four keys from this app's INI, so this app follows the shared file from then on. Other apps pick it up the next time they start, unless their own INI still sets those keys.
+
 ## Configuration
 
 Favorites reads `favorites.ini` beside the executable:

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -77,6 +77,14 @@ Available themes: `default`, `high_contrast`, `dracula`, `nord`, `gruvbox`, `mon
 
 To add libraries, repeat `games_folder` under `[systems]`. Each root and its `games` subfolder are considered. Built-in roots remain enabled on MiSTer. Shared `[systems] set_core` overrides are honored when generating new shortcuts, for example `set_core = NES:_Console/Custom`. Existing shortcuts are not rewritten when overrides change.
 
+### Shared interface settings
+
+Theme, mouse, CRT mode and on-screen keyboard can be set once for every mrext app instead of app by app.
+
+Each app reads these in order: its own `[tui]` section, then `/media/fat/Scripts/.config/mrext/tui.ini`, then the built-in defaults. An app's own INI still wins for any key it declares, so nothing changes until you ask for it.
+
+The settings screen has a **Use in all apps** row. It writes the current interface settings to the shared file and removes those four keys from this app's INI, so this app follows the shared file from then on. Other apps pick it up the next time they start, unless their own INI still sets those keys.
+
 ## names.txt
 
 `/media/fat/names.txt` supplies display and menu folder names:

--- a/pkg/bgm/config.go
+++ b/pkg/bgm/config.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
 )
 
 // DefaultINI is written only when bgm.ini is missing.
@@ -154,7 +156,37 @@ func LoadConfig(paths *Paths) (Config, error) {
 	if err != nil {
 		return DefaultConfig(), err
 	}
-	return ConfigFromDocument(doc), nil
+	cfg := ConfigFromDocument(doc)
+	applySharedTUI(doc, &cfg)
+	return cfg, nil
+}
+
+// applySharedTUI layers the shared [tui] file under bgm.ini. BGM keeps its own
+// configparser-compatible reader, so it cannot go through config.LoadUserConfig
+// like the other apps; the read order has to match theirs by hand. Only keys
+// bgm.ini does not declare are taken from the shared file.
+func applySharedTUI(doc *Document, cfg *Config) {
+	shared, err := config.LoadSharedTUI(config.TUIConfig{
+		Theme:            cfg.TUI.Theme,
+		Mouse:            cfg.TUI.Mouse,
+		CRTMode:          cfg.TUI.CRTMode,
+		OnScreenKeyboard: cfg.TUI.OnScreenKeyboard,
+	})
+	if err != nil {
+		return
+	}
+	if _, ok := doc.Get(iniSectionTUI, "theme"); !ok {
+		cfg.TUI.Theme = shared.Theme
+	}
+	if _, ok := doc.Get(iniSectionTUI, "mouse"); !ok {
+		cfg.TUI.Mouse = shared.Mouse
+	}
+	if _, ok := doc.Get(iniSectionTUI, "crt_mode"); !ok {
+		cfg.TUI.CRTMode = shared.CRTMode
+	}
+	if _, ok := doc.Get(iniSectionTUI, "on_screen_keyboard"); !ok {
+		cfg.TUI.OnScreenKeyboard = shared.OnScreenKeyboard
+	}
 }
 
 // ConfigFromDocument applies Python's fallbacks and parsing rules. Values

--- a/pkg/config/apps.go
+++ b/pkg/config/apps.go
@@ -40,6 +40,15 @@ const (
 	MrextConfigFolder   = ScriptsConfigFolder + "/mrext"
 )
 
+// SharedTUIConfigFile holds [tui] settings every mrext app falls back to, so a
+// theme can be chosen once instead of in each app's own INI. Optional: when it
+// is absent nothing changes. An app's own [tui] section still wins.
+const SharedTUIConfigFile = MrextConfigFolder + "/tui.ini"
+
+// SharedTUIConfigEnv overrides SharedTUIConfigFile, so tests never read or
+// write the real one.
+const SharedTUIConfigEnv = "MREXT_TUI_CONFIG"
+
 const (
 	ArcadeDBURL  = "https://api.github.com/repositories/521644036/contents/ArcadeDatabase_CSV"
 	ArcadeDBFile = MrextConfigFolder + "/ArcadeDatabase.csv"

--- a/pkg/config/sharedtui.go
+++ b/pkg/config/sharedtui.go
@@ -1,0 +1,116 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/ini.v1"
+)
+
+// SharedTUIConfigPath returns the shared [tui] file, honouring the override.
+func SharedTUIConfigPath() string {
+	if path := os.Getenv(SharedTUIConfigEnv); path != "" {
+		return path
+	}
+	return SharedTUIConfigFile
+}
+
+// LoadSharedTUI reads the shared [tui] settings over the given defaults. Keys
+// the file does not declare are left alone, so this layers cleanly under an
+// app's own INI: app INI, then this, then the built-in defaults.
+//
+// A missing file is not an error. It is the normal case.
+func LoadSharedTUI(defaults TUIConfig) (TUIConfig, error) {
+	path := SharedTUIConfigPath()
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return defaults, nil
+		}
+		return defaults, fmt.Errorf("stat shared interface configuration: %w", err)
+	}
+	file, err := ini.Load(filepath.Clean(path))
+	if err != nil {
+		return defaults, fmt.Errorf("load shared interface configuration: %w", err)
+	}
+	shared := defaults
+	if err := file.Section("tui").MapTo(&shared); err != nil {
+		return defaults, fmt.Errorf("map shared interface configuration: %w", err)
+	}
+	return shared, nil
+}
+
+// SaveSharedTUI writes the shared [tui] settings, creating the file and its
+// directory when needed. Unknown sections and keys in an existing file are
+// preserved, as everywhere else in mrext.
+func SaveSharedTUI(settings TUIConfig) error {
+	path := SharedTUIConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create shared configuration directory: %w", err)
+	}
+
+	file := ini.Empty()
+	if _, err := os.Stat(path); err == nil {
+		loaded, loadErr := ini.Load(filepath.Clean(path))
+		if loadErr != nil {
+			return fmt.Errorf("load shared interface configuration: %w", loadErr)
+		}
+		file = loaded
+	}
+
+	section, err := GetOrCreateSection(file, "tui")
+	if err != nil {
+		return err
+	}
+	SetKey(section, "theme", settings.Theme)
+	SetKey(section, "mouse", FormatBool(settings.Mouse))
+	SetKey(section, "crt_mode", FormatBool(settings.CRTMode))
+	SetKey(section, "on_screen_keyboard", FormatBool(settings.OnScreenKeyboard))
+
+	return WriteINIAtomically(path, file)
+}
+
+// RemoveLocalTUIKeys deletes the four managed [tui] keys from an app's own INI,
+// leaving every other key, section and comment alone. An app stops overriding
+// the shared file only when its own keys are gone.
+func RemoveLocalTUIKeys(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat user configuration: %w", err)
+	}
+	return UpdateINI(path, func(file *ini.File) error {
+		if !file.HasSection("tui") {
+			// No [tui] section: already following the shared file.
+			return nil
+		}
+		section := file.Section("tui")
+		for _, key := range []string{"theme", "mouse", "crt_mode", "on_screen_keyboard"} {
+			section.DeleteKey(key)
+		}
+		if len(section.Keys()) == 0 {
+			file.DeleteSection("tui")
+		}
+		return nil
+	})
+}

--- a/pkg/config/sharedtui_test.go
+++ b/pkg/config/sharedtui_test.go
@@ -1,0 +1,163 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+//nolint:gosec // Tests only operate on temporary fixture paths.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/ini.v1"
+)
+
+func sharedTUIFixture(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tui.ini")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv(SharedTUIConfigEnv, path)
+	return path
+}
+
+func TestSharedTUIResolutionOrder(t *testing.T) {
+	appINI := filepath.Join(t.TempDir(), "favorites.ini")
+
+	cases := []struct {
+		name   string
+		shared string
+		app    string
+		want   TUIConfig
+	}{
+		{
+			name: "neither file: built-in defaults",
+			want: TUIConfig{Theme: "default", Mouse: true, CRTMode: true, OnScreenKeyboard: true},
+		},
+		{
+			name:   "shared only",
+			shared: "[tui]\ntheme = nord\nmouse = false\n",
+			want:   TUIConfig{Theme: "nord", Mouse: false, CRTMode: true, OnScreenKeyboard: true},
+		},
+		{
+			name: "app only",
+			app:  "[tui]\ntheme = dracula\n",
+			want: TUIConfig{Theme: "dracula", Mouse: true, CRTMode: true, OnScreenKeyboard: true},
+		},
+		{
+			// The app INI wins per key, and only for the keys it declares:
+			// crt_mode is not in the app file, so the shared value survives.
+			name:   "both: app wins per key",
+			shared: "[tui]\ntheme = nord\nmouse = false\ncrt_mode = false\n",
+			app:    "[tui]\ntheme = gruvbox\n",
+			want:   TUIConfig{Theme: "gruvbox", Mouse: false, CRTMode: false, OnScreenKeyboard: true},
+		},
+	}
+
+	for _, item := range cases {
+		t.Run(item.name, func(t *testing.T) {
+			sharedTUIFixture(t, item.shared)
+			if item.app == "" {
+				_ = os.Remove(appINI)
+			} else if err := os.WriteFile(appINI, []byte(item.app), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			defaults := &UserConfig{
+				TUI: TUIConfig{Theme: "default", Mouse: true, CRTMode: true, OnScreenKeyboard: true},
+			}
+			cfg, err := LoadUserConfigAt(appINI, "/media/fat/Scripts/favorites.sh", defaults)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.TUI != item.want {
+				t.Fatalf("TUI = %+v, want %+v", cfg.TUI, item.want)
+			}
+		})
+	}
+}
+
+func TestSaveSharedTUIKeepsUnrelatedContent(t *testing.T) {
+	path := sharedTUIFixture(t, "; hand written\n[tui]\ntheme = nord\n\n[other]\nkeep = yes\n")
+
+	settings := TUIConfig{Theme: "gruvbox", Mouse: true, CRTMode: false, OnScreenKeyboard: true}
+	if err := SaveSharedTUI(settings); err != nil {
+		t.Fatal(err)
+	}
+
+	// go-ini aligns the "=" column, so match on the pair rather than spacing.
+	saved := readFileString(t, path)
+	reloaded, err := ini.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tui := reloaded.Section("tui")
+	if tui.Key("theme").String() != "gruvbox" || tui.Key("crt_mode").String() != "false" {
+		t.Errorf("interface settings not saved:\n%s", saved)
+	}
+	if reloaded.Section("other").Key("keep").String() != "yes" {
+		t.Errorf("unrelated section was lost:\n%s", saved)
+	}
+	if !strings.Contains(saved, "hand written") {
+		t.Errorf("comment was lost:\n%s", saved)
+	}
+}
+
+func TestRemoveLocalTUIKeysLeavesEverythingElse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "favorites.ini")
+	original := "[favorites]\ndefault_folder = _@Favorites\n\n[tui]\ntheme = nord\nmouse = false\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// An app INI that spells out these keys always beats the shared file, so
+	// sharing has to clear them or it would never take effect.
+	if err := RemoveLocalTUIKeys(path); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := readFileString(t, path)
+	if strings.Contains(saved, "theme") || strings.Contains(saved, "mouse") {
+		t.Errorf("interface keys survived:\n%s", saved)
+	}
+	if !strings.Contains(saved, "default_folder = _@Favorites") {
+		t.Errorf("unrelated settings were lost:\n%s", saved)
+	}
+
+	// Harmless to repeat, and harmless when the file does not exist.
+	if err := RemoveLocalTUIKeys(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveLocalTUIKeys(filepath.Join(t.TempDir(), "missing.ini")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/pkg/config/user.go
+++ b/pkg/config/user.go
@@ -153,6 +153,15 @@ func LoadUserConfigAt(iniPath, appPath string, defaultConfig *UserConfig) (*User
 	defaultConfig.AppPath = appPath
 	defaultConfig.IniPath = iniPath
 
+	// Layer the shared [tui] file under the app's own INI. go-ini only assigns
+	// fields the file actually declares, so seeding here and mapping the app
+	// INI over it gives: app INI, then shared file, then built-in defaults.
+	shared, sharedErr := LoadSharedTUI(defaultConfig.TUI)
+	if sharedErr != nil {
+		return defaultConfig, sharedErr
+	}
+	defaultConfig.TUI = shared
+
 	// #nosec G703 -- configuration path is explicitly selected by caller.
 	if _, statErr := os.Stat(iniPath); statErr != nil {
 		if os.IsNotExist(statErr) {

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -17,15 +17,19 @@
 // You should have received a copy of the GNU General Public License
 // along with mrext. If not, see <http://www.gnu.org/licenses/>.
 
+//nolint:gosec // Tests only operate on temporary fixture paths.
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
 )
 
 func TestKeyboardModalMatchesCompactZaparooLayout(t *testing.T) {
@@ -501,5 +505,42 @@ func TestDialogAndHelpTextKeepBracketsInNames(t *testing.T) {
 	frame.Draw(screen)
 	if drawn := screenText(screen, 75, 15); !strings.Contains(drawn, "[U].mgl") {
 		t.Errorf("help line lost the brackets:\n%s", drawn)
+	}
+}
+
+func TestShareInterfaceSettingsWritesSharedFileAndClearsLocalKeys(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "tui.ini")
+	t.Setenv(config.SharedTUIConfigEnv, shared)
+
+	appINI := filepath.Join(t.TempDir(), "favorites.ini")
+	original := "[favorites]\ndefault_folder = _@Favorites\n\n[tui]\ntheme = default\nmouse = true\n"
+	if err := os.WriteFile(appINI, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	options := ApplicationOptions{Theme: "nord", Mouse: false, CRTMode: true, OnScreenKeyboard: true}
+	if err := ShareInterfaceSettings(appINI, options); err != nil {
+		t.Fatal(err)
+	}
+
+	// The shared file holds the choice.
+	saved, err := config.LoadSharedTUI(config.TUIConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.Theme != "nord" || saved.Mouse || !saved.CRTMode {
+		t.Fatalf("shared settings = %+v", saved)
+	}
+
+	// The app stops overriding it, but keeps everything else.
+	local, err := os.ReadFile(appINI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(local), "theme") {
+		t.Errorf("app INI still overrides the shared theme:\n%s", local)
+	}
+	if !strings.Contains(string(local), "_@Favorites") {
+		t.Errorf("unrelated settings were lost:\n%s", local)
 	}
 }

--- a/pkg/tui/layout.go
+++ b/pkg/tui/layout.go
@@ -101,3 +101,29 @@ func (r *responsiveWrapper) MouseHandler() func(
 ) (bool, tview.Primitive) {
 	return r.child.MouseHandler()
 }
+
+// BoolLabel renders a toggle. One spelling across every app: GamesMenu used to
+// say Yes/No while BGM and Favorites said On/Off for the same kind of setting.
+func BoolLabel(value bool) string {
+	if value {
+		return "On"
+	}
+	return "Off"
+}
+
+// ApplyOptions applies saved interface settings to a running application.
+// Every settings page repeated this same three-step block after saving.
+func ApplyOptions(app *tview.Application, root tview.Primitive, options ApplicationOptions) {
+	_ = SetCurrentTheme(options.Theme)
+	app.EnableMouse(options.Mouse)
+	app.SetRoot(WrapRoot(options, root), true)
+}
+
+// InterfaceSettingsHelp is the footer help for the shared [tui] settings, so
+// the same setting reads the same way in every app.
+var InterfaceSettingsHelp = map[string]string{
+	"Theme":              "Choose a color palette to apply after saving.",
+	"Mouse":              "Enable mouse input alongside keyboard and controller navigation.",
+	"CRT mode":           "Use a compact 75-column, 15-row layout for CRT displays.",
+	"On-screen keyboard": "Use controller-friendly text entry; Off needs a physical keyboard.",
+}

--- a/pkg/tui/page_frame.go
+++ b/pkg/tui/page_frame.go
@@ -217,6 +217,15 @@ func (pf *PageFrame) SetupContentToButtonNavigation() {
 	capture := list.GetInputCapture()
 	list.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
+		// Left, Right and Tab move between actions; Enter presses the
+		// highlighted one, which is what the "Enter: Confirm" hint promises.
+		//
+		// Routing Enter here means the list's own SetSelectedFunc is never
+		// reached while this navigation is installed. Pages still behave
+		// correctly because every one of them puts the row action first, so
+		// Enter on a row activates that row. Keep that invariant: a page whose
+		// first button is not its row action would make Enter do something
+		// else entirely.
 		case tcell.KeyLeft, tcell.KeyRight, tcell.KeyTab, tcell.KeyBacktab, tcell.KeyEnter:
 			if handler := pf.buttonBar.InputHandler(); handler != nil {
 				handler(event, func(tview.Primitive) {})

--- a/pkg/tui/shared_settings.go
+++ b/pkg/tui/shared_settings.go
@@ -1,0 +1,74 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"fmt"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// ShareInterfaceSettingsLabel names the row every settings page offers.
+const ShareInterfaceSettingsLabel = "Use in all apps"
+
+// ShareInterfaceSettingsHelp explains it in the footer.
+const ShareInterfaceSettingsHelp = "Save these interface settings for every mrext app."
+
+// ShareInterfaceSettings writes the given interface settings to the shared
+// file, then removes the app's own [tui] keys so the shared file is what the
+// app reads next time.
+//
+// Removing them is the point: an app INI that spells out theme, mouse and the
+// rest always wins over the shared file, and the default INIs written on first
+// run do exactly that. Without this the shared file would never take effect
+// for anyone who had already run the app once.
+func ShareInterfaceSettings(appINIPath string, options ApplicationOptions) error {
+	if err := config.SaveSharedTUI(config.TUIConfig{
+		Theme:            options.Theme,
+		Mouse:            options.Mouse,
+		CRTMode:          options.CRTMode,
+		OnScreenKeyboard: options.OnScreenKeyboard,
+	}); err != nil {
+		return fmt.Errorf("save shared interface settings: %w", err)
+	}
+	if appINIPath == "" {
+		return nil
+	}
+	if err := config.RemoveLocalTUIKeys(appINIPath); err != nil {
+		return fmt.Errorf("stop overriding shared settings in %s: %w", appINIPath, err)
+	}
+	return nil
+}
+
+// ConfirmShareInterfaceSettings asks before writing, because this changes what
+// other apps look like, not just this one.
+func ConfirmShareInterfaceSettings(
+	pages *tview.Pages, app *tview.Application, appINIPath string,
+	options ApplicationOptions, onDone func(error), onCancel func(),
+) {
+	ShowConfirmModal(pages, app,
+		"Use in all apps",
+		"Save this theme and interface layout for every mrext app?\n\n"+
+			"This app will follow the shared settings from now on.",
+		func() { onDone(ShareInterfaceSettings(appINIPath, options)) },
+		onCancel,
+	)
+}

--- a/pkg/tui/theme.go
+++ b/pkg/tui/theme.go
@@ -273,3 +273,12 @@ func ApplyTheme(theme *Theme) {
 	tview.Styles.SecondaryTextColor = theme.SecondaryTextColor
 	tview.Styles.InverseTextColor = theme.InverseTextColor
 }
+
+// ThemeLabel returns a theme's display name, falling back to its key. Every
+// settings page needs this; each app used to carry its own copy.
+func ThemeLabel(name string) string {
+	if theme := AvailableThemes[name]; theme != nil {
+		return theme.DisplayName
+	}
+	return name
+}


### PR DESCRIPTION
Stages 2 and 5 of the refresh plan, batched.

## The three shared-TUI apps had drifted apart

Every visible detail differed between BGM, Favorites and GamesMenu:

| | Before | Now |
|---|---|---|
| Settings title | `GamesMenu Settings` vs `Background Music > Settings` | breadcrumb everywhere |
| Toggles | GamesMenu `Yes`/`No`, others `On`/`Off` | `On`/`Off` |
| Theme list order | GamesMenu sorted map keys, others `tui.ThemeNames` | `tui.ThemeNames` |
| Settings help | three different sentences for the same three settings | one shared table |
| Button help | "Change the selected setting" vs "Change selected setting", etc. | one wording |
| Row kind | GamesMenu `MenuRowItem`, others `MenuRowAction` | `MenuRowAction` |
| Favorites list editor | no app name in title, `AddButton` with no help, no help callback | breadcrumb, help on all five buttons, live footer |

`themeLabel` was copy-pasted into all three apps, as was the `SetCurrentTheme` + `EnableMouse` + `SetRoot` block each ran after saving. Added `tui.ThemeLabel`, `tui.BoolLabel`, `tui.ApplyOptions` and `tui.InterfaceSettingsHelp`; all three now use them.

## Set your theme once

New optional `/media/fat/Scripts/.config/mrext/tui.ini`. Resolution order is **app INI, then shared file, then built-in defaults**, per key — an app INI still wins for anything it declares, so a user who never creates the shared file sees exactly today's behaviour.

`go-ini` only assigns fields the file declares, so seeding the defaults from the shared file before mapping the app INI gives that ordering for free. BGM keeps its own configparser-compatible reader for Python compatibility, so it does the same layering by hand against the keys `bgm.ini` actually declares.

### Why "Use in all apps" clears local keys

The settings pages gain a **Use in all apps** row, confirmed before it writes. It saves the shared file *and* removes the four keys from the app's own INI.

That second half matters: an app INI that spells out `theme`, `mouse`, `crt_mode` and `on_screen_keyboard` always beats the shared file, and the default INIs written on first run do exactly that. Without clearing them the shared file would never take effect for anyone who had already run the app once. Everything else in the INI, including comments and unrelated sections, is untouched.

## Also

Documented why `PageFrame.SetupContentToButtonNavigation` routes Enter to the button bar rather than the list. It makes each page's `list.SetSelectedFunc` unreachable, and pages only behave correctly because every one of them puts the row action first — an invariant that was undocumented and easy to break. Verified it holds across all ten button bars.

## Tests

- `pkg/config/sharedtui_test.go` — the four resolution cases (neither file, shared only, app only, both with the app winning per key), shared saves preserving unrelated sections and comments, and `RemoveLocalTUIKeys` keeping everything but the four keys (idempotent, and safe on a missing file).
- `pkg/tui/foundation_test.go` — sharing writes the shared file and clears the app's keys without losing its other settings.
- Existing settings-page row counts updated for the new row.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for bgm, favorites and gamesmenu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared interface settings for theme, mouse, CRT mode, and on-screen keyboard across mrext apps.
  - Added a “Use in all apps” option to save shared settings and remove conflicting app-specific overrides.
  - Improved settings navigation with responsive footer help.

- **Bug Fixes**
  - Settings pages now consistently display theme names, toggle states, titles, and help text.

- **Documentation**
  - Documented shared settings, configuration precedence, and application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->