### PR TITLE
feat(tui): give the console apps a face and report versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ mage lintFix              # apply auto-fixes, then re-run mage lint
 mage build <app>          # host binary into _bin/<os>_<arch>/
 mage mister <app>         # static linux/arm GOARM=7 CGO_ENABLED=0 binary for MiSTer
 mage mister all           # every app; also rebuilds the Remote web UI
+mage deploy <ip>          # build everything and scp it to root@<ip>:/media/fat/Scripts
 mage generateSystemMetadata   # refresh pkg/games/system_metadata.gen.json
 mage genSystemsDoc        # regenerate docs/systems.md after a catalog bump
 npm ci --prefix web/remote && npm test --prefix web/remote && npm run build --prefix web/remote

--- a/cmd/bgm/main.go
+++ b/cmd/bgm/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/wizzomafizzo/mrext/pkg/bgm"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 const (
@@ -47,13 +48,15 @@ const (
 var serviceTimeout = 5 * time.Second
 
 type cliOptions struct {
-	root    string
-	command string
+	root        string
+	command     string
+	showVersion bool
 }
 
 func parseCLI(args []string) (cliOptions, error) {
 	flags := flag.NewFlagSet("bgm", flag.ContinueOnError)
 	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	showVersion := flags.Bool("version", false, "print the version and exit")
 	if err := flags.Parse(args); err != nil {
 		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
 	}
@@ -61,7 +64,7 @@ func parseCLI(args []string) (cliOptions, error) {
 	if len(positionals) > 1 {
 		return cliOptions{}, errors.New(usage)
 	}
-	options := cliOptions{root: *root}
+	options := cliOptions{root: *root, showVersion: *showVersion}
 	if len(positionals) == 1 {
 		switch positionals[0] {
 		case commandExec, commandStart, commandStop, commandRestart:
@@ -124,6 +127,10 @@ func run(args []string, stdout io.Writer) error {
 	options, err := parseCLI(args)
 	if err != nil {
 		return err
+	}
+	if options.showVersion {
+		_, _ = fmt.Fprintf(stdout, "bgm %s\n", version.String())
+		return nil
 	}
 	application, err := newApp(options, stdout)
 	if err != nil {

--- a/cmd/contool/main.go
+++ b/cmd/contool/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/games"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 // Alternate names for systems.
@@ -213,7 +214,12 @@ func main() {
 	detect := flag.Bool("detect", false, "list active system folders")
 	noDupes := flag.Bool("nodupes", false, "filter out duplicate games")
 	launchPath := flag.String("launch", "", "launch game with given path")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "contool", version.String())
+		return
+	}
 
 	// launch game
 	if *launchPath != "" {

--- a/cmd/favorites/main.go
+++ b/cmd/favorites/main.go
@@ -28,16 +28,19 @@ import (
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/favorites"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 type cliOptions struct {
-	root    string
-	command string
+	root        string
+	command     string
+	showVersion bool
 }
 
 func parseCLI(args []string) (cliOptions, error) {
 	flags := flag.NewFlagSet("favorites", flag.ContinueOnError)
 	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	showVersion := flags.Bool("version", false, "print the version and exit")
 	if err := flags.Parse(args); err != nil {
 		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
 	}
@@ -45,7 +48,7 @@ func parseCLI(args []string) (cliOptions, error) {
 	if len(positionals) > 1 || len(positionals) == 1 && positionals[0] != "refresh" {
 		return cliOptions{}, errors.New("usage: favorites.sh [--root PATH] [refresh]")
 	}
-	options := cliOptions{root: *root}
+	options := cliOptions{root: *root, showVersion: *showVersion}
 	if len(positionals) == 1 {
 		options.command = positionals[0]
 	}
@@ -92,6 +95,10 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
+	if options.showVersion {
+		_, _ = fmt.Printf("favorites %s\n", version.String())
+		return nil
+	}
 	cfg, manager, err := loadRuntime(options.root)
 	if err != nil {
 		return fmt.Errorf("load Favorites configuration: %w", err)
@@ -123,13 +130,22 @@ func run(args []string) error {
 		}
 	}()
 
-	if setupErr := manager.SetupArcadeLinks(); setupErr != nil {
-		return fmt.Errorf("prepare arcade links: %w", setupErr)
-	}
-	if refreshErr := manager.Refresh(); refreshErr != nil {
-		return fmt.Errorf("refresh Favorites: %w", refreshErr)
-	}
-	return newUI(cfg, manager).Run()
+	// SetupArcadeLinks walks every favourites folder and Refresh stats every
+	// favourite, so both run inside the app behind a progress modal rather
+	// than as dead air before the first frame.
+	view := newUI(cfg, manager)
+	view.SetStartupWork(func(report func(string)) error {
+		report("Checking arcade core links...")
+		if setupErr := manager.SetupArcadeLinks(); setupErr != nil {
+			return fmt.Errorf("prepare arcade links: %w", setupErr)
+		}
+		report("Refreshing favorites...")
+		if refreshErr := manager.Refresh(); refreshErr != nil {
+			return fmt.Errorf("refresh Favorites: %w", refreshErr)
+		}
+		return nil
+	})
+	return view.Run()
 }
 
 func main() {

--- a/cmd/favorites/settings.go
+++ b/cmd/favorites/settings.go
@@ -188,7 +188,6 @@ func (s *settingsPage) addText(
 		selection := s.list.GetCurrentItem()
 		s.ui.showNameInput(tui.InputOptions{
 			Title:        "Edit " + label,
-			Prompt:       "Enter " + strings.ToLower(label) + ".",
 			InitialValue: value,
 			Validate:     validate,
 		}, func(updated string) {

--- a/cmd/favorites/ui.go
+++ b/cmd/favorites/ui.go
@@ -48,6 +48,7 @@ type ui struct {
 	pages            *tview.Pages
 	options          tui.ApplicationOptions
 	mainSelection    int
+	startupWork      func(report func(string)) error
 	browserSelection map[string]int
 }
 
@@ -72,6 +73,14 @@ func newUI(cfg *config.UserConfig, manager *favorites.Manager) *ui {
 	}
 }
 
+// SetStartupWork registers the arcade-link walk and refresh that used to run
+// before anything was drawn. On a large favourites tree, or one on USB or a
+// network share, that was several seconds of blank screen with no way to tell
+// whether the app had hung.
+func (u *ui) SetStartupWork(work func(report func(string)) error) {
+	u.startupWork = work
+}
+
 func (u *ui) Run() error {
 	builder := func() (*tview.Application, error) {
 		app, err := tui.NewApplication(u.options)
@@ -84,12 +93,34 @@ func (u *ui) Run() error {
 			return nil, err
 		}
 		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
+		u.runStartupWork()
 		return app, nil
 	}
 	if err := tui.BuildAndRetry(builder); err != nil {
 		return fmt.Errorf("run Favorites TUI: %w", err)
 	}
 	return nil
+}
+
+// runStartupWork performs the slow startup steps behind a progress modal, then
+// redraws the list so it reflects what the refresh changed.
+func (u *ui) runStartupWork() {
+	if u.startupWork == nil {
+		return
+	}
+	options := tui.ProgressOptions{
+		Title:   "Favorites",
+		Initial: tui.ProgressUpdate{Text: "Checking favorites..."},
+	}
+	tui.ShowProgressModal(u.pages, u.app, options, func(update func(tui.ProgressUpdate)) error {
+		return u.startupWork(func(step string) { update(tui.ProgressUpdate{Text: step}) })
+	}, func(err error) {
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		u.mustShowMain()
+	})
 }
 
 func (u *ui) showMain() error {
@@ -171,12 +202,47 @@ func (u *ui) createFolder(onReturn func()) {
 	}, onReturn)
 }
 
+// showBrowser lists a folder. Reading a ZIP's members is the slow case, and
+// the Python original carried a FIXME about it, so that one goes behind a
+// progress modal instead of freezing on the previous screen.
 func (u *ui) showBrowser(folder string) {
-	entries, err := u.manager.ListDirectory(folder)
-	if err != nil {
-		u.showError(err, u.mustShowMain)
+	if !insideArchive(folder) {
+		entries, err := u.manager.ListDirectory(folder)
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		u.renderBrowser(folder, entries)
 		return
 	}
+
+	var entries []favorites.BrowseEntry
+	options := tui.ProgressOptions{
+		Title:   "Favorites",
+		Initial: tui.ProgressUpdate{Text: "Reading " + filepath.Base(strings.TrimSuffix(folder, "/")) + "..."},
+	}
+	tui.ShowProgressModal(u.pages, u.app, options, func(func(tui.ProgressUpdate)) error {
+		listed, err := u.manager.ListDirectory(folder)
+		if err != nil {
+			return fmt.Errorf("list archive contents: %w", err)
+		}
+		entries = listed
+		return nil
+	}, func(err error) {
+		if err != nil {
+			u.showError(err, u.mustShowMain)
+			return
+		}
+		u.renderBrowser(folder, entries)
+	})
+}
+
+// insideArchive reports a browse path that reaches into a ZIP.
+func insideArchive(folder string) bool {
+	return strings.Contains(strings.ToLower(folder), ".zip"+string(filepath.Separator))
+}
+
+func (u *ui) renderBrowser(folder string, entries []favorites.BrowseEntry) {
 	choices := make([]browserChoice, 0, len(entries)+2)
 	list := tui.NewMenuList()
 

--- a/cmd/favorites/ui.go
+++ b/cmd/favorites/ui.go
@@ -93,7 +93,11 @@ func (u *ui) Run() error {
 			return nil, err
 		}
 		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
-		u.runStartupWork()
+		// Deferred until this application is actually drawing. BuildAndRetry
+		// builds a second one to retry on /dev/tty2, so work started directly
+		// in a builder runs twice, and Refresh removes and recreates symlinks:
+		// two passes would race over the user's favourites.
+		tui.RunWhenStarted(app, u.runStartupWork)
 		return app, nil
 	}
 	if err := tui.BuildAndRetry(builder); err != nil {
@@ -108,10 +112,7 @@ func (u *ui) runStartupWork() {
 	if u.startupWork == nil {
 		return
 	}
-	options := tui.ProgressOptions{
-		Title:   "Favorites",
-		Initial: tui.ProgressUpdate{Text: "Checking favorites..."},
-	}
+	options := tui.ProgressOptions{Initial: tui.ProgressUpdate{Text: "Checking favorites..."}}
 	tui.ShowProgressModal(u.pages, u.app, options, func(update func(tui.ProgressUpdate)) error {
 		return u.startupWork(func(step string) { update(tui.ProgressUpdate{Text: step}) })
 	}, func(err error) {
@@ -218,7 +219,6 @@ func (u *ui) showBrowser(folder string) {
 
 	var entries []favorites.BrowseEntry
 	options := tui.ProgressOptions{
-		Title:   "Favorites",
 		Initial: tui.ProgressUpdate{Text: "Reading " + filepath.Base(strings.TrimSuffix(folder, "/")) + "..."},
 	}
 	tui.ShowProgressModal(u.pages, u.app, options, func(func(tui.ProgressUpdate)) error {
@@ -357,7 +357,6 @@ func (u *ui) startAddFavorite(entry favorites.BrowseEntry) {
 		defaultName := u.manager.DefaultName(entry.System, entry.Path)
 		u.showNameInput(tui.InputOptions{
 			Title:        "Favorite Name",
-			Prompt:       "Enter a display name for the favorite.",
 			InitialValue: defaultName,
 			Validate:     favorites.ValidateDisplayName,
 		}, func(name string) {
@@ -488,13 +487,17 @@ func (u *ui) showModify(item *favorites.Favorite) {
 
 func (u *ui) renameItem(item *favorites.Favorite, initial string) {
 	validator := favorites.ValidateDisplayName
+	prompt := ""
 	if item.Kind == favorites.FavoriteFolder {
 		validator = favorites.ValidateFolderName
 		initial = filepath.Base(item.Path)
+		// Renaming a folder has a rule renaming a favorite does not, and the
+		// same rule is spelled out when a folder is created.
+		prompt = "It must start with an underscore (_)."
 	}
 	u.showNameInput(tui.InputOptions{
 		Title:        "Rename Favorite",
-		Prompt:       "Enter a new display name.",
+		Prompt:       prompt,
 		InitialValue: initial,
 		Validate:     validator,
 	}, func(name string) {

--- a/cmd/favorites/ui_test.go
+++ b/cmd/favorites/ui_test.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -121,16 +122,55 @@ func TestCancelAddInsideArchiveReturnsToBrowser(t *testing.T) {
 	if closeErr := file.Close(); closeErr != nil {
 		t.Fatal(closeErr)
 	}
+	// Returning to an archive listing now goes through a progress modal, which
+	// needs a running application to resolve its QueueUpdateDraw.
+	screen := tcell.NewSimulationScreen("UTF-8")
+	view.app.SetScreen(screen)
+	screen.SetSize(75, 15)
+	done := make(chan error, 1)
+	go func() { done <- view.app.Run() }()
+	t.Cleanup(func() {
+		view.app.Stop()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Error(err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("UI did not stop")
+		}
+	})
+
+	waitForBrowser := func(cancelName bool) {
+		t.Helper()
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			var page string
+			var failed bool
+			view.app.QueueUpdate(func() {
+				page, _ = view.pages.GetFrontPage()
+				failed = view.pages.HasPage("tui_error_modal")
+			})
+			if failed {
+				t.Fatalf("cancelName=%v raised an error modal", cancelName)
+			}
+			if page == pageBrowser {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatalf("cancelName=%v did not return to the browser", cancelName)
+	}
+
 	for _, cancelName := range []bool{false, true} {
-		view.startAddFavorite(favorites.BrowseEntry{Path: archive + "/game.sfc"})
-		if cancelName {
-			sendUIKey(view, tcell.KeyEnter, 0)
-		}
-		sendUIKey(view, tcell.KeyEscape, 0)
-		page, _ := view.pages.GetFrontPage()
-		if page != pageBrowser || view.pages.HasPage("tui_error_modal") {
-			t.Fatalf("cancelName=%v returned to %s", cancelName, page)
-		}
+		view.app.QueueUpdateDraw(func() {
+			view.startAddFavorite(favorites.BrowseEntry{Path: archive + "/game.sfc"})
+			if cancelName {
+				sendUIKey(view, tcell.KeyEnter, 0)
+			}
+			sendUIKey(view, tcell.KeyEscape, 0)
+		})
+		waitForBrowser(cancelName)
 	}
 }
 

--- a/cmd/gamesmenu/main.go
+++ b/cmd/gamesmenu/main.go
@@ -28,20 +28,25 @@ import (
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/gamesmenu"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
-type cliOptions struct{ root string }
+type cliOptions struct {
+	root        string
+	showVersion bool
+}
 
 func parseCLI(args []string) (cliOptions, error) {
 	flags := flag.NewFlagSet("gamesmenu", flag.ContinueOnError)
 	root := flags.String("root", "", "use a local MiSTer filesystem root")
+	showVersion := flags.Bool("version", false, "print the version and exit")
 	if err := flags.Parse(args); err != nil {
 		return cliOptions{}, fmt.Errorf("parse arguments: %w", err)
 	}
 	if flags.NArg() != 0 {
 		return cliOptions{}, errors.New("usage: gamesmenu.sh [--root PATH]")
 	}
-	return cliOptions{root: *root}, nil
+	return cliOptions{root: *root, showVersion: *showVersion}, nil
 }
 
 func loadRuntime(root string) (*config.UserConfig, *gamesmenu.Manager, error) {
@@ -82,6 +87,10 @@ func run(args []string) error {
 	options, err := parseCLI(args)
 	if err != nil {
 		return err
+	}
+	if options.showVersion {
+		_, _ = fmt.Printf("gamesmenu %s\n", version.String())
+		return nil
 	}
 	cfg, manager, err := loadRuntime(options.root)
 	if err != nil {

--- a/cmd/lastplayed/main.go
+++ b/cmd/lastplayed/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/service"
 	"github.com/wizzomafizzo/mrext/pkg/tracker"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 const (
@@ -331,34 +332,43 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 	}, nil
 }
 
-func tryAddStartup() error {
+// startupInstalled reports whether the boot entry is present.
+func startupInstalled() (bool, error) {
 	var startup mister.Startup
+	if err := startup.Load(); err != nil {
+		return false, fmt.Errorf("load startup configuration: %w", err)
+	}
+	return startup.Exists("mrext/" + appName), nil
+}
 
-	err := startup.Load()
-	if err != nil {
+// addToStartup installs the boot entry. The question that used to gate this
+// was a raw-terminal arrow-key prompt; it is now the shared confirm dialog, so
+// it looks and behaves like every other question the apps ask.
+func addToStartup() error {
+	var startup mister.Startup
+	if err := startup.Load(); err != nil {
 		return fmt.Errorf("load startup configuration: %w", err)
 	}
-
-	if !startup.Exists("mrext/" + appName) {
-		if utils.YesOrNoPrompt("LastPlayed must be set to run on MiSTer startup. Add it now?") {
-			err = startup.AddService("mrext/" + appName)
-			if err != nil {
-				return fmt.Errorf("add LastPlayed startup service: %w", err)
-			}
-
-			err = startup.Save()
-			if err != nil {
-				return fmt.Errorf("save startup configuration: %w", err)
-			}
-		}
+	if startup.Exists("mrext/" + appName) {
+		return nil
 	}
-
+	if err := startup.AddService("mrext/" + appName); err != nil {
+		return fmt.Errorf("add LastPlayed startup service: %w", err)
+	}
+	if err := startup.Save(); err != nil {
+		return fmt.Errorf("save startup configuration: %w", err)
+	}
 	return nil
 }
 
 func main() {
 	svcOpt := flag.String("service", "", "manage lastplayed service (start, stop, restart, status)")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "lastplayed", version.String())
+		return
+	}
 
 	logger := service.NewLogger(appName)
 
@@ -403,13 +413,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// -service is how user-startup.sh and the shell invoke this, and it must
+	// stay headless. ServiceHandler exits for every command it recognises.
 	svc.ServiceHandler(svcOpt)
-
-	err = tryAddStartup()
-	if err != nil {
-		logger.Error("error adding startup: %s", err)
-		_, _ = fmt.Println("Error adding to startup:", err)
-	}
 
 	if !svc.Running() {
 		if startErr := svc.Start(); startErr != nil {
@@ -417,10 +423,14 @@ func main() {
 			_, _ = fmt.Println("Error starting service:", startErr)
 			os.Exit(1)
 		}
-		_, _ = fmt.Println("Service started successfully.")
-		os.Exit(0)
 	}
 
-	_, _ = fmt.Println("Service is running.")
+	// Interactive launch from the Scripts menu shows the service screen rather
+	// than printing one line and exiting.
+	if screenErr := showServiceScreen(svc, cfg); screenErr != nil {
+		logger.Error("error showing service screen: %s", screenErr)
+		_, _ = fmt.Println(screenErr)
+		os.Exit(1)
+	}
 	os.Exit(0)
 }

--- a/cmd/lastplayed/ui.go
+++ b/cmd/lastplayed/ui.go
@@ -126,26 +126,45 @@ func confirmUninstall(
 		done)
 }
 
+// uninstallService keeps the blocking half off the event goroutine. Stopping a
+// service waits for the process to exit and rewriting user-startup.sh is disk
+// I/O, and doing either inline froze the screen for as long as it took.
+// ServicePage.run already keeps Start, Stop and Restart off it, but Uninstall
+// is called straight from its button and has to arrange this itself.
 func uninstallService(
 	pages *tview.Pages, app *tview.Application, svc *service.Service, cfg *config.UserConfig, done func(),
 ) {
-	var report strings.Builder
-	if svc.Running() {
-		if err := svc.Stop(); err != nil {
-			_, _ = fmt.Fprintf(&report, "Could not stop the service: %s\n", err)
-		} else {
-			_, _ = report.WriteString("Stopped the service.\n")
-		}
-	}
-	if err := removeFromStartup(); err != nil {
-		_, _ = fmt.Fprintf(&report, "Could not remove the startup entry: %s\n", err)
-	} else {
-		_, _ = report.WriteString("Removed the startup entry.\n")
-	}
+	report := &strings.Builder{}
+	options := tui.ProgressOptions{Initial: tui.ProgressUpdate{Text: "Stopping the service..."}}
+	tui.ShowProgressModal(pages, app, options, func(update func(tui.ProgressUpdate)) error {
+		stopService(svc, report)
+		update(tui.ProgressUpdate{Text: "Removing the startup entry..."})
+		clearStartupEntry(report)
+		return nil
+	}, func(error) {
+		// Config and generated menu entries are asked about separately, and only
+		// after the service is actually stopped.
+		askRemoveShortcuts(pages, app, cfg, report, done)
+	})
+}
 
-	// Config and generated menu entries are asked about separately, and only
-	// after the service is actually stopped.
-	askRemoveShortcuts(pages, app, cfg, &report, done)
+func stopService(svc *service.Service, report *strings.Builder) {
+	if !svc.Running() {
+		return
+	}
+	if err := svc.Stop(); err != nil {
+		_, _ = fmt.Fprintf(report, "Could not stop the service: %s\n", err)
+		return
+	}
+	_, _ = report.WriteString("Stopped the service.\n")
+}
+
+func clearStartupEntry(report *strings.Builder) {
+	if err := removeFromStartup(); err != nil {
+		_, _ = fmt.Fprintf(report, "Could not remove the startup entry: %s\n", err)
+		return
+	}
+	_, _ = report.WriteString("Removed the startup entry.\n")
 }
 
 func askRemoveShortcuts(
@@ -158,8 +177,11 @@ func askRemoveShortcuts(
 	tui.ShowConfirmModal(pages, app, "Remove shortcuts",
 		"Also delete the generated Last Played shortcut and Recently Played folder?",
 		func() {
-			removeGenerated(cfg, report)
-			finish()
+			options := tui.ProgressOptions{Initial: tui.ProgressUpdate{Text: "Removing shortcuts..."}}
+			tui.ShowProgressModal(pages, app, options, func(func(tui.ProgressUpdate)) error {
+				removeGenerated(cfg, report)
+				return nil
+			}, func(error) { finish() })
 		},
 		finish)
 }

--- a/cmd/lastplayed/ui.go
+++ b/cmd/lastplayed/ui.go
@@ -1,0 +1,208 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+	"github.com/wizzomafizzo/mrext/pkg/service"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+	"github.com/wizzomafizzo/mrext/pkg/version"
+)
+
+const (
+	appTitle    = "LastPlayed"
+	pageService = "lastplayed_service"
+)
+
+// showServiceScreen replaces the console output this app used to print. It is
+// the same screen Remote has offered for years, so the state and the actions
+// are visible instead of scrolling past.
+func showServiceScreen(svc *service.Service, cfg *config.UserConfig) error {
+	options := tui.ApplicationOptions{
+		Theme:            cfg.TUI.Theme,
+		Mouse:            cfg.TUI.Mouse,
+		CRTMode:          cfg.TUI.CRTMode,
+		OnScreenKeyboard: cfg.TUI.OnScreenKeyboard,
+	}
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		pages := tview.NewPages()
+		var page *tui.ServicePage
+		page = tui.NewServicePage(app, pages, appTitle, tui.ServiceActions{
+			Running: svc.Running,
+			Start:   svc.Start,
+			Stop:    svc.Stop,
+			Restart: svc.Restart,
+			Exit:    app.Stop,
+			Uninstall: func() {
+				confirmUninstall(pages, app, svc, cfg, func() { page.Redraw() })
+			},
+			Status: func(running bool) string { return serviceStatus(running, cfg) },
+		})
+		page.Frame().SetVersion(version.Short())
+		page.Show(pageService)
+		app.SetRoot(tui.WrapRoot(options, pages), true)
+
+		// Same question the console prompt used to ask, on the shared dialog.
+		installed, err := startupInstalled()
+		if err != nil {
+			tui.ShowErrorModal(pages, app, err.Error(), func() { page.Redraw() })
+			return app, nil
+		}
+		if !installed {
+			tui.ShowConfirmModal(pages, app, appTitle,
+				appTitle+" must run on MiSTer startup to keep shortcuts up to date.\n\nAdd it now?",
+				func() {
+					if addErr := addToStartup(); addErr != nil {
+						tui.ShowErrorModal(pages, app, addErr.Error(), func() { page.Redraw() })
+						return
+					}
+					page.Redraw()
+				},
+				func() { page.Redraw() })
+		}
+		return app, nil
+	}
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run LastPlayed TUI: %w", err)
+	}
+	return nil
+}
+
+func serviceStatus(running bool, cfg *config.UserConfig) string {
+	state := "Service is NOT RUNNING"
+	if running {
+		state = "Service is RUNNING"
+	}
+	shortcut := cfg.LastPlayed.LastPlayedName
+	if shortcut == "" {
+		shortcut = defaultLastPlayedName
+	}
+	folder := cfg.LastPlayed.RecentFolderName
+	if folder == "" {
+		folder = defaultRecentFolderName
+	}
+	return fmt.Sprintf(
+		"%s\n\nShortcut: %s\nRecent folder: _%s\n\nIt's safe to exit; the service keeps running.",
+		state, shortcut, folder,
+	)
+}
+
+// confirmUninstall walks the removals separately, because deleting a menu
+// folder someone has curated is a different decision from stopping a service.
+func confirmUninstall(
+	pages *tview.Pages, app *tview.Application, svc *service.Service, cfg *config.UserConfig, done func(),
+) {
+	tui.ShowConfirmModal(pages, app, "Uninstall "+appTitle,
+		"Stop the service and remove "+appTitle+" from MiSTer startup?",
+		func() { uninstallService(pages, app, svc, cfg, done) },
+		done)
+}
+
+func uninstallService(
+	pages *tview.Pages, app *tview.Application, svc *service.Service, cfg *config.UserConfig, done func(),
+) {
+	var report strings.Builder
+	if svc.Running() {
+		if err := svc.Stop(); err != nil {
+			_, _ = fmt.Fprintf(&report, "Could not stop the service: %s\n", err)
+		} else {
+			_, _ = report.WriteString("Stopped the service.\n")
+		}
+	}
+	if err := removeFromStartup(); err != nil {
+		_, _ = fmt.Fprintf(&report, "Could not remove the startup entry: %s\n", err)
+	} else {
+		_, _ = report.WriteString("Removed the startup entry.\n")
+	}
+
+	// Config and generated menu entries are asked about separately, and only
+	// after the service is actually stopped.
+	askRemoveShortcuts(pages, app, cfg, &report, done)
+}
+
+func askRemoveShortcuts(
+	pages *tview.Pages, app *tview.Application, cfg *config.UserConfig, report *strings.Builder, done func(),
+) {
+	finish := func() {
+		tui.ShowInfoModal(pages, app, "Uninstall "+appTitle,
+			report.String()+"\nDelete "+config.ScriptsFolder+"/lastplayed.sh to finish.", done)
+	}
+	tui.ShowConfirmModal(pages, app, "Remove shortcuts",
+		"Also delete the generated Last Played shortcut and Recently Played folder?",
+		func() {
+			removeGenerated(cfg, report)
+			finish()
+		},
+		finish)
+}
+
+func removeGenerated(cfg *config.UserConfig, report *strings.Builder) {
+	shortcut := cfg.LastPlayed.LastPlayedName
+	if shortcut == "" {
+		shortcut = defaultLastPlayedName
+	}
+	folder := cfg.LastPlayed.RecentFolderName
+	if folder == "" {
+		folder = defaultRecentFolderName
+	}
+	for _, extension := range []string{".mgl", ".mra"} {
+		path := filepath.Join(config.SdFolder, shortcut+extension)
+		if err := os.Remove(path); err == nil {
+			_, _ = fmt.Fprintf(report, "Removed %s.\n", path)
+		} else if !os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(report, "Could not remove %s: %s\n", path, err)
+		}
+	}
+	recent := filepath.Join(config.SdFolder, "_"+folder)
+	if err := os.RemoveAll(recent); err != nil {
+		_, _ = fmt.Fprintf(report, "Could not remove %s: %s\n", recent, err)
+		return
+	}
+	_, _ = fmt.Fprintf(report, "Removed %s.\n", recent)
+}
+
+func removeFromStartup() error {
+	var startup mister.Startup
+	if err := startup.Load(); err != nil {
+		return fmt.Errorf("load startup configuration: %w", err)
+	}
+	name := "mrext/" + appName
+	if !startup.Exists(name) {
+		return nil
+	}
+	if err := startup.Remove(name); err != nil {
+		return fmt.Errorf("remove startup entry: %w", err)
+	}
+	if err := startup.Save(); err != nil {
+		return fmt.Errorf("save startup configuration: %w", err)
+	}
+	return nil
+}

--- a/cmd/launchsync/main.go
+++ b/cmd/launchsync/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -32,6 +33,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/games"
 	"github.com/wizzomafizzo/mrext/pkg/gamesdb"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 // TODO: handle filename being too long (255 chars)
@@ -124,7 +126,10 @@ func testSyncFile(cfg *config.UserConfig, path string) {
 	}
 }
 
-func findSyncFiles(verbose, update *bool) []syncFile {
+// findSyncFiles reports unreadable sync files through report rather than
+// printing them, so the same code serves the console log and the progress
+// modal without writing underneath a drawn screen.
+func findSyncFiles(report func(string)) []syncFile {
 	menuFolders := mister.GetMenuFolders(config.SdFolder)
 	menuFolders = append(menuFolders, config.SdFolder)
 	syncFiles := getSyncFiles(menuFolders)
@@ -133,9 +138,7 @@ func findSyncFiles(verbose, update *bool) []syncFile {
 	for _, path := range syncFiles {
 		sf, err := readSyncFile(path)
 		if err != nil {
-			if *verbose || !*update {
-				_, _ = fmt.Printf("Error reading %s: %s\n", path, err)
-			}
+			report(fmt.Sprintf("Error reading %s: %s", path, err))
 			continue
 		}
 		syncs = append(syncs, sf)
@@ -144,13 +147,97 @@ func findSyncFiles(verbose, update *bool) []syncFile {
 	return syncs
 }
 
+// syncOutcome is what one sync file produced, for the summary page.
+type syncOutcome struct {
+	name    string
+	found   int
+	missing int
+	failed  int
+}
+
+// runSync performs the whole sync, reporting each step as a complete line.
+// The console path prints those lines exactly as it always did; the TUI path
+// shows the latest one in a progress modal and the outcomes on a summary page.
+func runSync(cfg *config.UserConfig, report func(string)) ([]syncOutcome, error) {
+	report("Searching for sync files...")
+	syncs := findSyncFiles(report)
+	if len(syncs) == 0 {
+		return nil, errors.New("no sync files found")
+	}
+	report(fmt.Sprintf("Found %d sync file(s).", len(syncs)))
+
+	report("Checking for updates...")
+	for i := range syncs {
+		sync := &syncs[i]
+		newSync, updated, changeErr := checkForChanges(sync)
+		switch {
+		case changeErr != nil:
+			report(fmt.Sprintf("%d/%d: %s... error: %s", i+1, len(syncs), sync.name, changeErr))
+		case updated:
+			syncs[i] = newSync
+			report(fmt.Sprintf("%d/%d: %s... updated", i+1, len(syncs), sync.name))
+		default:
+			report(fmt.Sprintf("%d/%d: %s... no update", i+1, len(syncs), sync.name))
+		}
+	}
+
+	report("Building games index...")
+	if err := makeIndex(cfg, syncs); err != nil {
+		return nil, fmt.Errorf("error generating index: %w", err)
+	}
+	report("Building games index... done")
+
+	outcomes := make([]syncOutcome, 0, len(syncs))
+	for syncIndex := range syncs {
+		sync := &syncs[syncIndex]
+		report("---")
+		report("Name:    " + sync.name)
+		report("Author:  " + sync.author)
+		report("URL:     " + sync.url)
+		report(fmt.Sprintf("Updated: %s", sync.updated))
+		report("Folder:  " + sync.folder)
+		report("Games:")
+
+		// #nosec G301 -- generated launcher directory must remain world-readable.
+		if err := os.MkdirAll(sync.folder, 0o755); err != nil {
+			return outcomes, fmt.Errorf("error creating folder: %w", err)
+		}
+
+		outcome := syncOutcome{name: sync.name}
+		for gameIndex := range sync.games {
+			game := &sync.games[gameIndex]
+			file, found, err := tryLinkGame(cfg, sync, game)
+			switch {
+			case err != nil:
+				outcome.failed++
+				report("- " + game.name + "... error: " + err.Error())
+			case found:
+				outcome.found++
+				report("- " + game.name + "... found " + file)
+			default:
+				outcome.missing++
+				report("- " + game.name + "... not found")
+			}
+		}
+		outcomes = append(outcomes, outcome)
+	}
+	return outcomes, nil
+}
+
 func main() {
 	update := flag.Bool("update", false, "find, update and link all sync files on system")
 	verbose := flag.Bool("verbose", false, "print status information during update")
 	test := flag.String("test", "", "report if specified sync file is valid and display match results")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "launchsync", version.String())
+		return
+	}
 
-	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{})
+	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{
+		TUI: config.TUIConfig{Theme: "default", Mouse: true, CRTMode: true},
+	})
 	if err != nil {
 		_, _ = fmt.Println("Error loading config file:", err)
 		os.Exit(1)
@@ -161,96 +248,31 @@ func main() {
 		return
 	}
 
-	if *verbose || !*update {
-		_, _ = fmt.Print("Searching for sync files... ")
+	// -update is how a script or a startup hook runs this, so it keeps the
+	// console log and never draws a screen. A plain run from the Scripts menu
+	// gets the shared interface.
+	if *update {
+		runConsole(cfg, *verbose)
+		return
 	}
-	syncs := findSyncFiles(verbose, update)
-
-	if len(syncs) == 0 {
-		if *verbose || !*update {
-			_, _ = fmt.Println("no sync files found")
-		}
+	if err := showSyncScreen(cfg); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	if *verbose || !*update {
-		_, _ = fmt.Printf("found %d\n", len(syncs))
-	}
+}
 
-	if *verbose || !*update {
-		_, _ = fmt.Println("Checking for updates...")
-	}
-	for i := range syncs {
-		sync := &syncs[i]
-		if *verbose || !*update {
-			_, _ = fmt.Printf("%d/%d: %s... ", i+1, len(syncs), sync.name)
-		}
-		newSync, updated, changeErr := checkForChanges(sync)
-		switch {
-		case changeErr != nil:
-			if *verbose || !*update {
-				_, _ = fmt.Printf("error: %s\n", changeErr)
-			}
-		case updated:
-			syncs[i] = newSync
-			if *verbose || !*update {
-				_, _ = fmt.Println("updated")
-			}
-		case *verbose || !*update:
-			_, _ = fmt.Println("no update")
+// runConsole keeps the original non-interactive behaviour: the same lines, in
+// the same order, and exit 1 on failure.
+func runConsole(cfg *config.UserConfig, printLines bool) {
+	report := func(line string) {
+		if printLines {
+			_, _ = fmt.Println(line)
 		}
 	}
-
-	if *verbose || !*update {
-		_, _ = fmt.Print("Building games index... ")
-	}
-	err = makeIndex(cfg, syncs)
-	if err != nil {
-		if *verbose || !*update {
-			_, _ = fmt.Printf("error generating index: %s\n", err)
+	if _, err := runSync(cfg, report); err != nil {
+		if printLines {
+			_, _ = fmt.Println(err)
 		}
 		os.Exit(1)
-	}
-	if *verbose || !*update {
-		_, _ = fmt.Println("done")
-	}
-
-	for syncIndex := range syncs {
-		sync := &syncs[syncIndex]
-		if *verbose || !*update {
-			_, _ = fmt.Println("---")
-			_, _ = fmt.Printf("Name:    %s\n", sync.name)
-			_, _ = fmt.Printf("Author:  %s\n", sync.author)
-			_, _ = fmt.Printf("URL:     %s\n", sync.url)
-			_, _ = fmt.Printf("Updated: %s\n", sync.updated)
-			_, _ = fmt.Printf("Folder:  %s\n", sync.folder)
-			_, _ = fmt.Println("Games:")
-		}
-
-		// #nosec G301 -- generated launcher directory must remain world-readable.
-		err := os.MkdirAll(sync.folder, 0o755)
-		if err != nil {
-			if *verbose || !*update {
-				_, _ = fmt.Printf("error creating folder: %s\n", err)
-			}
-			os.Exit(1)
-		}
-
-		for gameIndex := range sync.games {
-			game := &sync.games[gameIndex]
-			if *verbose || !*update {
-				_, _ = fmt.Print("- " + game.name + "... ")
-			}
-			file, found, err := tryLinkGame(cfg, sync, game)
-			if *verbose || !*update {
-				switch {
-				case err != nil:
-					_, _ = fmt.Printf("error: %s\n", err)
-				case found:
-					_, _ = fmt.Printf("found %s\n", file)
-				default:
-					_, _ = fmt.Println("not found")
-				}
-			}
-		}
 	}
 }

--- a/cmd/launchsync/main.go
+++ b/cmd/launchsync/main.go
@@ -255,10 +255,20 @@ func main() {
 		runConsole(cfg, *verbose)
 		return
 	}
-	if err := showSyncScreen(cfg); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+	started, screenErr := showSyncScreen(cfg)
+	if screenErr == nil {
+		return
+	}
+	if started {
+		// A screen came up and the sync ran inside it, so this is a real
+		// failure. Re-running here would rewrite every shortcut again.
+		_, _ = fmt.Fprintln(os.Stderr, screenErr)
 		os.Exit(1)
 	}
+	// No screen was ever obtained and nothing ran, so this is a headless
+	// invocation: cron, ssh without a tty, a wrapper script. Behave the way a
+	// bare "launchsync" always did and print the log.
+	runConsole(cfg, true)
 }
 
 // runConsole keeps the original non-interactive behaviour: the same lines, in

--- a/cmd/launchsync/ui.go
+++ b/cmd/launchsync/ui.go
@@ -22,6 +22,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/rivo/tview"
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -38,16 +39,20 @@ const (
 // did. The console log this replaces printed "Building games index... " with
 // no newline and then blocked through the whole scan, so a slow step looked
 // like a hang.
-func showSyncScreen(cfg *config.UserConfig) error {
+//
+// It reports whether a screen was ever obtained, so a headless run can fall
+// back to the console instead of exiting having done nothing.
+func showSyncScreen(cfg *config.UserConfig) (started bool, err error) {
 	options := tui.ApplicationOptions{
 		Theme:   cfg.TUI.Theme,
 		Mouse:   cfg.TUI.Mouse,
 		CRTMode: cfg.TUI.CRTMode,
 	}
+	var drew *atomic.Bool
 	builder := func() (*tview.Application, error) {
-		app, err := tui.NewApplication(options)
-		if err != nil {
-			return nil, fmt.Errorf("create TUI application: %w", err)
+		app, buildErr := tui.NewApplication(options)
+		if buildErr != nil {
+			return nil, fmt.Errorf("create TUI application: %w", buildErr)
 		}
 		pages := tview.NewPages()
 		app.SetRoot(tui.WrapRoot(options, pages), true)
@@ -55,32 +60,38 @@ func showSyncScreen(cfg *config.UserConfig) error {
 		var outcomes []syncOutcome
 		var lines []string
 		progress := tui.ProgressOptions{
-			Title:   appTitle,
 			Initial: tui.ProgressUpdate{Text: "Searching for sync files..."},
 		}
-		tui.ShowProgressModal(pages, app, progress, func(update func(tui.ProgressUpdate)) error {
-			result, syncErr := runSync(cfg, func(line string) {
-				lines = append(lines, line)
-				update(tui.ProgressUpdate{Text: line})
+		// Deferred until this application is drawing. Starting it here would
+		// run a second sync when BuildAndRetry rebuilds for /dev/tty2, with
+		// both writing the same shortcut files.
+		drew = tui.RunWhenStarted(app, func() {
+			tui.ShowProgressModal(pages, app, progress, func(update func(tui.ProgressUpdate)) error {
+				result, syncErr := runSync(cfg, func(line string) {
+					lines = append(lines, line)
+					update(tui.ProgressUpdate{Text: line})
+				})
+				outcomes = result
+				if syncErr != nil {
+					return syncErr
+				}
+				return nil
+			}, func(syncErr error) {
+				if syncErr != nil {
+					tui.ShowErrorModal(pages, app, syncErr.Error(), app.Stop)
+					return
+				}
+				showSummary(pages, app, outcomes, lines)
 			})
-			outcomes = result
-			if syncErr != nil {
-				return syncErr
-			}
-			return nil
-		}, func(syncErr error) {
-			if syncErr != nil {
-				tui.ShowErrorModal(pages, app, syncErr.Error(), app.Stop)
-				return
-			}
-			showSummary(pages, app, outcomes, lines)
 		})
 		return app, nil
 	}
-	if err := tui.BuildAndRetry(builder); err != nil {
-		return fmt.Errorf("run LaunchSync TUI: %w", err)
+	runErr := tui.BuildAndRetry(builder)
+	started = drew != nil && drew.Load()
+	if runErr != nil {
+		return started, fmt.Errorf("run LaunchSync TUI: %w", runErr)
 	}
-	return nil
+	return started, nil
 }
 
 // showSummary lists what each sync file produced. The full log stays available

--- a/cmd/launchsync/ui.go
+++ b/cmd/launchsync/ui.go
@@ -1,0 +1,128 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+	"github.com/wizzomafizzo/mrext/pkg/version"
+)
+
+const (
+	appTitle    = "LaunchSync"
+	pageSummary = "launchsync_summary"
+)
+
+// showSyncScreen runs the sync behind a progress modal and then shows what it
+// did. The console log this replaces printed "Building games index... " with
+// no newline and then blocked through the whole scan, so a slow step looked
+// like a hang.
+func showSyncScreen(cfg *config.UserConfig) error {
+	options := tui.ApplicationOptions{
+		Theme:   cfg.TUI.Theme,
+		Mouse:   cfg.TUI.Mouse,
+		CRTMode: cfg.TUI.CRTMode,
+	}
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		pages := tview.NewPages()
+		app.SetRoot(tui.WrapRoot(options, pages), true)
+
+		var outcomes []syncOutcome
+		var lines []string
+		progress := tui.ProgressOptions{
+			Title:   appTitle,
+			Initial: tui.ProgressUpdate{Text: "Searching for sync files..."},
+		}
+		tui.ShowProgressModal(pages, app, progress, func(update func(tui.ProgressUpdate)) error {
+			result, syncErr := runSync(cfg, func(line string) {
+				lines = append(lines, line)
+				update(tui.ProgressUpdate{Text: line})
+			})
+			outcomes = result
+			if syncErr != nil {
+				return syncErr
+			}
+			return nil
+		}, func(syncErr error) {
+			if syncErr != nil {
+				tui.ShowErrorModal(pages, app, syncErr.Error(), app.Stop)
+				return
+			}
+			showSummary(pages, app, outcomes, lines)
+		})
+		return app, nil
+	}
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run LaunchSync TUI: %w", err)
+	}
+	return nil
+}
+
+// showSummary lists what each sync file produced. The full log stays available
+// behind Details, because "not found" for a specific game is the thing people
+// actually need to read.
+func showSummary(pages *tview.Pages, app *tview.Application, outcomes []syncOutcome, lines []string) {
+	list := tui.NewMenuList()
+	list.AddHeader("Sync files")
+	if len(outcomes) == 0 {
+		list.AddRow("Nothing to sync", tui.MenuRowItem)
+	}
+	for _, outcome := range outcomes {
+		list.AddRow(fmt.Sprintf("%s  %d found, %d missing, %d failed",
+			outcome.name, outcome.found, outcome.missing, outcome.failed), tui.MenuRowItem)
+	}
+
+	bar := tui.NewButtonBar(app).
+		AddButtonWithHelp("Details", "Show the full sync log", func() {
+			tui.ShowInfoModal(pages, app, appTitle+" log", strings.Join(lines, "\n"),
+				func() { showSummary(pages, app, outcomes, lines) })
+		}).
+		AddButtonWithHelp("Exit", "Exit LaunchSync", app.Stop).
+		SetupNavigation(app.Stop)
+	frame := tui.NewPageFrame(app).
+		SetTitle(appTitle).
+		SetContent(list).
+		SetHelpText(summaryHelp(outcomes)).
+		SetButtonBar(bar).
+		SetOnEscape(app.Stop)
+	frame.SetVersion(version.Short())
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	pages.AddAndSwitchToPage(pageSummary, frame, true)
+	app.SetFocus(list)
+}
+
+func summaryHelp(outcomes []syncOutcome) string {
+	found, missing, failed := 0, 0, 0
+	for _, outcome := range outcomes {
+		found += outcome.found
+		missing += outcome.missing
+		failed += outcome.failed
+	}
+	return fmt.Sprintf("%d shortcuts created, %d games not found, %d errors.", found, missing, failed)
+}

--- a/cmd/launchsync/ui.go
+++ b/cmd/launchsync/ui.go
@@ -77,11 +77,16 @@ func showSyncScreen(cfg *config.UserConfig) (started bool, err error) {
 				}
 				return nil
 			}, func(syncErr error) {
+				summary := func() { showSummary(pages, app, outcomes, lines) }
 				if syncErr != nil {
-					tui.ShowErrorModal(pages, app, syncErr.Error(), app.Stop)
+					// Go to the summary afterwards rather than stopping. A sync
+					// that fails partway has already linked games, and Details is
+					// the only place the log exists when the console path is not
+					// the one being used.
+					tui.ShowErrorModal(pages, app, syncErr.Error(), summary)
 					return
 				}
-				showSummary(pages, app, outcomes, lines)
+				summary()
 			})
 		})
 		return app, nil

--- a/cmd/launchsync/ui_test.go
+++ b/cmd/launchsync/ui_test.go
@@ -1,0 +1,75 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+)
+
+func TestSummaryCountsAndLog(t *testing.T) {
+	if _, err := tui.NewApplication(tui.ApplicationOptions{Theme: "default"}); err != nil {
+		t.Fatal(err)
+	}
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	outcomes := []syncOutcome{
+		{name: "Best of NES", found: 12, missing: 3, failed: 1},
+		{name: "SNES RPGs", found: 5},
+	}
+	lines := []string{"- Chrono Trigger... found /media/fat/games/SNES/ct.sfc"}
+	showSummary(pages, app, outcomes, lines)
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	pages.SetRect(0, 0, 75, 15)
+	pages.Draw(screen)
+
+	var text strings.Builder
+	for y := range 15 {
+		for x := range 75 {
+			value, _, _ := screen.Get(x, y)
+			_, _ = text.WriteString(value)
+		}
+		_ = text.WriteByte('\n')
+	}
+	drawn := text.String()
+
+	for _, want := range []string{"Best of NES", "12 found", "3 missing", "SNES RPGs", "Details", "Exit"} {
+		if !strings.Contains(drawn, want) {
+			t.Errorf("summary missing %q:\n%s", want, drawn)
+		}
+	}
+	// The footer totals across every sync file, which is what the console log
+	// never told you without reading all of it.
+	if got := summaryHelp(outcomes); !strings.Contains(got, "17 shortcuts created") ||
+		!strings.Contains(got, "3 games not found") || !strings.Contains(got, "1 errors") {
+		t.Errorf("summary help = %q", got)
+	}
+}

--- a/cmd/playlog/main.go
+++ b/cmd/playlog/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/service"
 	"github.com/wizzomafizzo/mrext/pkg/tracker"
-	"github.com/wizzomafizzo/mrext/pkg/utils"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 // TODO: offer to enable recents option and reboot
@@ -80,34 +80,14 @@ func startService(logger *service.Logger, cfg *config.UserConfig) (func() error,
 	}, nil
 }
 
-func tryAddStartup() error {
-	var startup mister.Startup
-
-	err := startup.Load()
-	if err != nil {
-		return fmt.Errorf("load startup configuration: %w", err)
-	}
-
-	if !startup.Exists("mrext/" + appName) {
-		if utils.YesOrNoPrompt("PlayLog must be set to run on MiSTer startup. Add it now?") {
-			err = startup.AddService("mrext/" + appName)
-			if err != nil {
-				return fmt.Errorf("add PlayLog startup service: %w", err)
-			}
-
-			err = startup.Save()
-			if err != nil {
-				return fmt.Errorf("save startup configuration: %w", err)
-			}
-		}
-	}
-
-	return nil
-}
-
 func main() {
 	svcOpt := flag.String("service", "", "manage playlog service (start, stop, restart, status)")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "playlog", version.String())
+		return
+	}
 
 	logger := service.NewLogger(appName)
 
@@ -151,13 +131,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// -service is how user-startup.sh and the shell invoke this, and it must
+	// stay headless. ServiceHandler exits for every command it recognises.
 	svc.ServiceHandler(svcOpt)
-
-	err = tryAddStartup()
-	if err != nil {
-		logger.Error("error adding startup: %s", err)
-		_, _ = fmt.Println("Error adding to startup:", err)
-	}
 
 	if !svc.Running() {
 		if startErr := svc.Start(); startErr != nil {
@@ -167,51 +143,11 @@ func main() {
 		}
 	}
 
-	db, err := openPlayLogDb()
-	if err != nil {
-		logger.Error("error opening db: %s", err)
-		_, _ = fmt.Println("Error opening database:", err)
+	// Interactive launch shows the service screen, with the play-time report
+	// on its own page instead of printed and scrolled past.
+	if screenErr := showServiceScreen(svc, cfg); screenErr != nil {
+		logger.Error("error showing service screen: %s", screenErr)
+		_, _ = fmt.Println(screenErr)
 		os.Exit(1)
-	}
-
-	cores, err := db.topCores(10)
-	if err != nil {
-		logger.Error("error getting top cores: %s", err)
-		_, _ = fmt.Println("Error getting top cores:", err)
-		os.Exit(1)
-	}
-	maxCoreLen := 0
-	for _, core := range cores {
-		if len(core.Name) > maxCoreLen {
-			maxCoreLen = len(core.Name)
-		}
-	}
-
-	games, err := db.topGames(10)
-	if err != nil {
-		logger.Error("error getting top games: %s", err)
-		_, _ = fmt.Println("Error getting top games:", err)
-		os.Exit(1)
-	}
-	maxGameLen := 0
-	for _, game := range games {
-		if len(game.Name) > maxGameLen {
-			maxGameLen = len(game.Name)
-		}
-	}
-
-	_, _ = fmt.Println("Top played cores:")
-	// TODO: convert names using names.txt
-	for _, core := range cores {
-		hours := core.Time / 3600
-		minutes := (core.Time % 3600) / 60
-		_, _ = fmt.Printf("%-*s  %dh %dm\n", maxCoreLen, core.Name, hours, minutes)
-	}
-	_, _ = fmt.Println()
-	_, _ = fmt.Println("Top played games:")
-	for _, game := range games {
-		hours := game.Time / 3600
-		minutes := (game.Time % 3600) / 60
-		_, _ = fmt.Printf("%-*s  %dh %dm\n", maxGameLen, game.Name, hours, minutes)
 	}
 }

--- a/cmd/playlog/ui.go
+++ b/cmd/playlog/ui.go
@@ -170,25 +170,45 @@ func confirmUninstall(pages *tview.Pages, app *tview.Application, svc *service.S
 		done)
 }
 
+// uninstallService keeps the blocking half off the event goroutine. Stopping a
+// service waits for the process to exit and rewriting user-startup.sh is disk
+// I/O, and doing either inline froze the screen for as long as it took.
+// ServicePage.run already keeps Start, Stop and Restart off it, but Uninstall
+// is called straight from its button and has to arrange this itself.
 func uninstallService(pages *tview.Pages, app *tview.Application, svc *service.Service, done func()) {
-	var report strings.Builder
-	if svc.Running() {
-		if err := svc.Stop(); err != nil {
-			_, _ = fmt.Fprintf(&report, "Could not stop the service: %s\n", err)
-		} else {
-			_, _ = report.WriteString("Stopped the service.\n")
-		}
+	report := &strings.Builder{}
+	options := tui.ProgressOptions{Initial: tui.ProgressUpdate{Text: "Stopping the service..."}}
+	tui.ShowProgressModal(pages, app, options, func(update func(tui.ProgressUpdate)) error {
+		stopService(svc, report)
+		update(tui.ProgressUpdate{Text: "Removing the startup entry..."})
+		clearStartupEntry(report)
+		return nil
+	}, func(error) {
+		// playlog.db is never touched here: it is the user's play history, and
+		// the docs are explicit that it should outlive an uninstall.
+		_, _ = fmt.Fprintf(report, "\nYour history is still in %s.\n", config.PlayLogDbFile)
+		_, _ = fmt.Fprintf(report, "Delete %s/playlog.sh to finish.", config.ScriptsFolder)
+		tui.ShowInfoModal(pages, app, "Uninstall "+appTitle, report.String(), done)
+	})
+}
+
+func stopService(svc *service.Service, report *strings.Builder) {
+	if !svc.Running() {
+		return
 	}
+	if err := svc.Stop(); err != nil {
+		_, _ = fmt.Fprintf(report, "Could not stop the service: %s\n", err)
+		return
+	}
+	_, _ = report.WriteString("Stopped the service.\n")
+}
+
+func clearStartupEntry(report *strings.Builder) {
 	if err := removeFromStartup(); err != nil {
-		_, _ = fmt.Fprintf(&report, "Could not remove the startup entry: %s\n", err)
-	} else {
-		_, _ = report.WriteString("Removed the startup entry.\n")
+		_, _ = fmt.Fprintf(report, "Could not remove the startup entry: %s\n", err)
+		return
 	}
-	// playlog.db is never touched here: it is the user's play history, and the
-	// docs are explicit that it should outlive an uninstall.
-	_, _ = fmt.Fprintf(&report, "\nYour history is still in %s.\n", config.PlayLogDbFile)
-	_, _ = fmt.Fprintf(&report, "Delete %s/playlog.sh to finish.", config.ScriptsFolder)
-	tui.ShowInfoModal(pages, app, "Uninstall "+appTitle, report.String(), done)
+	_, _ = report.WriteString("Removed the startup entry.\n")
 }
 
 func startupInstalled() (bool, error) {

--- a/cmd/playlog/ui.go
+++ b/cmd/playlog/ui.go
@@ -1,0 +1,235 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rivo/tview"
+	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/mister"
+	"github.com/wizzomafizzo/mrext/pkg/service"
+	"github.com/wizzomafizzo/mrext/pkg/tui"
+	"github.com/wizzomafizzo/mrext/pkg/version"
+)
+
+const (
+	appTitle    = "PlayLog"
+	pageService = "playlog_service"
+	pageStats   = "playlog_stats"
+	topCount    = 10
+)
+
+// showServiceScreen replaces the text report that used to scroll past on the
+// Scripts console. The same numbers are here, on a page that stays put.
+func showServiceScreen(svc *service.Service, cfg *config.UserConfig) error {
+	options := tui.ApplicationOptions{
+		Theme:            cfg.TUI.Theme,
+		Mouse:            cfg.TUI.Mouse,
+		CRTMode:          cfg.TUI.CRTMode,
+		OnScreenKeyboard: cfg.TUI.OnScreenKeyboard,
+	}
+	builder := func() (*tview.Application, error) {
+		app, err := tui.NewApplication(options)
+		if err != nil {
+			return nil, fmt.Errorf("create TUI application: %w", err)
+		}
+		pages := tview.NewPages()
+		var page *tui.ServicePage
+		page = tui.NewServicePage(app, pages, appTitle, tui.ServiceActions{
+			Running: svc.Running,
+			Start:   svc.Start,
+			Stop:    svc.Stop,
+			Restart: svc.Restart,
+			Exit:    app.Stop,
+			Uninstall: func() {
+				confirmUninstall(pages, app, svc, func() { page.Redraw() })
+			},
+			Status: func(running bool) string {
+				state := "Service is NOT RUNNING"
+				if running {
+					state = "Service is RUNNING"
+				}
+				return state + "\n\nPlay time is tracked in the background.\n" +
+					"It's safe to exit; the service keeps running."
+			},
+		})
+		page.Frame().SetVersion(version.Short())
+
+		// Stats is the reason most people open PlayLog, so it gets its own
+		// button rather than living behind a menu.
+		page.ButtonBar().AddButtonWithHelp("Stats", "Show the most played cores and games",
+			func() { showStats(pages, app, func() { page.Show(pageService) }) })
+		page.Show(pageService)
+		app.SetRoot(tui.WrapRoot(options, pages), true)
+
+		installed, err := startupInstalled()
+		if err != nil {
+			tui.ShowErrorModal(pages, app, err.Error(), func() { page.Redraw() })
+			return app, nil
+		}
+		if !installed {
+			tui.ShowConfirmModal(pages, app, appTitle,
+				appTitle+" must run on MiSTer startup to record play time.\n\nAdd it now?",
+				func() {
+					if addErr := addToStartup(); addErr != nil {
+						tui.ShowErrorModal(pages, app, addErr.Error(), func() { page.Redraw() })
+						return
+					}
+					page.Redraw()
+				},
+				func() { page.Redraw() })
+		}
+		return app, nil
+	}
+	if err := tui.BuildAndRetry(builder); err != nil {
+		return fmt.Errorf("run PlayLog TUI: %w", err)
+	}
+	return nil
+}
+
+func showStats(pages *tview.Pages, app *tview.Application, back func()) {
+	list := tui.NewMenuList()
+	db, err := openPlayLogDb()
+	if err != nil {
+		tui.ShowErrorModal(pages, app, err.Error(), back)
+		return
+	}
+	defer func() { _ = db.db.Close() }()
+
+	cores, coresErr := db.topCores(topCount)
+	games, gamesErr := db.topGames(topCount)
+	if coresErr != nil || gamesErr != nil {
+		problem := coresErr
+		if problem == nil {
+			problem = gamesErr
+		}
+		tui.ShowErrorModal(pages, app, problem.Error(), back)
+		return
+	}
+
+	list.AddHeader("Top played cores")
+	if len(cores) == 0 {
+		list.AddRow("Nothing recorded yet", tui.MenuRowItem)
+	}
+	for _, core := range cores {
+		list.AddRow(fmt.Sprintf("%s  %s", core.Name, formatPlayTime(core.Time)), tui.MenuRowItem)
+	}
+	list.AddHeader("Top played games")
+	if len(games) == 0 {
+		list.AddRow("Nothing recorded yet", tui.MenuRowItem)
+	}
+	for _, game := range games {
+		list.AddRow(fmt.Sprintf("%s  %s", game.Name, formatPlayTime(game.Time)), tui.MenuRowItem)
+	}
+
+	bar := tui.NewButtonBar(app).
+		AddButtonWithHelp("Back", "Return to the service screen", back).
+		SetupNavigation(back)
+	frame := tui.NewPageFrame(app).
+		SetTitle(appTitle, "Stats").
+		SetContent(list).
+		SetHelpText("Time played per core and per game.").
+		SetButtonBar(bar).
+		SetOnEscape(back)
+	frame.SetVersion(version.Short())
+	bar.SetHelpCallback(func(text string) { frame.SetHelpText(text) })
+	frame.SetupContentToButtonNavigation()
+	pages.AddAndSwitchToPage(pageStats, frame, true)
+	app.SetFocus(list)
+}
+
+// formatPlayTime keeps the "Xh Ym" shape the console report used.
+func formatPlayTime(seconds int) string {
+	return fmt.Sprintf("%dh %dm", seconds/3600, (seconds%3600)/60)
+}
+
+func confirmUninstall(pages *tview.Pages, app *tview.Application, svc *service.Service, done func()) {
+	tui.ShowConfirmModal(pages, app, "Uninstall "+appTitle,
+		"Stop the service and remove "+appTitle+" from MiSTer startup?\n\n"+
+			"Your play history in playlog.db is kept.",
+		func() { uninstallService(pages, app, svc, done) },
+		done)
+}
+
+func uninstallService(pages *tview.Pages, app *tview.Application, svc *service.Service, done func()) {
+	var report strings.Builder
+	if svc.Running() {
+		if err := svc.Stop(); err != nil {
+			_, _ = fmt.Fprintf(&report, "Could not stop the service: %s\n", err)
+		} else {
+			_, _ = report.WriteString("Stopped the service.\n")
+		}
+	}
+	if err := removeFromStartup(); err != nil {
+		_, _ = fmt.Fprintf(&report, "Could not remove the startup entry: %s\n", err)
+	} else {
+		_, _ = report.WriteString("Removed the startup entry.\n")
+	}
+	// playlog.db is never touched here: it is the user's play history, and the
+	// docs are explicit that it should outlive an uninstall.
+	_, _ = fmt.Fprintf(&report, "\nYour history is still in %s.\n", config.PlayLogDbFile)
+	_, _ = fmt.Fprintf(&report, "Delete %s/playlog.sh to finish.", config.ScriptsFolder)
+	tui.ShowInfoModal(pages, app, "Uninstall "+appTitle, report.String(), done)
+}
+
+func startupInstalled() (bool, error) {
+	var startup mister.Startup
+	if err := startup.Load(); err != nil {
+		return false, fmt.Errorf("load startup configuration: %w", err)
+	}
+	return startup.Exists("mrext/" + appName), nil
+}
+
+func addToStartup() error {
+	var startup mister.Startup
+	if err := startup.Load(); err != nil {
+		return fmt.Errorf("load startup configuration: %w", err)
+	}
+	if startup.Exists("mrext/" + appName) {
+		return nil
+	}
+	if err := startup.AddService("mrext/" + appName); err != nil {
+		return fmt.Errorf("add PlayLog startup service: %w", err)
+	}
+	if err := startup.Save(); err != nil {
+		return fmt.Errorf("save startup configuration: %w", err)
+	}
+	return nil
+}
+
+func removeFromStartup() error {
+	var startup mister.Startup
+	if err := startup.Load(); err != nil {
+		return fmt.Errorf("load startup configuration: %w", err)
+	}
+	name := "mrext/" + appName
+	if !startup.Exists(name) {
+		return nil
+	}
+	if err := startup.Remove(name); err != nil {
+		return fmt.Errorf("remove startup entry: %w", err)
+	}
+	if err := startup.Save(); err != nil {
+		return fmt.Errorf("save startup configuration: %w", err)
+	}
+	return nil
+}

--- a/cmd/random/main.go
+++ b/cmd/random/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/games"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 const (
@@ -42,7 +43,12 @@ func main() {
 	filter := flag.String("filter", "", "list of systems to filter (ex. gba,psx,nes)")
 	ignore := flag.String("ignore", "", "list of systems to ignore (ex. tgfx16-cd)")
 	noscan := flag.Bool("noscan", false, "don't index entire system (faster, but less random)")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "random", version.String())
+		return
+	}
 
 	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{})
 	if err != nil {

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/mrext/pkg/service"
 	"github.com/wizzomafizzo/mrext/pkg/tracker"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 const (
@@ -403,7 +404,12 @@ func appHandler(rw http.ResponseWriter, req *http.Request) {
 func main() {
 	svcOpt := flag.String("service", "", "manage playlog service (start, stop, restart, status)")
 	uninstallOpt := flag.Bool("uninstall", false, "uninstall MiSTer Remote")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "remote", version.String())
+		return
+	}
 
 	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{
 		Remote: config.RemoteConfig{

--- a/cmd/samindex/main.go
+++ b/cmd/samindex/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/config"
 	"github.com/wizzomafizzo/mrext/pkg/games"
 	"github.com/wizzomafizzo/mrext/pkg/utils"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 // SAM uses slightly different system IDs.
@@ -222,7 +223,12 @@ func main() {
 	quiet := flag.Bool("q", false, "suppress all status output")
 	detect := flag.Bool("d", false, "list active system folders")
 	noDupes := flag.Bool("nodupes", false, "filter out duplicate games")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "samindex", version.String())
+		return
+	}
 
 	// filter systems
 	var systems []games.System

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -25,13 +25,19 @@ import (
 	"os"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
+	"github.com/wizzomafizzo/mrext/pkg/version"
 )
 
 const appName = "search"
 
 func main() {
 	printPath := flag.Bool("print", false, "Print game path to stderr instead of launching the game")
+	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()
+	if *showVersion {
+		_, _ = fmt.Printf("%s %s\n", "search", version.String())
+		return
+	}
 
 	cfg, err := config.LoadUserConfig(appName, &config.UserConfig{
 		TUI: config.TUIConfig{Theme: "default", Mouse: true, CRTMode: true, OnScreenKeyboard: true},

--- a/cmd/search/ui.go
+++ b/cmd/search/ui.go
@@ -79,7 +79,12 @@ func (u *ui) Run() error {
 		app.SetRoot(tui.WrapRoot(u.options, u.pages), true)
 		// Typing is still the first thing that happens, as it was when the
 		// keyboard was the whole first screen.
-		u.startIndexThenSearch()
+		//
+		// Deferred until this application is drawing, because BuildAndRetry
+		// builds a second one to retry on /dev/tty2 and this can start an
+		// index rebuild. Two of those would collide on the writer lock and
+		// report a spurious "another indexer is running".
+		tui.RunWhenStarted(app, u.startIndexThenSearch)
 		return app, nil
 	}
 	if err := tui.BuildAndRetry(builder); err != nil {

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -69,6 +69,8 @@ These are the important commands:
 
 Binary releases all go in the `releases` folder.
 
+`mage build` and `mage mister` stamp the binary with `git describe` and the short commit, so every app answers `-version`. A plain `go build` leaves the stamp empty and falls back to the VCS information Go records, so the flag still reports something useful. Apps with a full-screen interface also print the version in the bottom border of the page frame.
+
 ## Project Layout
 
 This is an overview of all the major files and folders in the project.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -59,6 +59,10 @@ These are the important commands:
 
   Cross-compiles a static Linux ARMv7 binary for MiSTer with `CGO_ENABLED=0`. Building `remote` or `all` also rebuilds its web UI.
 
+- `mage deploy <address>`
+
+  Builds every application for MiSTer and copies the binaries to `/media/fat/Scripts` on the device at `<address>` over SSH as `root`. The address is a plain hostname or IP. Because it builds everything, it also rebuilds Remote's web UI. Stop any running mrext service on the device first if you are replacing a binary it is executing.
+
 - `mage remoteWeb`
 
   Runs deterministic npm installation and builds `web/remote` into the ignored `cmd/remote/_client/build` directory.

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -76,6 +76,8 @@ Each app reads these in order: its own `[tui]` section, then `/media/fat/Scripts
 
 The settings screen has a **Use in all apps** row. It writes the current interface settings to the shared file and removes those four keys from this app's INI, so this app follows the shared file from then on. Other apps pick it up the next time they start, unless their own INI still sets those keys.
 
+Startup work happens inside the app now. Checking arcade core links and refreshing favorites both walk the whole favorites tree, and on a large collection, or one on USB or a network share, that used to be several seconds of blank screen before anything was drawn. It runs behind a progress box instead. Reading the contents of a ZIP shows one too, since that is the slow part of browsing.
+
 ## Configuration
 
 Favorites reads `favorites.ini` beside the executable:

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -66,7 +66,7 @@ Changes remain staged until `Save` is selected. `Cancel` leaves the file untouch
 
 `USB shortcut folder` is the filesystem target of the browser's USB shortcut, normally `/media/usb0`. If that target contains a `games` folder, the shortcut opens it instead. This setting does not mount storage or change the destination of saved favorites; the INI key remains `external_folder`.
 
-The on-screen keyboard uses Zaparoo's compact 41×8 layout. Where an input has a prompt explaining what to enter, that line is shown above the keyboard; controller users could not see it otherwise, and they are the ones it is written for. Setting explanations stay in the settings page footer.
+The on-screen keyboard uses Zaparoo's compact 41×8 layout. Only inputs with a rule or an example that the keyboard's own title does not already give show a line above it, such as the underscore a folder name needs; controller users could not see that line otherwise, and they are the ones it is written for. The page behind the keyboard keeps drawing, so the row being edited and its footer help stay on screen.
 
 ### Shared interface settings
 
@@ -76,7 +76,7 @@ Each app reads these in order: its own `[tui]` section, then `/media/fat/Scripts
 
 The settings screen has a **Use in all apps** row. It writes the current interface settings to the shared file and removes those four keys from this app's INI, so this app follows the shared file from then on. Other apps pick it up the next time they start, unless their own INI still sets those keys.
 
-Startup work happens inside the app now. Checking arcade core links and refreshing favorites both walk the whole favorites tree, and on a large collection, or one on USB or a network share, that used to be several seconds of blank screen before anything was drawn. It runs behind a progress box instead. Reading the contents of a ZIP shows one too, since that is the slow part of browsing.
+Startup work happens inside the app now. Checking arcade core links and refreshing favorites both walk the whole favorites tree, and on a large collection, or one on USB or a network share, that used to be several seconds of blank screen before anything was drawn. It runs behind a progress box instead. Reading the contents of a ZIP shows one too, since that is the slow part of browsing. The box only appears once the work has taken half a second, so on a small collection it never appears at all; the interface stays locked while the work runs either way.
 
 ## Configuration
 

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -40,6 +40,16 @@ Recently Played numbers `.mra` and `.mgl` shortcuts together. Replaying a game r
 
 LastPlayed waits for MiSTer's state files to appear when it starts, so launching it from `user-startup.sh` before MiSTer main has created them no longer makes the service exit. It also recovers when another script replaces `/tmp/ACTIVEGAME` or `/tmp/CORENAME` instead of writing over them, which previously left tracking silent until a restart.
 
+## Service screen
+
+Running `lastplayed` from the Scripts menu now opens a screen instead of printing a line and exiting. It shows whether the service is running, the shortcut and recent folder names in use, and offers **Start**/**Stop**, **Restart**, **Uninstall** and **Exit**, with Exit selected by default. It uses the same interface as the other apps, including themes and CRT mode from `[tui]`.
+
+The question about adding LastPlayed to MiSTer startup is the same question, asked in the shared dialog rather than as a raw `[DOWN=Yes/UP=No]` terminal prompt.
+
+**Uninstall** stops the service and removes the `# mrext/lastplayed` entry from `user-startup.sh` without touching anything else in that file, then asks separately before deleting the generated `Last Played` shortcut and `Recently Played` folder. It does not delete `lastplayed.sh` or `lastplayed.ini`; the summary says so.
+
+`lastplayed.sh -service start|stop|restart|status` is unchanged and stays headless, so `user-startup.sh` is unaffected.
+
 ## Configuration
 
 LastPlayed can be configured by creating a `lastplayed.ini` file in the `/media/fat/Scripts` folder where you put `lastplayed.sh`. For example:

--- a/docs/launchsync.md
+++ b/docs/launchsync.md
@@ -39,6 +39,14 @@ LaunchSync indexes each required system once, regardless of how many playlist en
 
 Only requested systems are refreshed in the shared `/media/fat/Scripts/.config/mrext/games.db`; unrelated Search/Remote entries are retained. A successful refresh removes stale entries for the requested systems. Failed scans or writes leave the previous index intact. Allow free SD space for a replacement index and do not remove `games.db.lock` while an app is indexing. Playlist matching rules and generated shortcut formats are unchanged.
 
+## Sync screen
+
+Running `launchsync` from the Scripts menu shows a progress screen while it searches for sync files, checks them for updates and builds the games index, then a summary of what each sync file produced: shortcuts created, games not found and errors. **Details** shows the full log, which is the same text the console printed.
+
+Previously this was console output only, and `Building games index... ` was printed without a newline before a scan that can take minutes, so a slow step looked like a hang.
+
+`launchsync -update` is unchanged and stays on the console with no screen, so scripts and startup hooks behave exactly as before; add `-verbose` for the full log. `-test` is also unchanged.
+
 ## Uninstall
 
 Remove LaunchSync's Downloader subscription if configured, so updates do not reinstall it.

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -41,6 +41,18 @@ PlayLog does not record menu navigation. Earlier versions wrote a database row f
 
 PlayLog waits for MiSTer's state files to appear when it starts, so launching it from `user-startup.sh` before MiSTer main has created them no longer makes the service exit. It also recovers when another script replaces `/tmp/ACTIVEGAME` or `/tmp/CORENAME` instead of writing over them, which previously left tracking silent until a restart.
 
+## Service screen
+
+Running `playlog` from the Scripts menu now opens a screen instead of printing a report that scrolls past. It shows whether the service is running and offers **Start**/**Stop**, **Restart**, **Uninstall**, **Exit** and **Stats**, with Exit selected by default.
+
+**Stats** is the same top ten cores and top ten games, with the same `Xh Ym` times, on a page that stays put.
+
+The question about adding PlayLog to MiSTer startup is the same question, asked in the shared dialog rather than as a raw `[DOWN=Yes/UP=No]` terminal prompt.
+
+**Uninstall** stops the service and removes the `# mrext/playlog` entry from `user-startup.sh`. It never touches `playlog.db`: that is your play history, and the summary points at where it still is.
+
+`playlog.sh -service start|stop|restart|status` is unchanged and stays headless, so `user-startup.sh` is unaffected.
+
 ## Configuration
 
 PlayLog can be configured by creating a `playlog.ini` file in the `/media/fat/Scripts` folder where you put `playlog.sh`. For example:

--- a/magefile.go
+++ b/magefile.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -233,6 +234,57 @@ func Mister(appName string) error {
 		"GOARCH": "arm",
 		"GOARM":  "7",
 	})
+}
+
+// deployUser is the only account on a stock MiSTer, and deployDir is where its
+// Scripts menu looks for executables.
+const (
+	deployUser = "root"
+	deployDir  = "/media/fat/Scripts"
+)
+
+// Deploy builds every MiSTer binary and copies it to a device over SSH. The
+// address is the device's hostname or IP.
+//
+// It builds through Mister("all"), so it also reinstalls and rebuilds Remote's
+// web UI. Everything in the output directory is copied, including the internal
+// contool and samindex tools; the Scripts menu only lists the ".sh" files, so
+// the extras are inert.
+func Deploy(address string) error {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return errors.New("no device address given: mage deploy <address>")
+	}
+	if strings.ContainsAny(address, " \t/@:") {
+		return fmt.Errorf("device address must be a plain hostname or IP: %s", address)
+	}
+
+	if err := Mister("all"); err != nil {
+		return err
+	}
+
+	outDir := filepath.Join(binDir, "linux_arm")
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return fmt.Errorf("read built binaries: %w", err)
+	}
+	binaries := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		binaries = append(binaries, filepath.Join(outDir, entry.Name()))
+	}
+	if len(binaries) == 0 {
+		return fmt.Errorf("no binaries to deploy in %s", outDir)
+	}
+
+	target := deployUser + "@" + address + ":" + deployDir + "/"
+	fmt.Printf("Deploying %d binaries to %s\n", len(binaries), target)
+	if err := sh.RunV("scp", append(binaries, target)...); err != nil {
+		return fmt.Errorf("copy binaries to %s: %w", address, err)
+	}
+	return nil
 }
 
 type updateDbFile struct {

--- a/magefile.go
+++ b/magefile.go
@@ -154,6 +154,30 @@ func GenerateSystemMetadata() error {
 	return sh.RunV("go", "run", "./internal/gensystemmetadata")
 }
 
+const versionPackage = "github.com/wizzomafizzo/mrext/pkg/version"
+
+// versionLdflags stamps the build so every binary can report what it is. The
+// package falls back to Go's own VCS stamps for a plain "go build", so this is
+// only about producing a clean tag name for a release.
+func versionLdflags() string {
+	describe, err := sh.Output("git", "describe", "--tags", "--always", "--dirty")
+	if err != nil {
+		describe = ""
+	}
+	commit, err := sh.Output("git", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		commit = ""
+	}
+	flags := "-s -w"
+	if describe != "" {
+		flags += " -X " + versionPackage + ".Version=" + describe
+	}
+	if commit != "" {
+		flags += " -X " + versionPackage + ".Commit=" + commit
+	}
+	return flags
+}
+
 func buildApp(a app, out string, env map[string]string) error {
 	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
 		return err
@@ -165,7 +189,7 @@ func buildApp(a app, out string, env map[string]string) error {
 	for key, value := range env {
 		buildEnv[key] = value
 	}
-	return sh.RunWithV(buildEnv, "go", "build", "-trimpath", "-o", out, a.path)
+	return sh.RunWithV(buildEnv, "go", "build", "-trimpath", "-ldflags", versionLdflags(), "-o", out, a.path)
 }
 
 func buildApps(appName, platform string, env map[string]string) error {

--- a/pkg/tui/foundation_test.go
+++ b/pkg/tui/foundation_test.go
@@ -544,3 +544,82 @@ func TestShareInterfaceSettingsWritesSharedFileAndClearsLocalKeys(t *testing.T) 
 		t.Errorf("unrelated settings were lost:\n%s", local)
 	}
 }
+
+func TestServicePageShowsStateAndKeepsExitDefault(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	running := false
+
+	page := NewServicePage(app, pages, "LastPlayed", ServiceActions{
+		Running: func() bool { return running },
+		Start:   func() error { running = true; return nil },
+		Stop:    func() error { running = false; return nil },
+		Restart: func() error { return nil },
+		Exit:    func() {},
+		Status: func(isRunning bool) string {
+			if isRunning {
+				return "Service is RUNNING"
+			}
+			return "Service is NOT RUNNING"
+		},
+	})
+	page.Show("service")
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(75, 15)
+	pages.SetRect(0, 0, 75, 15)
+	pages.Draw(screen)
+
+	drawn := screenText(screen, 75, 15)
+	for _, want := range []string{"LastPlayed", "NOT RUNNING", "Start", "Restart", "Uninstall", "Exit"} {
+		if !strings.Contains(drawn, want) {
+			t.Errorf("missing %q:\n%s", want, drawn)
+		}
+	}
+	// Exit is selected on arrival: most visits are to read the state and leave.
+	if page.ButtonBar().FocusedIndex() != 3 {
+		t.Errorf("focused button = %d, want Exit at 3", page.ButtonBar().FocusedIndex())
+	}
+
+	// The toggle follows the service rather than being a fixed label.
+	running = true
+	page.Redraw()
+	pages.Draw(screen)
+	if drawn := screenText(screen, 75, 15); !strings.Contains(drawn, "Stop") {
+		t.Errorf("toggle did not become Stop:\n%s", drawn)
+	}
+}
+
+func TestPageFrameDrawsTheVersionWhenItFits(t *testing.T) {
+	app := tview.NewApplication()
+	frame := NewPageFrame(app).SetTitle("PlayLog").SetVersion("v1.4.2")
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(100, 15)
+	frame.SetRect(0, 0, 100, 15)
+	frame.Draw(screen)
+	if drawn := screenText(screen, 100, 15); !strings.Contains(drawn, "v1.4.2") {
+		t.Errorf("version not drawn:\n%s", drawn)
+	}
+
+	// A narrow screen keeps the key hints and drops the version rather than
+	// overlapping them.
+	screen.SetSize(60, 15)
+	frame.SetRect(0, 0, 60, 15)
+	frame.Draw(screen)
+	drawn := screenText(screen, 60, 15)
+	if strings.Contains(drawn, "v1.4.2") {
+		t.Errorf("version drawn over the hints at 60 columns:\n%s", drawn)
+	}
+	if !strings.Contains(drawn, "ESC") {
+		t.Errorf("key hints lost:\n%s", drawn)
+	}
+}

--- a/pkg/tui/modals.go
+++ b/pkg/tui/modals.go
@@ -102,6 +102,12 @@ func ShowConfirmModal(
 	app.SetFocus(dialog)
 }
 
+// InputOptions configures ShowInputModal. Prompt is drawn above the box, so it
+// should carry a rule or an example the Title does not already give: the page
+// behind the modal keeps drawing, which means the row being edited and its
+// footer help are still on screen next to the Title. A prompt that restates
+// any of those is the fourth way of saying one thing.
+//
 //nolint:govet // Field order keeps textual options readable at call sites.
 type InputOptions struct {
 	Title            string

--- a/pkg/tui/page_frame.go
+++ b/pkg/tui/page_frame.go
@@ -36,6 +36,7 @@ type PageFrame struct {
 	helpText  *tview.TextView
 	buttonBar *ButtonBar
 	onEscape  func()
+	version   string
 }
 
 func NewPageFrame(app *tview.Application) *PageFrame {
@@ -57,6 +58,14 @@ func NewPageFrame(app *tview.Application) *PageFrame {
 
 func (pf *PageFrame) SetTitle(path ...string) *PageFrame {
 	pf.Box.SetTitle(" " + strings.Join(path, " > ") + " ")
+	return pf
+}
+
+// SetVersion prints a build identifier in the bottom border, opposite the key
+// hints, so a user can say which build they are running without guessing from
+// a file date. Ignored when it does not fit.
+func (pf *PageFrame) SetVersion(version string) *PageFrame {
+	pf.version = version
 	return pf
 }
 
@@ -115,12 +124,16 @@ func (pf *PageFrame) Draw(screen tcell.Screen) {
 	pf.drawHints(screen)
 }
 
+func hintsRunes() []rune {
+	return []rune("↑↓: Rows │ ←→: Actions │ Enter: Confirm │ ESC: Back")
+}
+
 func (pf *PageFrame) drawHints(screen tcell.Screen) {
 	x, y, width, height := pf.GetRect()
 	if width <= 4 || height <= 2 {
 		return
 	}
-	hints := []rune("↑↓: Rows │ ←→: Actions │ Enter: Confirm │ ESC: Back")
+	hints := hintsRunes()
 	if len(hints) > width-4 {
 		hints = hints[:width-4]
 	}
@@ -132,6 +145,29 @@ func (pf *PageFrame) drawHints(screen tcell.Screen) {
 		screen.SetContent(column, y+height-1, ' ', nil, style)
 	}
 	for index, value := range hints {
+		screen.SetContent(start+index, y+height-1, value, nil, style)
+	}
+	pf.drawVersion(screen, x, y, width, height, start)
+}
+
+// drawVersion puts the build in the right of the bottom border, but only when
+// there is clear space between it and the key hints.
+func (pf *PageFrame) drawVersion(screen tcell.Screen, x, y, width, height, hintsStart int) {
+	if pf.version == "" {
+		return
+	}
+	label := []rune(pf.version)
+	start := x + width - 2 - len(label)
+	if start < hintsStart+len(hintsRunes())+2 {
+		return
+	}
+	style := tcell.StyleDefault.
+		Foreground(CurrentTheme().BorderColor).
+		Background(CurrentTheme().PrimitiveBackgroundColor)
+	for column := start - 1; column < start+len(label)+1; column++ {
+		screen.SetContent(column, y+height-1, ' ', nil, style)
+	}
+	for index, value := range label {
 		screen.SetContent(start+index, y+height-1, value, nil, style)
 	}
 }

--- a/pkg/tui/progress.go
+++ b/pkg/tui/progress.go
@@ -20,27 +20,45 @@
 package tui
 
 import (
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
 const (
-	progressModalPage       = "tui_progress_modal"
-	progressModalWidth      = 60
-	progressModalHeight     = 7
+	progressModalPage = "tui_progress_modal"
+	// The box fits itself to what it holds, between these bounds. The ceiling
+	// keeps a long step name from running off a 75-column CRT screen, and the
+	// line cap makes it wrap rather than grow past 15 rows.
+	progressModalMinWidth   = 24
+	progressModalMaxWidth   = 60
+	progressModalMaxLines   = 3
 	progressBarWidth        = 50
 	defaultProgressThrottle = 150 * time.Millisecond
+	defaultProgressDelay    = 500 * time.Millisecond
 )
 
-// ProgressOptions configures ShowProgressModal. Throttle bounds how often the
-// task goroutine may redraw the modal; zero selects a 150ms minimum interval.
+// ProgressOptions configures ShowProgressModal. Title is optional and belongs
+// in the border only when it says something the text does not: naming the
+// operation while the text names the item it is working on. A box reporting
+// one thing should leave it empty rather than repeat the app name.
+//
+// Throttle bounds how often the task goroutine may redraw the modal; zero
+// selects a 150ms minimum interval.
+//
+// Delay is how long the task may run before the box is drawn at all; zero
+// selects 500ms and a negative value draws it immediately. Work that finishes
+// inside the delay never shows a box, so a fast device does not flash one up
+// and tear it down again. Input is blocked for the whole task either way.
 type ProgressOptions struct {
 	Title    string
 	Initial  ProgressUpdate
 	Throttle time.Duration
+	Delay    time.Duration
 }
 
 // Progress is a bordered message box with an optional bar. It swallows all
@@ -48,6 +66,7 @@ type ProgressOptions struct {
 type Progress struct {
 	*tview.Box
 	update ProgressUpdate
+	hidden bool
 }
 
 func NewProgress(title string) *Progress {
@@ -57,9 +76,42 @@ func NewProgress(title string) *Progress {
 		SetBorder(true).
 		SetBorderColor(theme.BorderColor).
 		SetTitleColor(theme.BorderColor).
-		SetTitleAlign(tview.AlignCenter).
-		SetTitle(" " + title + " ")
+		SetTitleAlign(tview.AlignCenter)
+	// An empty title still clears two cells of the top border, leaving a gap
+	// where a name should be. Draw the border unbroken instead.
+	if title != "" {
+		progress.SetTitle(" " + title + " ")
+	}
 	return progress
+}
+
+// progressBoxWidth fits the box to the longest line it has to show, plus room
+// for the bar and the title when either is there. A fixed 60 cells made a box
+// that says one word look like a dialog waiting for an answer.
+func progressBoxWidth(title string, update ProgressUpdate) int {
+	width := progressModalMinWidth
+	if title != "" {
+		width = max(width, utf8.RuneCountInString(title)+6)
+	}
+	for _, line := range strings.Split(update.Text, "\n") {
+		width = max(width, utf8.RuneCountInString(line)+4)
+	}
+	if update.Total > 0 {
+		width = max(width, progressBarWidth+4)
+	}
+	return min(width, progressModalMaxWidth)
+}
+
+// progressBoxHeight is a border, the text wrapped to the given width, and a
+// blank line plus the bar when there is one. A fixed height left a one-word
+// message sitting on top of four empty rows.
+func progressBoxHeight(width int, update ProgressUpdate) int {
+	lines := min(max(len(tview.WordWrap(update.Text, width-2)), 1), progressModalMaxLines)
+	height := lines + 2
+	if update.Total > 0 {
+		height += 2
+	}
+	return height
 }
 
 // SetUpdate replaces the displayed text and bar. Call it on the UI goroutine.
@@ -73,7 +125,23 @@ func (p *Progress) Update() ProgressUpdate {
 	return p.update
 }
 
+// SetHidden stops the box drawing itself without taking it off the page, so it
+// keeps swallowing keys and mouse clicks while showing nothing. Call it on the
+// UI goroutine.
+func (p *Progress) SetHidden(hidden bool) *Progress {
+	p.hidden = hidden
+	return p
+}
+
+// Hidden reports whether the box is currently drawing nothing.
+func (p *Progress) Hidden() bool {
+	return p.hidden
+}
+
 func (p *Progress) Draw(screen tcell.Screen) {
+	if p.hidden {
+		return
+	}
 	p.DrawForSubclass(screen, p)
 	x, y, width, height := p.GetInnerRect()
 	if width <= 0 || height <= 0 {
@@ -126,12 +194,18 @@ func (*progressOverlay) MouseHandler() func(
 	}
 }
 
-// ShowProgressModal overlays a progress box on pages and runs task on a new
-// goroutine. The update callback handed to task may be called from that
-// goroutine as often as wanted; redraws are throttled and delivered with
+// ShowProgressModal covers pages with an input-blocking overlay and runs task
+// on a new goroutine. The update callback handed to task may be called from
+// that goroutine as often as wanted; redraws are throttled and delivered with
 // app.QueueUpdateDraw, so the application must be running. When task returns
-// the modal is removed and onDone runs on the UI goroutine with its error.
+// the overlay is removed and onDone runs on the UI goroutine with its error.
 // update must not be called after task returns.
+//
+// The overlay goes up straight away but the box inside it stays hidden until
+// options.Delay has passed, so quick work is silent rather than a box that
+// appears and vanishes in the same breath. The overlay is transparent while
+// the box is hidden, and it swallows keys and mouse clicks throughout, so the
+// task always has the screen to itself.
 func ShowProgressModal(
 	pages *tview.Pages,
 	app *tview.Application,
@@ -143,11 +217,35 @@ func ShowProgressModal(
 	if throttle <= 0 {
 		throttle = defaultProgressThrottle
 	}
+	delay := options.Delay
+	if delay == 0 {
+		delay = defaultProgressDelay
+	}
 	previousFocus := app.GetFocus()
-	progress := NewProgress(options.Title).SetUpdate(options.Initial)
-	overlay := &progressOverlay{Primitive: Centered(progressModalWidth, progressModalHeight, progress)}
-	pages.AddPage(progressModalPage, overlay, true, true)
-	app.SetFocus(progress)
+	progress := NewProgress(options.Title).SetUpdate(options.Initial).SetHidden(delay > 0)
+	width := progressBoxWidth(options.Title, options.Initial)
+	height := progressBoxHeight(width, options.Initial)
+	show := func() {
+		overlay := &progressOverlay{Primitive: Centered(width, height, progress)}
+		pages.AddPage(progressModalPage, overlay, true, true)
+		app.SetFocus(progress)
+	}
+	show()
+
+	// done and the hidden flag are only touched from queued callbacks, so the
+	// event loop orders them and no lock is needed.
+	var done bool
+	var reveal *time.Timer
+	if delay > 0 {
+		reveal = time.AfterFunc(delay, func() {
+			app.QueueUpdateDraw(func() {
+				if done {
+					return
+				}
+				progress.SetHidden(false)
+			})
+		})
+	}
 
 	var mu sync.Mutex
 	var last time.Time
@@ -160,12 +258,27 @@ func ShowProgressModal(
 		}
 		last = now
 		mu.Unlock()
-		app.QueueUpdateDraw(func() { progress.SetUpdate(update) })
+		app.QueueUpdateDraw(func() {
+			progress.SetUpdate(update)
+			// A bar arriving, or a longer step name, needs a bigger box. Only
+			// ever grow it: resizing to every step would leave the modal
+			// twitching around the screen for the whole run.
+			nextWidth := max(width, progressBoxWidth(options.Title, update))
+			nextHeight := max(height, progressBoxHeight(nextWidth, update))
+			if nextWidth != width || nextHeight != height {
+				width, height = nextWidth, nextHeight
+				show()
+			}
+		})
 	}
 
 	go func() {
 		err := task(update)
+		if reveal != nil {
+			reveal.Stop()
+		}
 		app.QueueUpdateDraw(func() {
+			done = true
 			pages.RemovePage(progressModalPage)
 			app.SetFocus(previousFocus)
 			if onDone != nil {

--- a/pkg/tui/progress_test.go
+++ b/pkg/tui/progress_test.go
@@ -66,6 +66,74 @@ func TestProgressDrawsTextAndHalfFilledBar(t *testing.T) {
 	})
 }
 
+func TestProgressBoxFitsWhatItHolds(t *testing.T) {
+	wide := ProgressUpdate{Text: strings.Repeat("x", 30)}
+	overflow := ProgressUpdate{Text: strings.Repeat("scanning a very long folder path ", 10)}
+	bar := ProgressUpdate{Text: "Scanning", Current: 1, Total: 10}
+	for _, testCase := range []struct {
+		name       string
+		title      string
+		update     ProgressUpdate
+		wantWidth  int
+		wantHeight int
+	}{
+		{"one short line", "", ProgressUpdate{Text: "Searching..."}, progressModalMinWidth, 3},
+		{"nothing to say yet", "", ProgressUpdate{}, progressModalMinWidth, 3},
+		{"a line past the minimum", "", wide, 34, 3},
+		{"a title wider than the text", "Creating MGL files...", ProgressUpdate{Text: "Done"}, 27, 3},
+		{"a bar needs room for itself", "", bar, progressBarWidth + 4, 5},
+		{"text stops at the ceiling", "", overflow, progressModalMaxWidth, progressModalMaxLines + 2},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			width := progressBoxWidth(testCase.title, testCase.update)
+			if width != testCase.wantWidth {
+				t.Fatalf("width = %d, want %d", width, testCase.wantWidth)
+			}
+			if height := progressBoxHeight(width, testCase.update); height != testCase.wantHeight {
+				t.Fatalf("height = %d, want %d", height, testCase.wantHeight)
+			}
+		})
+	}
+}
+
+// A title of "" was still written to the border as two spaces, leaving a gap
+// where a name should be.
+func TestProgressBoxWithoutATitleDrawsAnUnbrokenBorder(t *testing.T) {
+	if !SetCurrentTheme("default") {
+		t.Fatal("failed to select default theme")
+	}
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	update := ProgressUpdate{Text: "Searching..."}
+	width := progressBoxWidth("", update)
+	height := progressBoxHeight(width, update)
+	screen.SetSize(width, height)
+	progress := NewProgress("").SetUpdate(update)
+	progress.SetRect(0, 0, width, height)
+	progress.Draw(screen)
+
+	var border strings.Builder
+	for x := range width {
+		value, _, _ := screen.Get(x, 0)
+		_, _ = border.WriteString(value)
+	}
+	if strings.Contains(border.String(), " ") {
+		t.Fatalf("untitled border has a gap in it: %q", border.String())
+	}
+
+	var text strings.Builder
+	for x := range width {
+		value, _, _ := screen.Get(x, 1)
+		_, _ = text.WriteString(value)
+	}
+	if !strings.Contains(text.String(), "Searching...") {
+		t.Fatalf("progress text missing: %q", text.String())
+	}
+}
+
 func TestShowProgressModalRunsTaskAndThrottlesUpdates(t *testing.T) {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	if err := screen.Init(); err != nil {
@@ -120,6 +188,127 @@ func TestShowProgressModalRunsTaskAndThrottlesUpdates(t *testing.T) {
 	}
 	if shown.Current != 0 {
 		t.Fatalf("updates were not throttled: %+v", shown)
+	}
+}
+
+// runningProgressApp starts an application on a simulation screen with one
+// focusable page underneath, and stops it when the test ends.
+func runningProgressApp(t *testing.T) (*tview.Application, *tview.Pages, tview.Primitive) {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	app := tview.NewApplication().SetScreen(screen)
+	base := tview.NewBox()
+	pages := tview.NewPages().AddPage("base", base, true, true)
+	app.SetRoot(pages, true).SetFocus(base)
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run() }()
+	t.Cleanup(func() {
+		app.Stop()
+		select {
+		case <-runErr:
+		case <-time.After(5 * time.Second):
+			t.Error("application did not stop")
+		}
+	})
+	return app, pages, base
+}
+
+func TestProgressDrawsNothingWhileHidden(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(60, 7)
+	progress := NewProgress("Favorites").
+		SetUpdate(ProgressUpdate{Text: "Checking favorites...", Current: 1, Total: 2}).
+		SetHidden(true)
+	progress.SetRect(0, 0, 60, 7)
+	progress.Draw(screen)
+	for y := range 7 {
+		for x := range 60 {
+			value, _, _ := screen.Get(x, y)
+			if value != " " {
+				t.Fatalf("hidden progress drew %q at %d,%d", value, x, y)
+			}
+		}
+	}
+}
+
+// A modal that appears and disappears inside the same second reads as a glitch
+// rather than as feedback, so the box waits. The overlay does not: whatever the
+// task is doing, it does it alone.
+func TestShowProgressModalBlocksInputWhileTheBoxIsStillHidden(t *testing.T) {
+	app, pages, _ := runningProgressApp(t)
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	var progress *Progress
+	app.QueueUpdate(func() {
+		progress = ShowProgressModal(pages, app, ProgressOptions{Title: "Working", Delay: time.Hour},
+			func(func(ProgressUpdate)) error {
+				<-release
+				return nil
+			}, func(err error) { done <- err })
+	})
+
+	var hasPage, focused, hidden bool
+	app.QueueUpdate(func() {
+		hasPage = pages.HasPage(progressModalPage)
+		focused = app.GetFocus() == tview.Primitive(progress)
+		hidden = progress.Hidden()
+	})
+	if !hasPage {
+		t.Fatal("progress overlay was not added")
+	}
+	if !focused {
+		t.Fatal("progress overlay did not take focus, so keys reach the page underneath")
+	}
+	if !hidden {
+		t.Fatal("progress box drew before its delay elapsed")
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("progress task did not complete")
+	}
+}
+
+func TestShowProgressModalShowsTheBoxWhenWorkOutlastsTheDelay(t *testing.T) {
+	app, pages, _ := runningProgressApp(t)
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	var progress *Progress
+	app.QueueUpdate(func() {
+		progress = ShowProgressModal(pages, app, ProgressOptions{Title: "Working", Delay: time.Millisecond},
+			func(func(ProgressUpdate)) error {
+				<-release
+				return nil
+			}, func(err error) { done <- err })
+	})
+
+	var visible bool
+	deadline := time.Now().Add(5 * time.Second)
+	for !visible && time.Now().Before(deadline) {
+		app.QueueUpdate(func() { visible = !progress.Hidden() })
+		if visible {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !visible {
+		t.Fatal("progress box never appeared for work that outlasted its delay")
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("progress task did not complete")
 	}
 }
 

--- a/pkg/tui/service_page.go
+++ b/pkg/tui/service_page.go
@@ -1,0 +1,154 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"github.com/rivo/tview"
+)
+
+// ServiceActions are the operations a service page offers. They run off the UI
+// goroutine, so they may block.
+//
+// This takes callbacks rather than a *service.Service on purpose: pkg/tui
+// imports nothing from the rest of mrext, and keeping it that way is what lets
+// it be reasoned about and tested on its own.
+type ServiceActions struct {
+	Running   func() bool
+	Start     func() error
+	Stop      func() error
+	Restart   func() error
+	Uninstall func()
+	Exit      func()
+	// Status renders the body for the current state. Called on every redraw.
+	Status func(running bool) string
+}
+
+// ServicePage is the Scripts-menu screen shared by the daemon apps: a status
+// block and a Start/Stop, Restart, Uninstall, Exit bar, with Exit selected by
+// default because most visits are to read the state and leave.
+type ServicePage struct {
+	app     *tview.Application
+	pages   *tview.Pages
+	actions ServiceActions
+	status  *tview.TextView
+	bar     *ButtonBar
+	frame   *PageFrame
+	name    string
+}
+
+// NewServicePage builds the page. Call Show to put it on the pages.
+func NewServicePage(
+	app *tview.Application, pages *tview.Pages, name string, actions ServiceActions,
+) *ServicePage {
+	page := &ServicePage{
+		app:     app,
+		pages:   pages,
+		actions: actions,
+		name:    name,
+		status:  tview.NewTextView().SetTextAlign(tview.AlignCenter).SetWrap(true).SetWordWrap(true),
+	}
+	page.build()
+	return page
+}
+
+func (s *ServicePage) build() {
+	s.bar = NewButtonBar(s.app).
+		AddButtonWithHelp("Start", "Start or stop the "+s.name+" service", s.toggle).
+		AddButtonWithHelp("Restart", "Stop and start the service again", func() {
+			s.run("Restarting service...", s.actions.Restart)
+		}).
+		AddButtonWithHelp("Uninstall", "Remove "+s.name+" from startup and delete what it installed",
+			func() {
+				if s.actions.Uninstall != nil {
+					s.actions.Uninstall()
+				}
+			}).
+		AddButtonWithHelp("Exit", "Leave this screen; the service keeps running", s.exit).
+		SetupNavigation(s.exit)
+	s.bar.SetFocusedIndex(3)
+
+	s.frame = NewPageFrame(s.app).
+		SetTitle(s.name).
+		SetContent(s.status).
+		SetFocusTarget(s.bar).
+		SetHelpText("Leave this screen; the service keeps running").
+		SetButtonBar(s.bar).
+		SetOnEscape(s.exit)
+	s.bar.SetHelpCallback(func(text string) { s.frame.SetHelpText(text) })
+	s.Redraw()
+}
+
+func (s *ServicePage) exit() {
+	if s.actions.Exit != nil {
+		s.actions.Exit()
+		return
+	}
+	s.app.Stop()
+}
+
+func (s *ServicePage) toggle() {
+	if s.actions.Running() {
+		s.run("Stopping service...", s.actions.Stop)
+		return
+	}
+	s.run("Starting service...", s.actions.Start)
+}
+
+// run performs a service command on its own goroutine. Doing it inline froze
+// the screen for as long as the command took, with nothing to say why.
+func (s *ServicePage) run(message string, action func() error) {
+	if action == nil {
+		return
+	}
+	s.status.SetText(message)
+	go func() {
+		err := action()
+		s.app.QueueUpdateDraw(func() {
+			s.Redraw()
+			if err != nil {
+				ShowErrorModal(s.pages, s.app, err.Error(), s.Redraw)
+			}
+		})
+	}()
+}
+
+// Redraw refreshes the status block and the Start/Stop label.
+func (s *ServicePage) Redraw() {
+	running := s.actions.Running()
+	s.status.SetText(s.actions.Status(running))
+	toggle := "Start"
+	if running {
+		toggle = "Stop"
+	}
+	s.bar.UpdateButtonLabel(0, toggle)
+}
+
+// Frame exposes the page for callers that add it themselves.
+func (s *ServicePage) Frame() *PageFrame { return s.frame }
+
+// ButtonBar exposes the bar so an app can add its own action. Extra buttons
+// land after Exit; the Start/Stop toggle has to stay at index 0.
+func (s *ServicePage) ButtonBar() *ButtonBar { return s.bar }
+
+// Show adds the page and focuses its buttons.
+func (s *ServicePage) Show(name string) {
+	s.pages.AddAndSwitchToPage(name, s.frame, true)
+	s.app.SetFocus(s.bar)
+}

--- a/pkg/tui/startup.go
+++ b/pkg/tui/startup.go
@@ -1,0 +1,57 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// RunWhenStarted schedules work to run once the application's event loop is
+// live, and never if it is not. The returned flag reports whether that
+// happened, which is how a caller tells a real failure from a headless run
+// where no terminal was ever available.
+//
+// This exists because BuildAndRetry calls its builder a second time to retry
+// on /dev/tty2. Work started directly inside a builder therefore runs twice,
+// concurrently, against the same files.
+//
+// QueueUpdateDraw cannot be used from the builder either: it blocks until the
+// event loop executes the callback, so calling it before Run deadlocks. The
+// after-draw hook only fires when the application is really drawing, which is
+// exactly the signal needed, and the work is then queued from a goroutine so
+// it mutates the UI on the event loop rather than mid-draw.
+//
+// It installs an after-draw handler, so it must not be combined with a caller
+// that sets its own.
+func RunWhenStarted(app *tview.Application, work func()) *atomic.Bool {
+	var started atomic.Bool
+	var once sync.Once
+	app.SetAfterDrawFunc(func(tcell.Screen) {
+		once.Do(func() {
+			started.Store(true)
+			go app.QueueUpdateDraw(work)
+		})
+	})
+	return &started
+}

--- a/pkg/tui/startup_test.go
+++ b/pkg/tui/startup_test.go
@@ -1,0 +1,87 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestRunWhenStartedIgnoresAnApplicationThatNeverDraws(t *testing.T) {
+	// BuildAndRetry builds a second application to retry on /dev/tty2, so work
+	// started directly in a builder runs twice against the same files. The
+	// abandoned application never draws, so it must never start anything.
+	abandoned := tview.NewApplication()
+	ran := false
+	started := RunWhenStarted(abandoned, func() { ran = true })
+
+	time.Sleep(50 * time.Millisecond)
+
+	if started.Load() {
+		t.Error("reported started for an application that never ran")
+	}
+	if ran {
+		t.Error("work ran on an application that never drew")
+	}
+}
+
+func TestRunWhenStartedRunsOnceOnTheApplicationThatDraws(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	app := tview.NewApplication().SetScreen(screen)
+	app.SetRoot(tview.NewBox(), true)
+
+	runs := make(chan struct{}, 8)
+	started := RunWhenStarted(app, func() { runs <- struct{}{} })
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run() }()
+	t.Cleanup(func() {
+		app.Stop()
+		select {
+		case <-runErr:
+		case <-time.After(5 * time.Second):
+			t.Error("application did not stop")
+		}
+	})
+
+	select {
+	case <-runs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("work never ran on a drawing application")
+	}
+	if !started.Load() {
+		t.Error("started flag not set")
+	}
+
+	// Redraws must not start it again.
+	app.QueueUpdateDraw(func() {})
+	app.QueueUpdateDraw(func() {})
+	select {
+	case <-runs:
+		t.Error("work ran more than once")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/tui/virtual_keyboard.go
+++ b/pkg/tui/virtual_keyboard.go
@@ -37,6 +37,18 @@ const (
 	keyboardCancel  = "CANC"
 )
 
+// The grid is 39 cells wide. Character rows sit on a four-cell pitch, ten to a
+// row. The action row is [SHFT SYM] [SPC] [DEL OK CANC] on a five-cell pitch,
+// with the space bar stretched across whatever is left in the middle.
+const (
+	keyboardGridWidth   = 39
+	keyboardKeyPitch    = 4
+	keyboardActionPitch = 5
+	keyboardLeftKeys    = 2
+	keyboardSpaceCol    = 2
+	keyboardRightCol    = 3
+)
+
 var (
 	keyboardLower = [][]string{
 		{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
@@ -57,7 +69,9 @@ var (
 		{"-", "_", "=", "+", "[", "]", "{", "}", "\\", "|"},
 		{";", ":", "'", "\"", "`", "~", "/", "?", "<", ">"},
 		{},
-		{"ABC", keyboardSpace, keyboardDelete, keyboardSubmit, keyboardCancel},
+		// The blank holds ABC in the column SYM occupies in the other
+		// layouts, so toggling between them does not move the cursor.
+		{"", "ABC", keyboardSpace, keyboardDelete, keyboardSubmit, keyboardCancel},
 	}
 )
 
@@ -139,23 +153,23 @@ func (k *VirtualKeyboard) drawRow(
 	keys []string,
 	theme *Theme,
 ) {
-	if row == len(k.layout())-1 {
-		leftCount := len(keys) - 4
-		rightStart := 39 - 3*5
+	if row != len(k.layout())-1 {
 		for column, key := range keys {
-			keyX, keyWidth := x+column*5, 4
-			switch {
-			case column == leftCount:
-				keyWidth = rightStart - leftCount*5 - 1
-			case column > leftCount:
-				keyX = x + rightStart + (column-leftCount-1)*5
-			}
-			k.drawKey(screen, keyX, y, key, keyWidth, row, column, theme)
+			k.drawKey(screen, x+column*keyboardKeyPitch, y, key, keyboardKeyPitch-1, row, column, theme)
 		}
 		return
 	}
+	leftEnd := keyboardLeftKeys * keyboardActionPitch
+	rightStart := keyboardGridWidth - (len(keys)-keyboardRightCol)*keyboardActionPitch
 	for column, key := range keys {
-		k.drawKey(screen, x+column*4, y, key, 3, row, column, theme)
+		keyX, keyWidth := x+column*keyboardActionPitch, keyboardActionPitch-1
+		switch {
+		case column == keyboardSpaceCol:
+			keyX, keyWidth = x+leftEnd, rightStart-leftEnd-1
+		case column > keyboardSpaceCol:
+			keyX = x + rightStart + (column-keyboardRightCol)*keyboardActionPitch
+		}
+		k.drawKey(screen, keyX, y, key, keyWidth, row, column, theme)
 	}
 }
 
@@ -206,9 +220,9 @@ func (k *VirtualKeyboard) InputHandler() func(*tcell.EventKey, func(tview.Primit
 		case tcell.KeyDown:
 			k.moveVertical(layout, 1)
 		case tcell.KeyLeft:
-			k.cursorCol = (k.cursorCol - 1 + len(layout[k.cursorRow])) % len(layout[k.cursorRow])
+			k.cursorCol = k.moveHorizontal(layout, -1)
 		case tcell.KeyRight:
-			k.cursorCol = (k.cursorCol + 1) % len(layout[k.cursorRow])
+			k.cursorCol = k.moveHorizontal(layout, 1)
 		case tcell.KeyEnter:
 			k.activate()
 		case tcell.KeyEscape:
@@ -224,15 +238,93 @@ func (k *VirtualKeyboard) InputHandler() func(*tcell.EventKey, func(tview.Primit
 	})
 }
 
-func (k *VirtualKeyboard) moveVertical(layout [][]string, direction int) {
+// moveHorizontal wraps along the current row, stepping over the blank that
+// holds the symbols action row in line with the other layouts.
+func (k *VirtualKeyboard) moveHorizontal(layout [][]string, direction int) int {
+	keys := layout[k.cursorRow]
 	column := k.cursorCol
-	for {
-		k.cursorRow = (k.cursorRow + direction + len(layout)) % len(layout)
-		if len(layout[k.cursorRow]) > 0 {
-			k.cursorCol = min(column, len(layout[k.cursorRow])-1)
-			return
+	for range keys {
+		column = (column + direction + len(keys)) % len(keys)
+		if keys[column] != "" {
+			return column
 		}
 	}
+	return k.cursorCol
+}
+
+func (k *VirtualKeyboard) moveVertical(layout [][]string, direction int) {
+	from := k.cursorRow
+	row := k.cursorRow
+	for range layout {
+		row = (row + direction + len(layout)) % len(layout)
+		if len(layout[row]) > 0 {
+			break
+		}
+	}
+	k.cursorRow = row
+	k.cursorCol = mapKeyboardColumn(layout, from, row, k.cursorCol)
+}
+
+// mapKeyboardColumn keeps the cursor under the key it left when crossing
+// between the character rows and the action row, which are drawn on different
+// pitches: z<->SHFT, x/c<->SYM, v/b/n<->SPC, m<->DEL, ,<->OK, .<->CANC. This
+// is Zaparoo Core's mapping, and without it a plain column index sends "." to
+// CANC on the way down and lands on "n" on the way back up, with everything
+// from "v" rightwards jumping across the row.
+func mapKeyboardColumn(layout [][]string, from, to, column int) int {
+	bottom := len(layout) - 1
+	keys := layout[to]
+	switch {
+	case from == bottom && to != bottom:
+		return skipBlankKey(keys, actionToCharacterColumn(column, len(keys)))
+	case from != bottom && to == bottom:
+		return skipBlankKey(keys, characterToActionColumn(column))
+	default:
+		return min(column, len(keys)-1)
+	}
+}
+
+func actionToCharacterColumn(column, width int) int {
+	switch column {
+	case 0:
+		return 0
+	case 1:
+		return min(1, width-1)
+	case 2:
+		return min(4, width-1)
+	case 3:
+		return min(6, width-1)
+	case 4:
+		return min(7, width-1)
+	default:
+		return width - 1
+	}
+}
+
+func characterToActionColumn(column int) int {
+	switch column {
+	case 0:
+		return 0
+	case 1, 2:
+		return 1
+	case 3, 4, 5:
+		return keyboardSpaceCol
+	case 6:
+		return keyboardRightCol
+	case 7:
+		return 4
+	default:
+		return 5
+	}
+}
+
+// skipBlankKey shifts off the symbols row's spacer, which is drawn but is not
+// a key. Zaparoo lets the cursor rest on it; there is nothing to press there.
+func skipBlankKey(keys []string, column int) int {
+	for column < len(keys) && keys[column] == "" {
+		column++
+	}
+	return min(column, len(keys)-1)
 }
 
 func (k *VirtualKeyboard) deleteLast() {
@@ -260,7 +352,8 @@ func (k *VirtualKeyboard) activate() {
 	case keyboardSymbols:
 		k.symbols = true
 		k.shift = false
-		k.cursorCol = 0
+		// ABC sits where SYM was, so the cursor does not appear to move.
+		k.cursorCol = 1
 	case "ABC":
 		k.symbols = false
 		k.cursorCol = 1

--- a/pkg/tui/virtual_keyboard_test.go
+++ b/pkg/tui/virtual_keyboard_test.go
@@ -1,0 +1,171 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func pressKeyboard(keyboard *VirtualKeyboard, key tcell.Key) {
+	keyboard.InputHandler()(tcell.NewEventKey(key, 0, tcell.ModNone), nil)
+}
+
+func selectedKey(keyboard *VirtualKeyboard) string {
+	return keyboard.layout()[keyboard.cursorRow][keyboard.cursorCol]
+}
+
+// selectedSpan renders the keyboard and reports where the highlighted key is
+// actually drawn, so the tests measure the layout instead of recomputing it.
+func selectedSpan(t *testing.T, keyboard *VirtualKeyboard) (row, start, end int) {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer screen.Fini()
+	screen.SetSize(keyboardModalWidth, keyboardModalHeight)
+	keyboard.SetRect(0, 0, keyboardModalWidth, keyboardModalHeight)
+	keyboard.Draw(screen)
+	highlight := tcell.GetColor(CurrentTheme().HighlightBackgroundName)
+	row, start, end = -1, -1, -1
+	for y := range keyboardModalHeight {
+		for x := range keyboardModalWidth {
+			_, style, _ := screen.Get(x, y)
+			_, background, _ := style.Decompose()
+			if background != highlight {
+				continue
+			}
+			if row < 0 {
+				row, start = y, x
+			}
+			end = x
+		}
+	}
+	if row < 0 {
+		t.Fatalf("no key is highlighted for %q", selectedKey(keyboard))
+	}
+	return row, start, end
+}
+
+// The character rows are drawn on a four-cell pitch and the action row on a
+// five-cell one, so a plain column index does not survive the move between
+// them: "v" lands on DEL, seven cells away. Pressing down must land on the key
+// drawn underneath the one being left.
+func TestVirtualKeyboardActionKeysSitUnderTheCharactersAbove(t *testing.T) {
+	if !SetCurrentTheme("default") {
+		t.Fatal("failed to select default theme")
+	}
+	characters := keyboardLower[len(keyboardLower)-2]
+	for column, key := range characters {
+		keyboard := NewVirtualKeyboard("", nil, nil)
+		keyboard.cursorRow = len(keyboardLower) - 2
+		keyboard.cursorCol = column
+		characterRow, characterStart, characterEnd := selectedSpan(t, keyboard)
+
+		pressKeyboard(keyboard, tcell.KeyDown)
+		actionRow, actionStart, actionEnd := selectedSpan(t, keyboard)
+
+		if actionRow != characterRow+1 {
+			t.Fatalf("%q moved from row %d to row %d", key, characterRow, actionRow)
+		}
+		if actionEnd < characterStart || actionStart > characterEnd {
+			t.Fatalf("down from %q at %d-%d landed on %q at %d-%d, which is not drawn under it",
+				key, characterStart, characterEnd, selectedKey(keyboard), actionStart, actionEnd)
+		}
+	}
+}
+
+func TestVirtualKeyboardVerticalNavigationReturnsToTheSameKey(t *testing.T) {
+	actions := keyboardLower[len(keyboardLower)-1]
+	for column, key := range actions {
+		keyboard := NewVirtualKeyboard("", nil, nil)
+		keyboard.cursorRow = len(keyboardLower) - 1
+		keyboard.cursorCol = column
+		pressKeyboard(keyboard, tcell.KeyUp)
+		above := selectedKey(keyboard)
+		pressKeyboard(keyboard, tcell.KeyDown)
+		if got := selectedKey(keyboard); got != key {
+			t.Fatalf("%q went up to %q and came back to %q", key, above, got)
+		}
+	}
+}
+
+func TestVirtualKeyboardSymbolToggleKeepsTheCursorWhereItWas(t *testing.T) {
+	if !SetCurrentTheme("default") {
+		t.Fatal("failed to select default theme")
+	}
+	keyboard := NewVirtualKeyboard("", nil, nil)
+	keyboard.cursorRow = len(keyboardLower) - 1
+	keyboard.cursorCol = 1
+	if selectedKey(keyboard) != keyboardSymbols {
+		t.Fatalf("expected to start on SYM, got %q", selectedKey(keyboard))
+	}
+	symbolRow, symbolStart, symbolEnd := selectedSpan(t, keyboard)
+
+	pressKeyboard(keyboard, tcell.KeyEnter)
+	if selectedKey(keyboard) != "ABC" {
+		t.Fatalf("SYM left the cursor on %q", selectedKey(keyboard))
+	}
+	row, start, end := selectedSpan(t, keyboard)
+	if row != symbolRow || start != symbolStart || end != symbolEnd {
+		t.Fatalf("ABC is drawn at %d:%d-%d but SYM was at %d:%d-%d",
+			row, start, end, symbolRow, symbolStart, symbolEnd)
+	}
+
+	pressKeyboard(keyboard, tcell.KeyEnter)
+	if selectedKey(keyboard) != keyboardSymbols {
+		t.Fatalf("ABC left the cursor on %q", selectedKey(keyboard))
+	}
+}
+
+// The symbols action row carries a blank in SHFT's column so ABC lines up with
+// SYM. It is drawn, but it is not a key, and the cursor must never stop there.
+func TestVirtualKeyboardNeverSelectsTheSpacer(t *testing.T) {
+	keyboard := NewVirtualKeyboard("", nil, nil)
+	keyboard.cursorRow = len(keyboardLower) - 1
+	keyboard.cursorCol = 1
+	pressKeyboard(keyboard, tcell.KeyEnter)
+	if !keyboard.symbols {
+		t.Fatal("SYM did not switch to the symbols layout")
+	}
+
+	characters := keyboardSymbolKeys[len(keyboardSymbolKeys)-3]
+	for column := range characters {
+		keyboard.cursorRow = len(keyboardSymbolKeys) - 3
+		keyboard.cursorCol = column
+		pressKeyboard(keyboard, tcell.KeyDown)
+		if selectedKey(keyboard) == "" {
+			t.Fatalf("down from column %d rested on the spacer", column)
+		}
+	}
+
+	for _, direction := range []tcell.Key{tcell.KeyLeft, tcell.KeyRight} {
+		keyboard.cursorRow = len(keyboardSymbolKeys) - 1
+		keyboard.cursorCol = 1
+		for step := range len(keyboardSymbolKeys[len(keyboardSymbolKeys)-1]) * 2 {
+			pressKeyboard(keyboard, direction)
+			if selectedKey(keyboard) == "" {
+				t.Fatalf("step %d of horizontal navigation rested on the spacer", step)
+			}
+		}
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,99 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+// Package version reports which build of an mrext app is running.
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Version is stamped at build time with -ldflags "-X .../pkg/version.Version=...".
+// Left empty for a plain "go build", which falls back to the VCS stamps Go
+// records automatically.
+var Version = ""
+
+// Commit is stamped the same way. Empty falls back to vcs.revision.
+var Commit = ""
+
+const unknown = "unknown"
+
+// String renders "<version> (<commit>)" for a binary, or as much of it as is
+// known. Apps print this for -version and show it in their title bar, so a user
+// can say which build they are on without guessing from a file date.
+func String() string {
+	version, commit := Version, Commit
+	if version == "" || commit == "" {
+		buildVersion, buildCommit := fromBuildInfo()
+		if version == "" {
+			version = buildVersion
+		}
+		if commit == "" {
+			commit = buildCommit
+		}
+	}
+	if version == "" {
+		version = unknown
+	}
+	if commit == "" {
+		return version
+	}
+	return version + " (" + commit + ")"
+}
+
+// Short renders just the version, for a title bar where the commit does not fit.
+func Short() string {
+	if Version != "" {
+		return Version
+	}
+	if buildVersion, _ := fromBuildInfo(); buildVersion != "" {
+		return buildVersion
+	}
+	return unknown
+}
+
+func fromBuildInfo() (version, commit string) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", ""
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		version = info.Main.Version
+	}
+	modified := false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			commit = setting.Value
+			if len(commit) > 7 {
+				commit = commit[:7]
+			}
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+	if modified && commit != "" {
+		commit += "-dirty"
+	}
+	if version == "" && commit != "" {
+		version = "dev"
+	}
+	return version, strings.TrimSpace(commit)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,59 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStringPrefersStampedValues(t *testing.T) {
+	previousVersion, previousCommit := Version, Commit
+	t.Cleanup(func() { Version, Commit = previousVersion, previousCommit })
+
+	Version, Commit = "v1.4.2", "8839ae1"
+	if got := String(); got != "v1.4.2 (8839ae1)" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := Short(); got != "v1.4.2" {
+		t.Errorf("Short() = %q", got)
+	}
+
+	// Without a commit the version still stands on its own.
+	Commit = ""
+	if got := String(); !strings.HasPrefix(got, "v1.4.2") {
+		t.Errorf("String() without a commit = %q", got)
+	}
+}
+
+func TestStringFallsBackToBuildInfo(t *testing.T) {
+	previousVersion, previousCommit := Version, Commit
+	t.Cleanup(func() { Version, Commit = previousVersion, previousCommit })
+
+	// A plain "go build" leaves these empty; Go's own VCS stamps fill in, and
+	// failing that the output is still something a user can report.
+	Version, Commit = "", ""
+	if got := String(); got == "" {
+		t.Error("String() must never be empty")
+	}
+	if got := Short(); got == "" {
+		t.Error("Short() must never be empty")
+	}
+}


### PR DESCRIPTION
Stages 4 and 6 of the refresh plan, plus the two items I deferred from the last one.

## The console-only apps

LastPlayed, PlayLog and LaunchSync printed to the Scripts console and exited. Two of them asked their startup question through `utils.YesOrNoPrompt` — a raw-terminal `[DOWN=Yes/UP=No]` read that `panic`s when stdin is not a TTY.

New `pkg/tui.ServicePage`: status text plus `Start`/`Stop`, `Restart`, `Uninstall`, `Exit`, with Exit focused because most visits are to read the state and leave. **It takes callbacks, not a `*service.Service`** — `pkg/tui` imports nothing from the rest of mrext and that stays true.

- **LastPlayed** and **PlayLog** adopt it. The startup question is the same question on the shared confirm dialog.
- **PlayLog's** top-ten cores and games become a Stats page with the same `Xh Ym` times, instead of a report that scrolls past.
- **Uninstall** stops the service and removes only that app's own `user-startup.sh` block, then asks *separately* before deleting generated menu entries. PlayLog never touches `playlog.db` and the summary says where it still is. This closes #117.

## LaunchSync

Its steps run behind a progress box now, with a summary of what each sync file produced — created, not found, errors — and Details for the full log.

It used to print `Building games index... ` *without a newline* and then block through a scan that can take minutes, so a slow step looked like a hang.

`findSyncFiles` reports through the same callback rather than printing directly. That is what lets one code path serve both the console log and the modal — without it, its `fmt.Printf` would have written underneath the drawn screen.

## Favorites' blank startup

`SetupArcadeLinks` (a recursive symlink walk) and `Refresh` (a stat and readlink per favourite) ran *before* anything was drawn. On a large collection, or one on USB or a network share, that was several seconds of blank screen with no way to tell whether it had hung. Both now run inside the app behind a progress box, as does reading a ZIP's contents — the Python original carried a FIXME about how slow that is.

## Versions

Every binary answers `-version`. `mage build`/`mage mister` stamp it from `git describe` plus the short commit; a plain `go build` falls back to Go's own VCS stamps, so the flag always reports something useful. Apps with a page frame also print it in the bottom border, dropped when it would collide with the key hints.

Documented in `docs/dev.md`, not the README — that holds per-app blurbs and download links.

## Nothing headless changed

`-service start|stop|restart|status` and `launchsync -update` still produce no screen and the same output, so `user-startup.sh` and any script calling them behave exactly as before. `-test` is unchanged too. Verified `-update` is silent without `-verbose` and unchanged with it.

## Tests

- `pkg/tui` — the service page renders its state, keeps Exit focused and flips Start to Stop; the version draws when it fits and is dropped at 60 columns rather than overlapping the hints.
- `pkg/version` — stamped values win, and the fallback never returns empty.
- `cmd/launchsync` — summary counts, totals and buttons.
- `cmd/favorites` — `TestCancelAddInsideArchiveReturnsToBrowser` now drives a running application, because returning to an archive listing goes through a progress modal and `QueueUpdateDraw` needs one.

## Validation

`mage test`, `mage lint` (0 issues), `mage mister` for all nine apps, `npm test --prefix web/remote` (29 tests), and `go test -race` across `./cmd/...` and `./pkg/...`.

Not device-tested. Remote's screen at 57 columns under CRT mode and the new service pages are what I would want eyes on.

---

# Follow-up: startup work, the keyboard, and the loading box

Four fixes found while going over the above on hardware, plus a deploy target.

## Startup work ran twice, and a headless LaunchSync did nothing

`BuildAndRetry` calls its builder a **second time** to retry on `/dev/tty2`. Work started inside a builder therefore ran twice, concurrently, against the same files — for Favorites that is `Refresh` removing and recreating the same symlinks from two goroutines.

New `tui.RunWhenStarted` defers the work to the application's first draw via `SetAfterDrawFunc` (guarded by a `sync.Once`) and returns whether that ever happened. BGM already used the same hook for exactly this "we are live now" signal.

`QueueUpdateDraw` cannot be used from a builder — it blocks until the event loop executes the callback, so calling it before `Run` deadlocks. My first attempt did that and hung all three apps at startup; the test caught it by hanging.

That "was a screen ever obtained" flag is what makes the headless fallback safe: **LaunchSync** run from cron or `ssh` without a tty now prints the console log it always printed, while a failure *after* a screen came up is reported as a failure rather than silently re-running and rewriting every shortcut.

## The on-screen keyboard's rows had nothing to do with each other

Adapted from Zaparoo Core's `pkg/ui/tui/osk.go` without `mapColumnForVerticalNav`. Character rows are drawn on a four-cell pitch and the action row on a five-cell one, and the adaptation just clamped the column index across that boundary:

- `v` is drawn at x13; pressing Down landed on `DEL` at x25.
- `.` went down to `CANC` and came back up to `n`.

Ports the mapping verbatim — `z↔SHFT, x/c↔SYM, v/b/n↔SPC, m↔DEL, ,↔OK, .↔CANC`. It cannot be derived from the geometry: `SPC` deliberately claims three letters, and no distance rule reproduces both `c→SYM` and `.→CANC`.

Also ports the blank that holds `ABC` in `SYM`'s column, so toggling the symbol layer no longer jumps the cursor sideways. **One deviation from upstream:** their nav switch still assumes the older five-key symbols row, so the cursor can rest on that blank and press a key that does nothing. Navigation here skips it.

## The loading box

A fixed 60×7 with an unconditional title, so `Searching...` sat above four empty rows under a two-space gap in the border where an empty title had been written over it.

- Fits its content, between 24 and 60 cells, and only ever grows — sizing to every update would leave it twitching around the screen for a whole index rebuild.
- A title only where it says something the text does not. GamesMenu keeps its two (`Creating MGL files...` over `Scanning SNES`); Search, Favorites and LaunchSync had the app name over a one-word status, and no longer do.
- Stays **hidden for the first 500ms** while its overlay still takes focus and swallows mouse clicks, so quick work is silent instead of a box that appears and vanishes. Input has to stay dead in that window — `Refresh` is mutating symlinks — and `Centered` is built on a `tview.Flex`, which sets `dontClear`, so a hidden box paints nothing at all.

## Redundant input prompts

The page behind a modal keeps drawing, so the row being edited and its footer help are already on screen beside the modal's title. `Enter default folder.` above `Edit Default folder` was the fourth way of saying one thing. Removed where it restated the title; kept where it carries a rule or an example. Renaming a *folder* now says the thing none of the others do — the name needs a leading underscore, which its validator has always required.

## `mage deploy <address>`

Builds every app and copies `_bin/linux_arm` over SSH to `root@<address>:/media/fat/Scripts`. The address is validated before the build, so a typo does not cost a full `mister all` first.

## Tests

- `pkg/tui/startup_test.go` — an application that never draws starts nothing and reports not-started; one that does runs the work exactly once and is not re-triggered by later redraws.
- `pkg/tui/virtual_keyboard_test.go` — the alignment test measures the **rendered** highlight rather than recomputing the layout, so it cannot drift with the constants. Against the old code: `down from "v" at 13-15 landed on "DEL" at 25-28`.
- `pkg/tui/progress_test.go` — box size against content, the unbroken border, and that the overlay holds focus while the box is still hidden.

Each of these was checked against a mutated implementation to confirm it actually fails.

## Validation

`mage test`, `mage lint` (0 issues), `-race` across `./cmd/...` and `./pkg/...`, `mage mister all`.

Still not device-tested. The `/dev/tty2` retry path is the one thing here that only really exercises on a MiSTer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version`/`-version` options across command-line tools.
  * Added `mage deploy <address>` to build and copy applications to MiSTer devices.
  * Added interactive service screens for LastPlayed and PlayLog, including controls, status, statistics, and uninstall options.
  * Added a LaunchSync progress screen with sync summaries and detailed logs.
  * Added version information to full-screen application borders.

* **Improvements**
  * Favorites now provides clearer progress feedback when starting, refreshing, and browsing archives.
  * Improved virtual keyboard layout and cursor navigation.
  * Search startup now loads more reliably after the interface appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->