### PR TITLE
docs: position mrext as maintained, and fix three stale strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,22 @@ Human docs live in [README.md](README.md), [docs/dev.md](docs/dev.md) and
 
 ## Scope and Zaparoo
 
-- Read [MIGRATE.md](MIGRATE.md) before proposing a new MiSTer integration or a
-  new cross-platform feature. Where it maps an mrext component to a maintained
-  Zaparoo replacement, do not present mrext's REST/WebSocket API, Go packages,
-  or `.mgl`/`.sync` generation as the preferred path for new integrations.
-- Work that keeps mrext apps working, or improves stock-MiSTer behaviour that
-  MIGRATE.md records as a gap, is in scope. Say plainly when a change targets
-  stock MiSTer without Core rather than presenting it as Zaparoo architecture.
-- Do not claim replacement parity. Preserve and report the gaps in MIGRATE.md.
+- mrext is actively maintained and standalone. Preserve familiar workflows,
+  configuration, files, CLI behavior, and existing Remote client contracts.
+  Do not tell end users they must migrate or describe the tools as retired.
+- For new media applications and integrations, including MiSTer-only projects,
+  use the Zaparoo Core daemon's public API or CLI. Do not use mrext's internal
+  indexing, tracking, launch packages, or Remote media API as the default
+  foundation when Core provides the required interface. Read
+  [MIGRATE.md](MIGRATE.md) for mappings and genuine workflow differences.
+- Remote's API remains supported for existing clients and specialist MiSTer
+  functions such as INI editing, wallpapers, and menu management. Use mrext
+  where those functions are needed without claiming full Core parity.
+- Keep maintenance of these tools separate from runtime integration changes.
+  Do not add a mandatory Core dependency, silently switch backends, or claim
+  proposed integration is shipped.
+- Public app docs should explain usage and relevant Zaparoo features, not
+  internal strategy, maintenance sequencing, or speculative architecture.
 - `/tmp/ACTIVEGAME` is a MiSTer-specific compatibility file that both mrext and
   Zaparoo Core maintain. Keep existing readers working; new integrations should
   prefer Core's public state, notification or MQTT interfaces.

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,10 +1,16 @@
-# Migrating from mrext to Zaparoo
+# mrext and Zaparoo
 
-mrext is maintained for legacy users. Before starting or extending a MiSTer project with mrext, use this guide to check whether current Zaparoo features provide a maintained replacement.
+MiSTer Extensions is actively maintained and works without Zaparoo. You can keep using its tools for stock-menu shortcuts, controller-driven search, music, and MiSTer settings.
 
-Existing mrext installations can keep working. Migrate only after verifying the replacement for your workflow. mrext and raw MiSTer conventions can remain appropriate where this guide records a gap, especially when software must work on a stock MiSTer without Zaparoo Core.
+[Zaparoo](https://zaparoo.org/) offers additional ways to browse, launch, control, and track your games through its apps and the Core daemon. No NFC reader is required. Some features overlap with mrext, but Zaparoo does not replace every stock-MiSTer workflow. Use the comparison below if you are considering a change.
 
-## Supported starting points
+## Building an integration?
+
+Use **Zaparoo Core's public API** for new game search, launching, tracking, and automation integrations, including MiSTer-only projects. Core provides the shared media services so your application does not need to build on mrext's internal packages or reproduce its indexing and tracking.
+
+Remote's API remains supported for existing clients and MiSTer-specific functions such as INI editing, wallpapers, and menu-file management. Use it where those functions are needed, rather than as the default media API for a new project. The API mappings below help existing clients adopt Core where appropriate.
+
+## Zaparoo starting points
 
 - [Zaparoo Core API](https://zaparoo.org/docs/core/api/) for applications and services
 - [`@zaparoo/cli`](https://github.com/ZaparooProject/zaparoo-cli) for terminals, scripts, tests, and AI agents
@@ -16,22 +22,24 @@ The mrext Remote REST and WebSocket APIs are not compatible with the Zaparoo Cor
 
 ## Component map
 
-| mrext component | Current Zaparoo path | Gap to check before migrating |
+| mrext component | Related Zaparoo capability | Distinct mrext workflow or difference |
 | --- | --- | --- |
-| Remote | App/Web UI, Frontend, Core API, or CLI | No direct parity for stock-menu file management, wallpaper browsing, every `MiSTer.ini` value, BGM UI, or all system information |
-| Search | App, Web UI, Frontend, `media.search`, or `zaparoo-cli media search` | No standalone controller-driven search inside the stock MiSTer OSD |
-| Random | ZapScript `launch.random` | No exact equivalent to every old flag or Scripts-menu wrapper |
-| Favorites | Frontend favorites | Does not generate or repair stock-menu `.mgl` shortcuts |
-| GamesMenu | Frontend folder, category, and system browsing | Does not mirror a library into stock MiSTer menu folders |
-| LastPlayed | Frontend recents, Core history, CLI history, and ZapScript `launch.last` | No stock-menu dynamic shortcut or `bootcore` generator |
-| LaunchSync | Online cards/decks, Zap Links, self-hosted Zap Link servers, and playlists | No `.sync` subscriber that generates auto-updating stock-menu `.mgl` shortcuts |
-| PlayLog | Core history, playtime, active media, notifications, MQTT, and optional Online history | Requires Core; executable hooks and stock-only use are not direct equivalents |
+| Remote | App/Web UI, Frontend, Core API, or CLI | Standalone remote control and MiSTer administration, including menu files, wallpapers, INI editing, BGM UI, and system information; no complete Zaparoo equivalent |
+| Search | App, Web UI, `media.search`, or `zaparoo-cli media search` | Controller-driven search from the stock Scripts menu, using mrext's own index rather than Core |
+| Random | ZapScript `launch.random` | Standalone Scripts-menu action and CLI options; not every flag has an exact ZapScript equivalent |
+| Favorites | Frontend favorites | Creates and repairs stock-menu `.mgl` shortcuts and core links; Frontend favorites do not generate these |
+| GamesMenu | Frontend folder, category, and system browsing | Mirrors a library into stock MiSTer menu folders rather than presenting a separate frontend |
+| LastPlayed | Frontend recents, Core history, CLI history, and ZapScript `launch.last` | Generates stock-menu recents, a dynamic last-played shortcut, and optional `bootcore` files |
+| LaunchSync | Online cards/decks, Zap Links, self-hosted Zap Link servers, and playlists | Consumes `.sync` subscriptions and generates auto-updating stock-menu `.mgl` folders; the Zaparoo paths do neither |
+| PlayLog | Core history, playtime, active media, notifications, MQTT, and optional Online history | Standalone local tracking, reports, and executable hooks; the related Zaparoo features require Core and do not directly replace the hooks |
 | `/tmp/ACTIVEGAME` | Continue reading it on MiSTer; Zaparoo Core creates and maintains the file. New integrations can also use `media.active`, notifications, or MQTT | MiSTer-specific compatibility file, not a public cross-platform API |
-| BGM | Core audio playback, background slot, playlists, pause-on-launch, repeat, and controls | No confirmed internet-radio equivalent or exact BGM UI/configuration parity |
+| BGM | Core audio playback, background slot, playlists, pause-on-launch, repeat, and controls | Standalone menu music, boot sounds, radio, and folder-based setup; no confirmed Core internet-radio equivalent or exact UI/configuration parity |
 
 ## Common API migrations
 
-| mrext Remote API | Zaparoo replacement |
+For new media integrations, use the Core interfaces below. Existing Remote clients remain supported and can migrate calls as needed. Similar capabilities do not guarantee identical parameters, results, events, or behavior.
+
+| mrext Remote API | Related Core interface |
 | --- | --- |
 | `GET /games/playing` | Core `media.active` or `zaparoo-cli media active` |
 | `POST /games/search` | Core `media.search` or `zaparoo-cli media search` |
@@ -56,13 +64,13 @@ Launching media, sending input, writing NFC, or changing settings affects the de
 
 Zaparoo Core creates and maintains `/tmp/ACTIVEGAME` on MiSTer. It updates the file for launches performed through Core and for supported launches observed from MiSTer itself, and clears it when returning to the menu. Existing integrations that read this file can continue working with Core installed.
 
-For new MiSTer state integrations, the public Core interfaces provide richer and cross-platform state. Query `media.active` for a current snapshot, subscribe to `media.started` and `media.stopped` for live changes, or use the built-in [MQTT publisher](https://zaparoo.org/docs/features/publishers/#mqtt). Query `media.active` again after reconnecting because notification streams are not durable state. For history, use `media.history`, `media.history.latest`, `media.history.top`, or their CLI commands.
+For new state integrations, including MiSTer-only tools, use Core's public interfaces. Query `media.active` for a current snapshot, subscribe to `media.started` and `media.stopped` for live changes, or use the built-in [MQTT publisher](https://zaparoo.org/docs/features/publishers/#mqtt). Query `media.active` again after reconnecting because notification streams are not durable state. For history, use `media.history`, `media.history.latest`, `media.history.top`, or their CLI commands.
 
 `/tmp/ACTIVEGAME` remains a MiSTer-specific compatibility file rather than a public cross-platform API. PlayLog's executable state hooks still have no direct Core feature that runs arbitrary local scripts; move that logic into an API or MQTT subscriber when migrating it.
 
 ## Launch and library workflows
 
-Use [`launch.random`](https://zaparoo.org/docs/zapscript/launch/#launchrandom) for random media and [`launch.last`](https://zaparoo.org/docs/zapscript/launch/#launchlast) for recent media:
+For Core-based workflows, use [`launch.random`](https://zaparoo.org/docs/zapscript/launch/#launchrandom) for random media and [`launch.last`](https://zaparoo.org/docs/zapscript/launch/#launchlast) for recent media:
 
 ```zapscript
 **launch.random:SNES,NES,Genesis
@@ -78,12 +86,9 @@ For shareable or remotely updated lists, compare [Online cards and decks](https:
 
 ## Guidance for contributors and coding agents
 
-Before using an mrext package or convention as the basis for new MiSTer work:
+- **Building a new application or integration:** use the Zaparoo Core daemon and its public API or CLI for media functionality, even if MiSTer is your only target. Do not start a new media integration on Remote's API, mrext's internal Go packages, or raw tracking files when Core provides the required interface.
+- **Maintaining an mrext tool or existing client:** preserve standalone operation, configuration, generated files, command-line behavior, and Remote API contracts. Supporting existing users does not require migrating them to Core.
+- **Implementing a MiSTer-specific function Core does not expose:** use the relevant mrext interface or package where needed. Check the comparison above rather than assuming API or workflow parity.
+- **Working on system definitions or MGL generation:** reuse the shared `mister/catalog` and `mister/mgl` modules from Zaparoo Core instead of adding parallel tables. These libraries do not require a running Core daemon.
 
-1. Check the component map and migration notes in this guide.
-2. Use the mapped Zaparoo replacement when it meets the project's requirements.
-3. Use public Zaparoo documentation as the contract for that replacement.
-4. Keep mrext or raw MiSTer approaches when the guide records a gap or Zaparoo Core is not part of the target system.
-5. Record genuine replacement gaps instead of claiming feature parity.
-
-Report corrections or missing migrations through a relevant [ZaparooProject repository](https://github.com/ZaparooProject) or [Zaparoo Discord](https://zaparoo.org/discord).
+Report mrext issues and comparison corrections through [mrext issues](https://github.com/wizzomafizzo/mrext/issues). For Zaparoo-specific issues, use the relevant [ZaparooProject repository](https://github.com/ZaparooProject) or [Zaparoo Discord](https://zaparoo.org/discord).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MiSTer Extensions
 
-> [!IMPORTANT]
-> mrext is maintained for legacy users. Before starting or extending a MiSTer project with mrext, review current Zaparoo replacements in [MIGRATE.md](MIGRATE.md). Existing installations can keep working, and mrext can remain appropriate where Zaparoo does not replace required stock-MiSTer workflows.
+> [!NOTE]
+> MiSTer Extensions is actively maintained and works without Zaparoo. For additional features, or if you're building your own integration, see [mrext and Zaparoo](MIGRATE.md).
 
 Extensions and utilities for [MiSTer](https://github.com/MiSTer-devel/Main_MiSTer/wiki).
 

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -402,7 +402,7 @@ func appHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func main() {
-	svcOpt := flag.String("service", "", "manage playlog service (start, stop, restart, status)")
+	svcOpt := flag.String("service", "", "manage remote service (start, stop, restart, status)")
 	uninstallOpt := flag.Bool("uninstall", false, "uninstall MiSTer Remote")
 	showVersion := flag.Bool("version", false, "print the version and exit")
 	flag.Parse()

--- a/docs/bgm.md
+++ b/docs/bgm.md
@@ -2,7 +2,7 @@
 
 BGM plays background music in MiSTer's menu, stops it while a core runs, and plays boot sounds when MiSTer starts or a core launches. It runs as a standalone Go application and does not require Zaparoo Core.
 
-Zaparoo Core also offers core audio playback. See [MIGRATE.md](../MIGRATE.md) before choosing between them; internet radio and BGM's folder-based configuration have no confirmed equivalent there.
+Zaparoo also offers background audio playback, with different controls and configuration. See [mrext and Zaparoo](../MIGRATE.md) to compare features, including radio support.
 
 ## Installation
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,9 +1,11 @@
 # Developer Guide
 
-> [!IMPORTANT]
-> This guide documents legacy mrext development. Before using or extending mrext for new MiSTer work, read [MIGRATE.md](../MIGRATE.md) to see whether current Zaparoo features provide a maintained replacement. mrext can still be appropriate where the migration guide records a gap, especially for stock-MiSTer workflows that do not use Zaparoo Core.
+> [!NOTE]
+> This guide covers development of the maintained mrext tools. If you're building a new media application or integration, use the [Zaparoo Core API](https://zaparoo.org/docs/core/api/), even for MiSTer-only projects. See [mrext and Zaparoo](../MIGRATE.md) for API mappings and the MiSTer-specific functions available through mrext.
 
-MiSTer Extensions is a single Go project that outputs multiple individual binary applications. The goal of the project is to create a unified library to manage all aspects of a MiSTer system, and offer a set of modular applications that create a rich user experience for the MiSTer userspace.
+MiSTer Extensions is a single Go project that outputs multiple individual binary applications. It provides modular tools for MiSTer menu workflows and device management, backed by shared packages rather than duplicate implementations. Zaparoo Core is not required on the device.
+
+Changes to these tools should preserve existing configuration, folder layouts, command-line contracts, and controller-driven workflows. Remote's API remains supported for existing clients and its specialist MiSTer functions. For new media integrations, use Core's daemon rather than building on mrext's internal indexing, tracking, or launch implementation.
 
 Applications should:
 - Be usable with only a controller for at least the core functionality

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -99,7 +99,7 @@ All global configuration settings, MiSTer environment paths and the module for p
 
 #### tui
 
-Reusable terminal UI components built with tview and tcell, including list pickers, an on-screen keyboard, progress views, and MiSTer's framebuffer-console retry flow.
+Reusable terminal UI components built with tview and tcell: themes, the page frame, button bar, menu list, dialogs, progress boxes, an on-screen keyboard, and MiSTer's framebuffer-console retry flow.
 
 #### games
 

--- a/docs/favorites.md
+++ b/docs/favorites.md
@@ -2,7 +2,7 @@
 
 Favorites creates and manages game and core shortcuts in MiSTer's stock menu. It runs as a standalone Go application and does not require Zaparoo Core.
 
-Zaparoo Frontend also provides favorites for indexed media, but it does not create or repair stock-menu `.mgl` shortcuts. See [MIGRATE.md](../MIGRATE.md) before choosing between them.
+Zaparoo Frontend also provides favorites, but it does not create or repair these stock-menu shortcuts. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 ## Installation
 

--- a/docs/gamesmenu.md
+++ b/docs/gamesmenu.md
@@ -2,7 +2,7 @@
 
 GamesMenu mirrors game libraries into `/media/fat/_Games`, letting you launch games directly from the stock MiSTer menu without opening a core first. It does not require Zaparoo Core.
 
-For new Zaparoo integrations, prefer Frontend library browsing and Core's public interfaces. Frontend does not mirror libraries into stock-menu folders; see [migration guidance](../MIGRATE.md).
+Zaparoo Frontend offers library browsing in a separate interface rather than generating stock-menu folders. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 ## Installation
 

--- a/docs/lastplayed.md
+++ b/docs/lastplayed.md
@@ -1,7 +1,7 @@
 # LastPlayed
 
-> [!IMPORTANT]
-> LastPlayed is maintained for stock-menu shortcuts. Before using it for a new MiSTer recents workflow, consider Frontend recents, Core play history, or ZapScript `launch.last`. Keep LastPlayed when dynamic `.mgl` or `bootcore` files are required. See [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> LastPlayed works without Zaparoo. Zaparoo also offers play history and recents, but does not generate LastPlayed's stock-menu shortcuts or `bootcore` files. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 LastPlayed is a service for automatically generating dynamic shortcuts in the MiSTer menu.
 

--- a/docs/launchsync.md
+++ b/docs/launchsync.md
@@ -41,11 +41,13 @@ Only requested systems are refreshed in the shared `/media/fat/Scripts/.config/m
 
 ## Sync screen
 
-Running `launchsync` from the Scripts menu shows a progress screen while it searches for sync files, checks them for updates and builds the games index, then a summary of what each sync file produced: shortcuts created, games not found and errors. **Details** shows the full log, which is the same text the console printed.
+Running `launchsync` from the Scripts menu shows a progress screen while it searches for sync files, checks them for updates and builds the games index, then a summary of what each sync file produced: shortcuts created, games not found and errors. **Details** shows the full log. A sync that fails partway still reaches the summary, so the log stays readable after the error.
 
 Previously this was console output only, and `Building games index... ` was printed without a newline before a scan that can take minutes, so a slow step looked like a hang.
 
 `launchsync -update` is unchanged and stays on the console with no screen, so scripts and startup hooks behave exactly as before; add `-verbose` for the full log. `-test` is also unchanged.
+
+Running `launchsync` with no arguments where no screen can be opened — cron, `ssh` without a terminal, a wrapper script — falls back to the console log it has always printed, rather than failing. The log's wording changed slightly: steps that used to print a prefix and their result on one line, such as `Building games index... done`, are now reported as complete lines.
 
 ## Uninstall
 

--- a/docs/launchsync.md
+++ b/docs/launchsync.md
@@ -1,7 +1,7 @@
 # LaunchSync
 
-> [!IMPORTANT]
-> LaunchSync is maintained for `.sync` files and stock-menu shortcuts. Before creating a new shared MiSTer list with it, consider Online cards and decks, Zap Links, self-hosted Zap Link servers, or Zaparoo playlists. Keep LaunchSync when subscribed `.mgl` folders are required. See [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> LaunchSync works without Zaparoo. Zaparoo also offers shared cards, decks, Zap Links, and playlists, but does not read `.sync` files or generate LaunchSync's menu folders. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 LaunchSync allows people to create, share and maintain live-updating game playlists for the MiSTer.
 

--- a/docs/playlog.md
+++ b/docs/playlog.md
@@ -1,7 +1,7 @@
 # PlayLog
 
-> [!IMPORTANT]
-> PlayLog is maintained for legacy and stock-MiSTer workflows. Zaparoo Core also creates and maintains `/tmp/ACTIVEGAME` on MiSTer, so existing file readers can continue working. New MiSTer state and history integrations can use Core history, `media.active`, media notifications, or MQTT for richer cross-platform state. Executable state hooks have no direct Core replacement. See [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> PlayLog works without Zaparoo. Zaparoo also offers play history and tracking, but does not directly replace PlayLog's executable hooks. If you're building a new tracking integration, use Core's API. See [mrext and Zaparoo](../MIGRATE.md) for details.
 
 PlayLog is an application to track and store stats of what games and cores you play on your MiSTer.
 

--- a/docs/random.md
+++ b/docs/random.md
@@ -1,7 +1,7 @@
 # Random
 
-> [!IMPORTANT]
-> Random is maintained for Scripts-menu use. Before adding it to a new MiSTer workflow, consider ZapScript `launch.random`, which supports one or more systems, equal system weighting, search patterns, and tags. Keep Random when its Scripts-menu wrapper or unmatched command-line flags are required. See [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> Random works without Zaparoo. For more selection options, Zaparoo's `launch.random` supports search patterns and tags. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 Random is a simple application for launching a game at random from your MiSTer's collection.
 

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -1,7 +1,7 @@
 # Remote API
 
-> [!IMPORTANT]
-> This API is maintained for legacy Remote clients and is not compatible with the Zaparoo Core API. Before building a new MiSTer integration against it, review the public Core WebSocket JSON-RPC API and `@zaparoo/cli` mappings in [MIGRATE.md](../MIGRATE.md). Migrating requires translating calls, not pointing an existing client at a new port.
+> [!NOTE]
+> For new game search, launching, tracking, and automation integrations, use the [Zaparoo Core API](https://zaparoo.org/docs/core/api/), including for MiSTer-only projects. Remote's API remains supported for existing clients and MiSTer-specific functions such as INI editing and menu management. See [mrext and Zaparoo](../MIGRATE.md) for API mappings and differences. The APIs are not interchangeable; changing the port is not enough to migrate a client.
 
 <!-- TOC -->
 * [Remote API](#remote-api)

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -1,7 +1,7 @@
 # Remote
 
-> [!IMPORTANT]
-> Remote is maintained for legacy users. Before building a new MiSTer remote control with it, consider Zaparoo App/Web UI, Frontend, or the public Core API and CLI. Remote can remain appropriate for stock-menu file management, wallpaper browsing, arbitrary `MiSTer.ini` editing, and other gaps listed in [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> Remote is actively maintained and works without Zaparoo. Zaparoo also offers game browsing, launching, and control; Remote includes MiSTer-specific tools such as INI editing and wallpaper management. See [mrext and Zaparoo](../MIGRATE.md) to compare features.
 
 Remote is a web-based interface with a stack of modern features to manage all aspects of your MiSTer. Can be used from your phone, tablet or computer.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,7 +1,7 @@
 # Search
 
-> [!IMPORTANT]
-> Search is maintained for its controller-driven stock-OSD workflow. Before using it for new MiSTer search or library work, consider Core's media index and `media.search`, `zaparoo-cli media search`, or the search interfaces in App, Web UI, and Frontend. See [MIGRATE.md](../MIGRATE.md).
+> [!NOTE]
+> Search works without Zaparoo. To search and launch games from your phone or browser, you can also use Zaparoo App or Web UI. If you're building a new search integration, use Core's API. See [mrext and Zaparoo](../MIGRATE.md) for details.
 
 Search is an application to *search* for games on your MiSTer. It indexes all your games, lets you enter search queries without a keyboard, and then displays a list of results that can be launched directly.
 


### PR DESCRIPTION
Two unrelated things that were both sitting uncommitted on `main`, kept as separate commits.

## Positioning: mrext is maintained, not legacy

`MIGRATE.md` was written as a one-way door — *"mrext is maintained for legacy users… migrate only after verifying the replacement for your workflow"* — with a component map whose third column was headed **"Gap to check before migrating"**. That framing tells anyone landing on the repo that the project is winding down, which is not what is happening.

It is now a comparison of what each project does. The component map's third column records the stock-MiSTer workflow each app actually provides, rather than listing it as a shortfall:

| before | after |
| --- | --- |
| LaunchSync — *No `.sync` subscriber that generates auto-updating stock-menu `.mgl` shortcuts* | *Consumes `.sync` subscriptions and generates auto-updating stock-menu `.mgl` folders; the Zaparoo paths do neither* |
| Favorites — *Does not generate or repair stock-menu `.mgl` shortcuts* | *Creates and repairs stock-menu `.mgl` shortcuts and core links; Frontend favorites do not generate these* |

The per-app doc banners lose the "maintained for legacy users" opening, and the API table is headed "Related Core interface" rather than "Zaparoo replacement", with a note that similar capabilities do not guarantee identical parameters, results, events or behaviour.

**The guidance for new work is unchanged in substance.** Core's public API is still the recommendation for cross-platform media integrations, including MiSTer-only ones; Remote's API stays supported for existing clients and for the MiSTer-specific administration Core does not cover — INI editing, wallpapers, menu-file management. `AGENTS.md` gains the matching rules: new standalone stock-MiSTer work is in scope, and mrext is not to be described as retired or deprecated.

## Three stale strings

Found in a pass over `main` after #227 merged.

- **`cmd/remote/main.go`** — the `-service` flag help read `manage playlog service (start, stop, restart, status)`. The identical copy-paste was fixed for LastPlayed during the refresh, but Remote was missed, and this is what `remote.sh -h` prints.
- **`docs/dev.md`** — still listed *list pickers* among `pkg/tui`'s components. `ListPicker` was deleted in #226 when Search and Remote moved onto the shared stack. Replaced with what is actually in the package.
- **`docs/launchsync.md`** — did not mention the headless fallback added in #227, and claimed **Details** shows *"the same text the console printed"*. That is now slightly off: `runSync` reports complete lines so one code path can serve both the console log and the progress modal, so `Building games index... done` arrives as two lines where it used to be one. Both are documented.

## What else that pass checked

Everything below was verified against `8839ae1`, the commit before the refresh run started, and none of it needed a change:

- Every existing CLI flag on all 11 binaries is intact; `-version` is the only addition. Checked by running `-h` and `-version` on host builds.
- The `user-startup.sh` line is byte-identical, and BGM's startup file is unchanged.
- INI keys and sections are identical in `pkg/config/user.go`, `pkg/bgm/config.go` and `pkg/favorites/settings.go`. The only new path anywhere is the opt-in `tui.ini`.
- Generated artefact names are unchanged — `.mgl`/`.mra`, `_Games`, `Last Played`, `_Recently Played`.
- `ServiceHandler` still exits for every command except the empty one, so `-service exec|start|stop|restart|status` cannot reach a TUI, with the same exit codes as before.
- `pkg/tui` still imports only `pkg/config` from the rest of mrext.
- The detached-drive guards, the games-index lock timeout, the PlayLog menu-event skip and the Remote path guard are all still in place with their tests.

One thing worth knowing rather than fixing: the version in the page frame renders on a tagged build (`v2.1.0` fits the bottom border at 75×15 and 80×25) but is dropped on a dev build, where `git describe` produces something like `v20260612-5-516-g0400efb` and it would collide with the key hints. That is the intended behaviour, but it does mean only release binaries show it.

## Validation

`mage test`, `mage lint` (0 issues), `mage checkConflicts`, `mage mister remote`. Confirmed the corrected flag help in the built ARM binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that MiSTer Extensions remains actively maintained and works without Zaparoo.
  - Added guidance for new integrations to use Zaparoo Core’s public API while retaining Remote API support for existing and MiSTer-specific workflows.
  - Updated migration and feature-comparison documentation to describe coexistence and workflow differences.
  - Expanded LaunchSync documentation for partial failures and console-log fallback behavior.
  - Corrected the `-service` command-line help text to describe the remote service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->