### PR TITLE
ci: restore UPX compression and tag stamping for releases

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          # Full history and tags: the build stamps every binary from
+          # git describe --tags, which reports nothing on a shallow clone.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -41,7 +44,19 @@ jobs:
       - name: Use pinned npm
         run: npm install --global npm@12.0.2
 
+      # Release binaries have always been UPX compressed, which roughly halves
+      # what each app costs on the SD card. This used to come from the armv7
+      # build container; the container is gone, so install it here. Release()
+      # refuses to run without UPX_BIN rather than shipping larger binaries by
+      # accident.
+      - name: Install UPX
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y upx-ucl
+
       - name: Run mage prepRelease
+        env:
+          UPX_BIN: upx-ucl
         run: go run github.com/magefile/mage prepRelease
 
       - name: Upload release assets


### PR DESCRIPTION
Tagging a release right now would fail before it built anything. This fixes that.

## UPX

The release workflow used to run `mage prepRelease` inside an armv7 build container:

```yaml
docker run --rm --platform linux/arm/v7 \
  -e UPX_BIN=upx-ucl \
  ...
  go run github.com/magefile/mage prepRelease
```

#137 replaced that container with a native Go cross-build, and `UPX_BIN` went with it. But `magefile.go:375` still refuses to continue without it:

```go
if upxBin == "" {
    fmt.Println("UPX is required for releases")
    os.Exit(1)
}
```

So the workflow exits 1 on the first app. It has not run since the rewrite — the last successful build was **v20260612-5** in June, on the container version.

The guard is right, so this installs `upx-ucl` on the runner and passes `UPX_BIN` to the one step that needs it. Dropping compression instead would roughly double what each app costs on the SD card: the uncompressed ARM binaries are 5–12 MB each, and every release so far has shipped them compressed.

## Tag stamping

`versionLdflags` stamps every binary from `git describe --tags`, and `actions/checkout` clones shallow by default, so there is nothing to describe. This is the first release to carry `-version`, and without `fetch-depth: 0` those binaries would have reported a bare commit hash instead of the tag — including in the page frame that now shows it on screen.

## Validation

The release path has never run in its current form, so I exercised the whole thing locally with a stub `upx-ucl` on `PATH`:

```
$ PATH=…/fakebin:$PATH UPX_BIN=upx-ucl mage prepRelease
Preparing release: remote
STUB-UPX called: -9 …/_bin/releases/remote.sh
… nine times …
prepRelease rc=0
```

- All nine assets are produced under the exact names `repo.yml` curls: `bgm.sh favorites.sh gamesmenu.sh lastplayed.sh launchsync.sh playlog.sh random.sh remote.sh search.sh`. That matters because `repo.yml` uses `curl -fsSL` and fails hard on any missing file.
- The stamp resolves: `search v20260612-5-516-g0400efb-dirty (0400efb)` — dirty here only because the workflow file was modified in my tree; a clean tag checkout gives the tag name.
- `actionlint` is clean on all three workflows.

What I could not verify locally is `upx-ucl` on an amd64 runner compressing an ARM ELF; I have no UPX installed here. UPX handles `linux/arm` as a target and the previous setup compressed the same binaries, just with an ARM-native build of it, so I expect no difference — but it is the one step that will prove itself on the first real run.

## Releasing after this merges

```sh
git tag v20260907-1
git push origin v20260907-1
```

That runs **Build and Release** (builds the nine, compresses, creates the GitHub release, uploads), and on success **Repo database creation** fires automatically: it downloads those nine from the latest release, runs `scripts/generate_repo.py <tag>`, and commits the regenerated Downloader databases to `main`.
