### PR TITLE
feat(remote): add save_state and load_state named keys

### DIFF
--- a/cmd/remote/control/control.go
+++ b/cmd/remote/control/control.go
@@ -122,6 +122,24 @@ func SendKeyboard(kbd input.Keyboard, key string) error {
 		return wrapKeyboard("exit console", kbd.ExitConsole())
 	case "computer_osd":
 		return wrapKeyboard("send computer OSD key", kbd.ComputerOSD())
+	// Savestate slots. The unnumbered names are slot 1, which is what a quick
+	// save button wants; the numbered ones reach the other three.
+	case "save_state", "save_state_1":
+		return wrapKeyboard("save state", kbd.SaveState(1))
+	case "save_state_2":
+		return wrapKeyboard("save state 2", kbd.SaveState(2))
+	case "save_state_3":
+		return wrapKeyboard("save state 3", kbd.SaveState(3))
+	case "save_state_4":
+		return wrapKeyboard("save state 4", kbd.SaveState(4))
+	case "load_state", "load_state_1":
+		return wrapKeyboard("load state", kbd.LoadState(1))
+	case "load_state_2":
+		return wrapKeyboard("load state 2", kbd.LoadState(2))
+	case "load_state_3":
+		return wrapKeyboard("load state 3", kbd.LoadState(3))
+	case "load_state_4":
+		return wrapKeyboard("load state 4", kbd.LoadState(4))
 	default:
 		return fmt.Errorf("unknown key: %s", key)
 	}

--- a/cmd/remote/control/control_test.go
+++ b/cmd/remote/control/control_test.go
@@ -1,0 +1,156 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package control
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bendahl/uinput"
+	"github.com/wizzomafizzo/mrext/pkg/input"
+)
+
+// keyEvent is one uinput key transition. Recording both edges is what makes
+// a combo distinguishable from consecutive presses of the same keys.
+type keyEvent struct {
+	code int
+	down bool
+}
+
+// fakeKeyboard records what a real virtual keyboard would emit, so the named
+// key table can be asserted without a uinput device.
+type fakeKeyboard struct {
+	events []keyEvent
+}
+
+func (f *fakeKeyboard) KeyPress(code int) error {
+	f.events = append(f.events, keyEvent{code, true}, keyEvent{code, false})
+	return nil
+}
+
+func (f *fakeKeyboard) KeyDown(code int) error {
+	f.events = append(f.events, keyEvent{code, true})
+	return nil
+}
+
+func (f *fakeKeyboard) KeyUp(code int) error {
+	f.events = append(f.events, keyEvent{code, false})
+	return nil
+}
+
+func (*fakeKeyboard) FetchSyspath() (string, error) {
+	return "", nil
+}
+
+func (*fakeKeyboard) Close() error {
+	return nil
+}
+
+// press is the event pair produced by input.Keyboard.Press.
+func press(code int) []keyEvent {
+	return []keyEvent{{code, true}, {code, false}}
+}
+
+// combo is the event sequence produced by input.Keyboard.Combo: every key is
+// held in order, then released in that same order.
+func combo(codes ...int) []keyEvent {
+	events := make([]keyEvent, 0, len(codes)*2)
+	for _, code := range codes {
+		events = append(events, keyEvent{code, true})
+	}
+	for _, code := range codes {
+		events = append(events, keyEvent{code, false})
+	}
+	return events
+}
+
+// TestSendKeyboardNamedKeys pins every name accepted by SendKeyboard to the
+// keys it sends. The names are a published part of the Remote API, so a
+// changed mapping here is a change to what existing clients do to a MiSTer.
+func TestSendKeyboardNamedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		want []keyEvent
+	}{
+		{"up", press(uinput.KeyUp)},
+		{"down", press(uinput.KeyDown)},
+		{"left", press(uinput.KeyLeft)},
+		{"right", press(uinput.KeyRight)},
+		{"volume_up", press(uinput.KeyVolumeup)},
+		{"volume_down", press(uinput.KeyVolumedown)},
+		{"volume_mute", press(uinput.KeyMute)},
+		{"menu", press(uinput.KeyEsc)},
+		{"back", press(uinput.KeyBackspace)},
+		{"confirm", press(uinput.KeyEnter)},
+		{"cancel", press(uinput.KeyEsc)},
+		{"osd", press(uinput.KeyF12)},
+		{"screenshot", combo(uinput.KeyLeftalt, uinput.KeyScrolllock)},
+		{"raw_screenshot", combo(uinput.KeyLeftalt, uinput.KeyLeftshift, uinput.KeyScrolllock)},
+		{"pair_bluetooth", press(uinput.KeyF11)},
+		{"change_background", press(uinput.KeyF1)},
+		{"core_select", combo(uinput.KeyLeftalt, uinput.KeyF12)},
+		{"user", combo(uinput.KeyLeftctrl, uinput.KeyLeftalt, uinput.KeyRightalt)},
+		{"reset", combo(uinput.KeyLeftshift, uinput.KeyLeftctrl, uinput.KeyLeftalt, uinput.KeyRightalt)},
+		{"toggle_core_dates", press(uinput.KeyF2)},
+		{"console", press(uinput.KeyF9)},
+		{"exit_console", press(uinput.KeyF12)},
+		{"computer_osd", combo(uinput.KeyLeftmeta, uinput.KeyF12)},
+		{"save_state", combo(uinput.KeyLeftalt, uinput.KeyF1)},
+		{"save_state_1", combo(uinput.KeyLeftalt, uinput.KeyF1)},
+		{"save_state_2", combo(uinput.KeyLeftalt, uinput.KeyF2)},
+		{"save_state_3", combo(uinput.KeyLeftalt, uinput.KeyF3)},
+		{"save_state_4", combo(uinput.KeyLeftalt, uinput.KeyF4)},
+		{"load_state", press(uinput.KeyF1)},
+		{"load_state_1", press(uinput.KeyF1)},
+		{"load_state_2", press(uinput.KeyF2)},
+		{"load_state_3", press(uinput.KeyF3)},
+		{"load_state_4", press(uinput.KeyF4)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeKeyboard{}
+			kbd := input.Keyboard{Device: fake}
+
+			if err := SendKeyboard(kbd, tt.name); err != nil {
+				t.Fatalf("send %s: %v", tt.name, err)
+			}
+
+			if !slices.Equal(fake.events, tt.want) {
+				t.Errorf("%s sent %v, want %v", tt.name, fake.events, tt.want)
+			}
+		})
+	}
+}
+
+// TestSendKeyboardUnknownKey checks an unrecognised name is rejected rather
+// than silently doing nothing, which is what makes the handler return 500.
+func TestSendKeyboardUnknownKey(t *testing.T) {
+	fake := &fakeKeyboard{}
+	kbd := input.Keyboard{Device: fake}
+
+	if err := SendKeyboard(kbd, "not_a_key"); err == nil {
+		t.Fatal("expected an error for an unknown key name")
+	}
+
+	if len(fake.events) != 0 {
+		t.Errorf("unknown key sent %v, want nothing", fake.events)
+	}
+}

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -63,6 +63,14 @@ The Screenshots-page camera and `POST /screenshots` use the same normal screensh
 
 Both normal screenshot actions depend on MiSTer accepting `Alt+Scroll Lock`; PS/2 keyboard mode can disable that shortcut. The API reports keyboard-send failures, but its one-second delay does not confirm a screenshot was saved. Check the screenshot list afterward.
 
+## Savestate keys
+
+`save_state` and `load_state` cover MiSTer's four savestate slots through `POST /controls/keyboard/{name}` and the `kbd` WebSocket message. The unnumbered names are slot 1; `save_state_1` to `save_state_4` and `load_state_1` to `load_state_4` reach a specific one. Saving sends `Alt` with `F1` to `F4`, loading sends `F1` to `F4`.
+
+Only cores built with savestate support respond. Others ignore the key, and no error is reported either way, because the key is sent to MiSTer rather than acknowledged by it.
+
+The load keys are the same ones the menu core uses for its own functions, so `load_state` and `change_background` both send `F1`, and `load_state_2` and `toggle_core_dates` both send `F2`. They describe the same key in different contexts. The save keys have no raw equivalent: `/controls/keyboard-raw` sends one key and prefixes shift only, so it cannot express `Alt+F1`.
+
 ## MiSTer SAM compatibility
 
 After successful game, core, file, or launch-token requests, Remote signals user activity through SAM's existing `/tmp/.SAM_tmp/SAM_Joy_Activity` file. Current SAM MCP recognizes the `zaparoo` message as external activity: in normal mode it resets idle and exits attract mode while keeping the current game, rather than returning to Menu. This supports stock MiSTer without requiring Zaparoo Core.

--- a/pkg/input/keyboard.go
+++ b/pkg/input/keyboard.go
@@ -186,3 +186,31 @@ func (k *Keyboard) ExitConsole() error {
 func (k *Keyboard) ComputerOSD() error {
 	return k.Combo(uinput.KeyLeftmeta, uinput.KeyF12)
 }
+
+// savestateSlotKey maps a savestate slot to its function key. Cores with
+// savestate support use F1 to F4 for the four slots, and Alt with the same key
+// to save. Anything outside 1 to 4 falls back to the first slot.
+func savestateSlotKey(slot int) int {
+	switch slot {
+	case 2:
+		return uinput.KeyF2
+	case 3:
+		return uinput.KeyF3
+	case 4:
+		return uinput.KeyF4
+	default:
+		return uinput.KeyF1
+	}
+}
+
+// SaveState writes a savestate to the given slot.
+func (k *Keyboard) SaveState(slot int) error {
+	return k.Combo(uinput.KeyLeftalt, savestateSlotKey(slot))
+}
+
+// LoadState restores a savestate from the given slot. These are the keys the
+// menu core uses for its own functions, so a load name and a menu name can
+// share a code and differ only in the intent they express.
+func (k *Keyboard) LoadState(slot int) error {
+	return k.Press(savestateSlotKey(slot))
+}

--- a/web/remote/src/lib/models.ts
+++ b/web/remote/src/lib/models.ts
@@ -106,7 +106,17 @@ export type KeyboardCodes =
   | "toggle_core_dates"
   | "console"
   | "exit_console"
-  | "computer_osd";
+  | "computer_osd"
+  | "save_state"
+  | "save_state_1"
+  | "save_state_2"
+  | "save_state_3"
+  | "save_state_4"
+  | "load_state"
+  | "load_state_1"
+  | "load_state_2"
+  | "load_state_3"
+  | "load_state_4";
 
 export type MouseButtons =
   | "click"


### PR DESCRIPTION
Hi again! This is the one we talked about: named keys for save state and load state.

MiSTer maps `Alt+F1` to `Alt+F4` for saving and `F1` to `F4` for loading, and
`SendKeyboard` has a name for neither. Loading is reachable already, since `F1`
alone goes through `/controls/keyboard-raw/59`. Saving is not: `Alt+F1` is a
combo, and `keyboard-raw` documents that it sends a single key with an optional
shift prefix.

That gap shows up in any client that cannot open a WebSocket. My app puts a
mini-remote on the iOS Lock Screen, and it runs in a widget extension that can
only make plain HTTP requests. It could offer load without save, which felt
worse than offering neither, so I left both out until now.

All four slots are covered. `save_state` and `load_state` are slot 1, which is
what a quick save button wants, and `save_state_1` to `save_state_4` and
`load_state_1` to `load_state_4` reach a specific one. Saving sends `Alt` with
`F1` to `F4`, loading sends `F1` to `F4`. They go through the existing named key
path, so the `kbd` WebSocket message accepts them too.

The load keys are the same ones the menu core uses, so `load_state` and
`change_background` both send `F1`, and `load_state_2` and `toggle_core_dates`
both send `F2`. Same key, different intent, depending on what is running. 

## Tests

`cmd/remote/control/control_test.go` is new. It asserts the exact uinput events
for every named key through a fake device, not only the ones added here. The
names are a contract with clients already out there, so it seemed worth pinning
the whole table rather than just my part. It also covers the unknown-name error,
and it catches a slot mapped to the wrong function key.

`go test ./...` and `golangci-lint run ./...` (v2.13.2) pass, `mage mister
remote` builds, and the Remote web UI tests and build pass after adding the new
names to the `KeyboardCodes` union.

Run on a SuperStation One: the keys answer 200, an unknown name still answers
500, and `change_background` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote keyboard controls for saving and loading savestates across four slots.
  * Unnumbered save/load controls target slot 1, while numbered controls target specific slots.
  * Added support for savestate controls in the remote interface.

* **Documentation**
  * Documented savestate keyboard controls, slot mappings, and core compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->