### PR TITLE
feat(remote): choose the core when launching a game

### DIFF
--- a/cmd/remote/games/launchers.go
+++ b/cmd/remote/games/launchers.go
@@ -22,6 +22,7 @@ package games
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,7 @@ func LaunchGame(logger *service.Logger, cfg *config.UserConfig) http.HandlerFunc
 	return func(w http.ResponseWriter, r *http.Request) {
 		var args struct {
 			Path string `json:"path"`
+			RBF  string `json:"rbf"`
 		}
 
 		err := json.NewDecoder(r.Body).Decode(&args)
@@ -48,6 +50,22 @@ func LaunchGame(logger *service.Logger, cfg *config.UserConfig) http.HandlerFunc
 			return
 		}
 
+		var launch *games.LaunchCore
+		if strings.TrimSpace(args.RBF) != "" {
+			core, findErr := games.FindLaunchCore(args.RBF)
+			switch {
+			case errors.Is(findErr, games.ErrUnknownRBF):
+				http.Error(w, "unknown rbf", http.StatusBadRequest)
+				logger.Error("launch game: %s", findErr)
+				return
+			case findErr != nil:
+				http.Error(w, findErr.Error(), http.StatusInternalServerError)
+				logger.Error("launch game: looking up rbf: %s", findErr)
+				return
+			}
+			launch = &core
+		}
+
 		system, err := games.BestSystemMatch(cfg, args.Path)
 		if err != nil {
 			http.Error(w, "no system found for game", http.StatusBadRequest)
@@ -55,8 +73,13 @@ func LaunchGame(logger *service.Logger, cfg *config.UserConfig) http.HandlerFunc
 			return
 		}
 
-		err = mister.LaunchGame(cfg, &system, args.Path)
-		if err != nil {
+		err = mister.LaunchGameWithCore(cfg, &system, args.Path, launch)
+		switch {
+		case errors.Is(err, mister.ErrRBFOverrideUnsupported):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Error("launch game: %s: %s", err, args.Path)
+			return
+		case err != nil:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			logger.Error("launch game: during launch: %s", err)
 			return

--- a/cmd/remote/main.go
+++ b/cmd/remote/main.go
@@ -315,6 +315,7 @@ func setupAPI(
 
 	sub.HandleFunc("/systems", systems.ListSystems(logger)).Methods("GET")
 	sub.HandleFunc("/systems/{id}", withSAMActivity(systems.LaunchCore(cfg, logger), logger)).Methods("POST")
+	sub.HandleFunc("/systems/{id}/rbfs", systems.ListSystemRBFs(cfg, logger)).Methods("GET")
 
 	sub.HandleFunc("/wallpapers", wallpapers.AllWallpapersHandler(logger)).Methods("GET")
 	sub.HandleFunc("/wallpapers", wallpapers.UnsetWallpaperHandler(logger)).Methods("DELETE")

--- a/cmd/remote/systems/systems.go
+++ b/cmd/remote/systems/systems.go
@@ -39,6 +39,16 @@ type System struct {
 	Category string `json:"category"`
 }
 
+type SystemRBF struct {
+	RBF      string `json:"rbf"`
+	Name     string `json:"name"`
+	Core     string `json:"core"`
+	SetName  string `json:"setname"`
+	Filename string `json:"filename"`
+	Path     string `json:"path"`
+	Default  bool   `json:"default"`
+}
+
 var ignoreSystems = []string{
 	"Arcade",
 	"NESMusic",
@@ -78,6 +88,45 @@ func ListSystems(logger *service.Logger) http.HandlerFunc {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			logger.Error("list systems: during encode: %s", err)
+			return
+		}
+	}
+}
+
+func ListSystemRBFs(cfg *config.UserConfig, logger *service.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		system, err := games.GetSystem(id)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		cores, err := games.SystemLaunchCores(system)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("list system rbfs: %s", err)
+			return
+		}
+
+		defaultRBF := mister.SystemRBF(cfg, system)
+		results := make([]SystemRBF, 0, len(cores))
+		for _, core := range cores {
+			results = append(results, SystemRBF{
+				RBF:      core.Launch,
+				Name:     core.Name,
+				Core:     core.RBF,
+				SetName:  core.SetName,
+				Filename: core.Filename,
+				Path:     core.Path,
+				Default:  !core.IsLauncher() && strings.EqualFold(core.RBF, defaultRBF),
+			})
+		}
+
+		err = json.NewEncoder(w).Encode(results)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			logger.Error("list system rbfs: during encode: %s", err)
 			return
 		}
 	}

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -283,6 +283,83 @@ Example request:
 curl --request POST --url "http://mister:8182/api/systems/SNES"
 ```
 
+#### List system cores
+
+List the cores a system's games can be launched with: the core file Remote
+launches by default, any alternative build kept beside it under the same
+name with a suffix, for example `NES_Alt` next to `NES`, and any MGL
+launcher that runs one of those cores, for example `_RA_Cores/NES.mgl`. The
+`rbf` value can be passed to [launch game](#launch-game) to run a game with
+that core.
+
+```plaintext
+GET /systems/{id}/rbfs
+```
+
+Arguments:
+
+| Attribute | Type   | Required | Description            |
+|-----------|--------|----------|------------------------|
+| `id`      | string | Yes      | System's internal ID. See [systems](systems.md). |
+
+On success, returns `200` and a list of objects with attributes:
+
+| Attribute  | Type    | Description                                                                  |
+|------------|---------|------------------------------------------------------------------------------|
+| `rbf`      | string  | Value to pass to launch game: a core in the short form an `.mgl` file uses, or the SD-relative path of an MGL launcher. |
+| `name`     | string  | Name to show: the launcher's `setname` when it has one, otherwise the core's short name. |
+| `core`     | string  | Core the launch will load, in the short form an `.mgl` file uses.           |
+| `setname`  | string  | `setname` the launch will set, empty for a plain core file.                 |
+| `filename` | string  | Filename of the core or launcher, the newest one when several core releases share a name. |
+| `path`     | string  | Absolute path to the core or launcher file.                                 |
+| `default`  | boolean | `true` for the core a plain launch uses, after any `set_core` override in `remote.ini`. |
+
+Only the top two menu levels of the SD card are scanned, the same as
+[list systems](#list-systems). An MGL launcher counts when it names an
+`<rbf>` and no `<file>`; an MGL that launches a game is not a core.
+
+If system does not exist, returns `404`.
+
+Example request:
+
+```shell
+curl --request GET --url "http://mister:8182/api/systems/NES/rbfs"
+```
+
+Example response:
+
+```json
+[
+  {
+    "rbf": "_Console/NES",
+    "name": "NES",
+    "core": "_Console/NES",
+    "setname": "",
+    "filename": "NES_20240310.rbf",
+    "path": "/media/fat/_Console/NES_20240310.rbf",
+    "default": true
+  },
+  {
+    "rbf": "_Console/NES_Alt",
+    "name": "NES_Alt",
+    "core": "_Console/NES_Alt",
+    "setname": "",
+    "filename": "NES_Alt_20240102.rbf",
+    "path": "/media/fat/_Console/NES_Alt_20240102.rbf",
+    "default": false
+  },
+  {
+    "rbf": "_RA_Cores/NES.mgl",
+    "name": "RA_NES",
+    "core": "_RA_Cores/Cores/NES",
+    "setname": "RA_NES",
+    "filename": "NES.mgl",
+    "path": "/media/fat/_RA_Cores/NES.mgl",
+    "default": false
+  }
+]
+```
+
 ### Wallpapers
 
 Remote has its own mechanism of setting wallpapers as "active" on the MiSTer menu by managing a symlink to the wallpaper
@@ -742,7 +819,7 @@ Arguments (JSON):
 | Attribute | Type   | Required | Description                 |
 |-----------|--------|----------|-----------------------------|
 | `path`    | string | Yes      | Absolute path to game file. |
-| `rbf`     | string | No       | Core to run the game with instead of the system default: a core in the short form an `.mgl` file uses, for example `_Console/NES_Alt`, or an MGL launcher such as `_RA_Cores/NES.mgl`, whose `rbf` and `setname` are used. Either may be given as an absolute path. |
+| `rbf`     | string | No       | Core to run the game with instead of the system default: a core in the short form an `.mgl` file uses, for example `_Console/NES_Alt`, or an MGL launcher such as `_RA_Cores/NES.mgl`, whose `rbf` and `setname` are used. Either may be given as an absolute path. See [list system cores](#list-system-cores). |
 
 On success, returns `200`.
 

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -742,15 +742,31 @@ Arguments (JSON):
 | Attribute | Type   | Required | Description                 |
 |-----------|--------|----------|-----------------------------|
 | `path`    | string | Yes      | Absolute path to game file. |
+| `rbf`     | string | No       | Core to run the game with instead of the system default: a core in the short form an `.mgl` file uses, for example `_Console/NES_Alt`, or an MGL launcher such as `_RA_Cores/NES.mgl`, whose `rbf` and `setname` are used. Either may be given as an absolute path. |
 
 On success, returns `200`.
 
 If system cannot be detected from path, returns `500`.
 
+If `rbf` is not a core Remote can see, or `path` is an `.mra` or `.mgl` file,
+which names its own core, returns `400`.
+
 Example request:
 
 ```shell
 curl --request POST --url "http://mister:8182/api/games/launch" --data '{"path":"/media/fat/games/PSX/1 USA - A-D/Crash Bandicoot (USA).chd"}'
+```
+
+Example request with a specific core:
+
+```shell
+curl --request POST --url "http://mister:8182/api/games/launch" --data '{"path":"/media/fat/games/NES/Contra (USA).nes","rbf":"_Console/NES_Alt"}'
+```
+
+Example request through an MGL launcher, here a RetroAchievements build:
+
+```shell
+curl --request POST --url "http://mister:8182/api/games/launch" --data '{"path":"/media/fat/games/NES/Contra (USA).nes","rbf":"_RA_Cores/NES.mgl"}'
 ```
 
 #### Generate search index

--- a/docs/remote-api.md
+++ b/docs/remote-api.md
@@ -823,7 +823,7 @@ Arguments (JSON):
 
 On success, returns `200`.
 
-If system cannot be detected from path, returns `500`.
+If system cannot be detected from path, returns `400`.
 
 If `rbf` is not a core Remote can see, or `path` is an `.mra` or `.mgl` file,
 which names its own core, returns `400`.

--- a/pkg/games/games.go
+++ b/pkg/games/games.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -165,17 +166,19 @@ type RBFInfo struct {
 	MGLName   string // relative path launch-able from MGL file
 }
 
+var rbfDateSuffix = regexp.MustCompile(`_\d{8}$`)
+
 func ParseRBF(path string) RBFInfo {
 	info := RBFInfo{
 		Path:     path,
 		Filename: filepath.Base(path),
 	}
 
-	if strings.Contains(info.Filename, "_") {
-		info.ShortName = info.Filename[0:strings.LastIndex(info.Filename, "_")]
-	} else {
-		info.ShortName = strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename))
-	}
+	// Only a release date comes off the name, the way MiSTer itself resolves
+	// an MGL's rbf: NES_20240310.rbf is NES, and an undated NES_Alt.rbf stays
+	// NES_Alt rather than collapsing into the stock core.
+	stem := strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename))
+	info.ShortName = rbfDateSuffix.ReplaceAllString(stem, "")
 
 	if strings.HasPrefix(path, config.SdFolder) {
 		relDir := strings.TrimPrefix(filepath.Dir(path), config.SdFolder+"/")

--- a/pkg/games/games.go
+++ b/pkg/games/games.go
@@ -187,28 +187,13 @@ func ParseRBF(path string) RBFInfo {
 	return info
 }
 
-// Find all rbf files in the top 2 menu levels of the SD card.
-func shallowScanRBF() ([]RBFInfo, error) {
-	results := make([]RBFInfo, 0)
+// shallowScanPaths lists the files with an extension in the top 2 menu
+// levels of the SD card: the root and every _ folder in it.
+func shallowScanPaths(ext string) ([]string, error) {
+	results := make([]string, 0)
 
-	isRBF := func(file os.DirEntry) bool {
-		return filepath.Ext(strings.ToLower(file.Name())) == ".rbf"
-	}
-
-	infoSymlink := func(path string) (RBFInfo, error) {
-		info, err := os.Lstat(path)
-		if err != nil {
-			return RBFInfo{}, fmt.Errorf("inspect RBF path: %w", err)
-		}
-
-		if info.Mode()&os.ModeSymlink != 0 {
-			newPath, err := os.Readlink(path)
-			if err != nil {
-				return RBFInfo{}, fmt.Errorf("read RBF symlink: %w", err)
-			}
-			return ParseRBF(newPath), nil
-		}
-		return ParseRBF(path), nil
+	isMatch := func(file os.DirEntry) bool {
+		return strings.EqualFold(filepath.Ext(file.Name()), ext)
 	}
 
 	files, err := os.ReadDir(config.SdFolder)
@@ -224,23 +209,41 @@ func shallowScanRBF() ([]RBFInfo, error) {
 			}
 
 			for _, subFile := range subFiles {
-				if isRBF(subFile) {
-					path := filepath.Join(config.SdFolder, file.Name(), subFile.Name())
-					info, err := infoSymlink(path)
-					if err != nil {
-						continue
-					}
-					results = append(results, info)
+				if isMatch(subFile) {
+					results = append(results, filepath.Join(config.SdFolder, file.Name(), subFile.Name()))
 				}
 			}
-		} else if isRBF(file) {
-			path := filepath.Join(config.SdFolder, file.Name())
-			info, err := infoSymlink(path)
+		} else if isMatch(file) {
+			results = append(results, filepath.Join(config.SdFolder, file.Name()))
+		}
+	}
+
+	return results, nil
+}
+
+// Find all rbf files in the top 2 menu levels of the SD card.
+func shallowScanRBF() ([]RBFInfo, error) {
+	paths, err := shallowScanPaths(".rbf")
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]RBFInfo, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			newPath, err := os.Readlink(path)
 			if err != nil {
 				continue
 			}
-			results = append(results, info)
+			results = append(results, ParseRBF(newPath))
+			continue
 		}
+		results = append(results, ParseRBF(path))
 	}
 
 	return results, nil

--- a/pkg/games/launchcores.go
+++ b/pkg/games/launchcores.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -213,8 +212,6 @@ func SystemLaunchCores(system *System) ([]LaunchCore, error) {
 	}
 	return matchSystemLaunchCores(rbfFiles, launchers, system), nil
 }
-
-var rbfDateSuffix = regexp.MustCompile(`_\d{8}$`)
 
 // isCoreVariant reports whether a core's short name is the system's core or
 // a suffixed build of it.

--- a/pkg/games/launchcores.go
+++ b/pkg/games/launchcores.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/wizzomafizzo/mrext/pkg/config"
@@ -193,4 +195,71 @@ func matchRBF(rbfFiles []RBFInfo, name string) (RBFInfo, bool) {
 		}
 	}
 	return RBFInfo{}, false
+}
+
+// SystemLaunchCores returns the cores a game of a system can be launched
+// with: the core file the catalog names and any variant that adds a suffix
+// to that name, such as NES_Alt beside NES, followed by every MGL launcher
+// whose core is one of those. Core files that share a launch name, like two
+// dated builds, are reported once, as the newest file.
+func SystemLaunchCores(system *System) ([]LaunchCore, error) {
+	rbfFiles, err := shallowScanRBF()
+	if err != nil {
+		return nil, fmt.Errorf("scan rbf files: %w", err)
+	}
+	launchers, err := shallowScanMGL()
+	if err != nil {
+		return nil, fmt.Errorf("scan mgl files: %w", err)
+	}
+	return matchSystemLaunchCores(rbfFiles, launchers, system), nil
+}
+
+var rbfDateSuffix = regexp.MustCompile(`_\d{8}$`)
+
+// isCoreVariant reports whether a core's short name is the system's core or
+// a suffixed build of it.
+func isCoreVariant(shortName, base string) bool {
+	short := strings.ToLower(shortName)
+	return short == base || strings.HasPrefix(short, base+"_")
+}
+
+func matchSystemLaunchCores(rbfFiles []RBFInfo, launchers []LaunchCore, system *System) []LaunchCore {
+	base := strings.ToLower(filepath.Base(system.Rbf))
+	if base == "" || base == "." {
+		return nil
+	}
+
+	byName := make(map[string]RBFInfo)
+	for _, info := range rbfFiles {
+		if !isCoreVariant(info.ShortName, base) {
+			continue
+		}
+
+		key := strings.ToLower(info.MGLName)
+		if prev, ok := byName[key]; ok && prev.Filename >= info.Filename {
+			continue
+		}
+		byName[key] = info
+	}
+
+	results := make([]LaunchCore, 0, len(byName))
+	for _, info := range byName {
+		results = append(results, rbfLaunchCore(info))
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return strings.ToLower(results[i].Launch) < strings.ToLower(results[j].Launch)
+	})
+
+	fromLaunchers := make([]LaunchCore, 0)
+	for _, core := range launchers {
+		shortName := rbfDateSuffix.ReplaceAllString(filepath.Base(core.RBF), "")
+		if isCoreVariant(shortName, base) {
+			fromLaunchers = append(fromLaunchers, core)
+		}
+	}
+	sort.Slice(fromLaunchers, func(i, j int) bool {
+		return strings.ToLower(fromLaunchers[i].Launch) < strings.ToLower(fromLaunchers[j].Launch)
+	})
+
+	return append(results, fromLaunchers...)
 }

--- a/pkg/games/launchcores.go
+++ b/pkg/games/launchcores.go
@@ -1,0 +1,196 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wizzomafizzo/mrext/pkg/config"
+)
+
+// LaunchCore is one way to run a system's games: a core file the launcher
+// can see, or an MGL launcher that names a core and, usually, a setname so
+// the core keeps its own config folder. RetroAchievements builds are
+// installed the second way, as _RA_Cores/NES.mgl pointing at
+// _RA_Cores/Cores/NES with the setname RA_NES.
+type LaunchCore struct {
+	Name           string // what to call it: the setname when there is one, else the core's short name
+	Launch         string // value a client passes back to launch with this core
+	RBF            string // core in the short form an MGL takes
+	SetName        string // setname the launcher sets, empty for a plain core file
+	Path           string // file this entry came from, .rbf or .mgl
+	Filename       string
+	SetNameSameDir bool // same_dir attribute of that setname
+}
+
+// IsLauncher reports whether the entry came from an MGL launcher rather than
+// a core file.
+func (c *LaunchCore) IsLauncher() bool {
+	return strings.EqualFold(filepath.Ext(c.Path), ".mgl")
+}
+
+// ErrUnknownRBF is returned by FindLaunchCore when nothing the launcher can
+// see matches.
+var ErrUnknownRBF = errors.New("unknown rbf")
+
+func rbfLaunchCore(info RBFInfo) LaunchCore {
+	return LaunchCore{
+		Name:     info.ShortName,
+		Launch:   info.MGLName,
+		RBF:      info.MGLName,
+		Path:     info.Path,
+		Filename: info.Filename,
+	}
+}
+
+// mglLauncher is the part of an MGL file that describes a core launch.
+type mglLauncher struct {
+	XMLName xml.Name      `xml:"mistergamedescription"`
+	RBF     string        `xml:"rbf"`
+	SetName mglSetName    `xml:"setname"`
+	Files   []mglFileMark `xml:"file"`
+}
+
+type mglSetName struct {
+	Value   string `xml:",chardata"`
+	SameDir string `xml:"same_dir,attr"`
+}
+
+// mglFileMark only records that a <file> element is present.
+type mglFileMark struct{}
+
+// parseMGLLauncher reads an MGL that launches a core on its own. An MGL
+// with a <file> element launches a game, so it is not a core launcher.
+func parseMGLLauncher(path string, data []byte) (LaunchCore, bool) {
+	var mgl mglLauncher
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.Strict = false
+	if err := decoder.Decode(&mgl); err != nil {
+		return LaunchCore{}, false
+	}
+
+	rbf := strings.TrimSpace(mgl.RBF)
+	if rbf == "" || len(mgl.Files) > 0 {
+		return LaunchCore{}, false
+	}
+
+	setName := strings.TrimSpace(mgl.SetName.Value)
+	sameDir := strings.TrimSpace(mgl.SetName.SameDir)
+	core := LaunchCore{
+		Name:           setName,
+		Launch:         path,
+		RBF:            rbf,
+		SetName:        setName,
+		SetNameSameDir: sameDir == "1" || strings.EqualFold(sameDir, "true"),
+		Path:           path,
+		Filename:       filepath.Base(path),
+	}
+	if strings.HasPrefix(path, config.SdFolder+"/") {
+		core.Launch = strings.TrimPrefix(path, config.SdFolder+"/")
+	}
+	if core.Name == "" {
+		core.Name = strings.TrimSuffix(core.Filename, filepath.Ext(core.Filename))
+	}
+	return core, true
+}
+
+// shallowScanMGL finds the core launchers in the top 2 menu levels of the
+// SD card, the same levels shallowScanRBF covers.
+func shallowScanMGL() ([]LaunchCore, error) {
+	paths, err := shallowScanPaths(".mgl")
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]LaunchCore, 0, len(paths))
+	for _, path := range paths {
+		// #nosec G304 -- path comes from the menu scan, not from a request.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if core, ok := parseMGLLauncher(path, data); ok {
+			results = append(results, core)
+		}
+	}
+	return results, nil
+}
+
+func matchMGLLauncher(launchers []LaunchCore, name string) (LaunchCore, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return LaunchCore{}, false
+	}
+
+	for _, core := range launchers {
+		if strings.EqualFold(core.Launch, name) || core.Path == name {
+			return core, true
+		}
+	}
+	return LaunchCore{}, false
+}
+
+// FindLaunchCore looks up a core to launch a game with, by the value a
+// client got from SystemLaunchCores: the short name of a core file
+// (_Console/NES_Alt), the SD-relative path of an MGL launcher
+// (_RA_Cores/NES.mgl), or the absolute path of either. Only files the
+// launcher can see match.
+func FindLaunchCore(name string) (LaunchCore, error) {
+	name = strings.TrimSpace(name)
+	if strings.EqualFold(filepath.Ext(name), ".mgl") {
+		launchers, err := shallowScanMGL()
+		if err != nil {
+			return LaunchCore{}, fmt.Errorf("scan mgl files: %w", err)
+		}
+		if core, ok := matchMGLLauncher(launchers, name); ok {
+			return core, nil
+		}
+		return LaunchCore{}, fmt.Errorf("%w: %s", ErrUnknownRBF, name)
+	}
+
+	rbfFiles, err := shallowScanRBF()
+	if err != nil {
+		return LaunchCore{}, fmt.Errorf("scan rbf files: %w", err)
+	}
+	if info, ok := matchRBF(rbfFiles, name); ok {
+		return rbfLaunchCore(info), nil
+	}
+	return LaunchCore{}, fmt.Errorf("%w: %s", ErrUnknownRBF, name)
+}
+
+func matchRBF(rbfFiles []RBFInfo, name string) (RBFInfo, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return RBFInfo{}, false
+	}
+
+	for _, info := range rbfFiles {
+		if strings.EqualFold(info.MGLName, name) || info.Path == name {
+			return info, true
+		}
+	}
+	return RBFInfo{}, false
+}

--- a/pkg/games/launchcores.go
+++ b/pkg/games/launchcores.go
@@ -263,3 +263,49 @@ func matchSystemLaunchCores(rbfFiles []RBFInfo, launchers []LaunchCore, system *
 
 	return append(results, fromLaunchers...)
 }
+
+// LauncherSetName ties the setname an MGL launcher sets to a system whose
+// core it runs, so a tracker can tell which system a core like RA_NES is.
+type LauncherSetName struct {
+	System  *System
+	SetName string
+}
+
+// LauncherSetNames returns the setnames of every MGL launcher the launcher
+// can see, paired with each system that uses the core it names. A core
+// shared by several systems, like NES, FDS and NESMusic, is listed once per
+// system, and the tracker picks between them from the game path.
+func LauncherSetNames() ([]LauncherSetName, error) {
+	launchers, err := shallowScanMGL()
+	if err != nil {
+		return nil, fmt.Errorf("scan mgl files: %w", err)
+	}
+	return setNamesOfLaunchers(launchers), nil
+}
+
+func setNamesOfLaunchers(launchers []LaunchCore) []LauncherSetName {
+	ids := make([]string, 0, len(Systems))
+	for id := range Systems {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	results := make([]LauncherSetName, 0)
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SetName == "" {
+			continue
+		}
+		shortName := rbfDateSuffix.ReplaceAllString(filepath.Base(launcher.RBF), "")
+
+		for _, id := range ids {
+			system := Systems[id]
+			base := strings.ToLower(filepath.Base(system.Rbf))
+			if base == "" || base == "." || !isCoreVariant(shortName, base) {
+				continue
+			}
+			results = append(results, LauncherSetName{SetName: launcher.SetName, System: &system})
+		}
+	}
+	return results
+}

--- a/pkg/games/rbf_test.go
+++ b/pkg/games/rbf_test.go
@@ -56,6 +56,58 @@ func TestMatchRBFByLaunchNameAndPath(t *testing.T) {
 	}
 }
 
+func TestMatchSystemLaunchCoresKeepsVariantsAndNewestRelease(t *testing.T) {
+	t.Parallel()
+
+	system, err := GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rbfFiles := []RBFInfo{
+		ParseRBF("/media/fat/_Console/NES_20230101.rbf"),
+		ParseRBF("/media/fat/_Console/NES_20240310.rbf"),
+		ParseRBF("/media/fat/_Console/NES_Alt_20240102.rbf"),
+		ParseRBF("/media/fat/_Other/NES_Dev_20240201.rbf"),
+		ParseRBF("/media/fat/_Console/SNES_20240310.rbf"),
+		ParseRBF("/media/fat/_Console/NESMusic_20240310.rbf"),
+		ParseRBF("/media/fat/_Console/Genesis_20240310.rbf"),
+	}
+
+	got := matchSystemLaunchCores(rbfFiles, nil, system)
+
+	want := []string{
+		"_Console/NES", "NES_20240310.rbf",
+		"_Console/NES_Alt", "NES_Alt_20240102.rbf",
+		"_Other/NES_Dev", "NES_Dev_20240201.rbf",
+	}
+	if len(got) != len(want)/2 {
+		t.Fatalf("got %d results, want %d: %+v", len(got), len(want)/2, got)
+	}
+	for i, core := range got {
+		if core.Launch != want[i*2] || core.Filename != want[i*2+1] {
+			t.Fatalf("result %d: got %s %s, want %s %s", i, core.Launch, core.Filename, want[i*2], want[i*2+1])
+		}
+		if core.RBF != core.Launch || core.SetName != "" || core.IsLauncher() {
+			t.Fatalf("result %d: a core file should launch as itself with no setname: %+v", i, core)
+		}
+	}
+}
+
+func TestMatchSystemLaunchCoresWithoutMatches(t *testing.T) {
+	t.Parallel()
+
+	system, err := GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := matchSystemLaunchCores([]RBFInfo{ParseRBF("/media/fat/_Console/SNES_20240310.rbf")}, nil, system)
+	if len(got) != 0 {
+		t.Fatalf("expected no results, got %+v", got)
+	}
+}
+
 const (
 	raNESLauncher = "<mistergamedescription>\n\t<rbf>_RA_Cores/Cores/NES</rbf>\n" +
 		"\t<setname same_dir=\"1\">RA_NES</setname>\n</mistergamedescription>"
@@ -67,6 +119,42 @@ const (
 	nesGameLauncher  = "<mistergamedescription><rbf>_Console/NES</rbf>" +
 		"<file delay=\"1\" type=\"f\" index=\"0\" path=\"x.nes\"/></mistergamedescription>"
 )
+
+func TestMatchSystemLaunchCoresIncludesLaunchersForTheCore(t *testing.T) {
+	t.Parallel()
+
+	system, err := GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rbfFiles := []RBFInfo{ParseRBF("/media/fat/_Console/NES_20240310.rbf")}
+	launchers := []LaunchCore{
+		mustParseLauncher(t, "/media/fat/_RA_Cores/SNES.mgl", raSNESLauncher),
+		mustParseLauncher(t, "/media/fat/_RA_Cores/NES.mgl", raNESLauncher),
+		mustParseLauncher(t, "/media/fat/_Other/NES dated.mgl", datedNESLauncher),
+		mustParseLauncher(t, "/media/fat/_Other/NESMusic.mgl",
+			"<mistergamedescription><rbf>_Console/NESMusic</rbf></mistergamedescription>"),
+	}
+
+	got := matchSystemLaunchCores(rbfFiles, launchers, system)
+	if len(got) != 3 {
+		t.Fatalf("got %d results, want 3: %+v", len(got), got)
+	}
+	if got[0].Launch != "_Console/NES" || got[0].IsLauncher() {
+		t.Fatalf("core file should come first: %+v", got[0])
+	}
+
+	ra := got[1]
+	if ra.Launch != "_Other/NES dated.mgl" || ra.Name != "NES_Dated" || ra.SetNameSameDir {
+		t.Fatalf("dated launcher: %+v", ra)
+	}
+	ra = got[2]
+	if ra.Launch != "_RA_Cores/NES.mgl" || ra.RBF != "_RA_Cores/Cores/NES" ||
+		ra.SetName != "RA_NES" || !ra.SetNameSameDir || ra.Name != "RA_NES" || !ra.IsLauncher() {
+		t.Fatalf("RA launcher: %+v", ra)
+	}
+}
 
 func TestParseMGLLauncherSkipsGameLaunchers(t *testing.T) {
 	t.Parallel()

--- a/pkg/games/rbf_test.go
+++ b/pkg/games/rbf_test.go
@@ -20,6 +20,7 @@
 package games
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -205,6 +206,32 @@ func TestMatchMGLLauncherByRelativeAndAbsolutePath(t *testing.T) {
 		if ok != tt.found {
 			t.Fatalf("%q: found %v, want %v", tt.name, ok, tt.found)
 		}
+	}
+}
+
+func TestLauncherSetNamesCoverEverySystemOnTheCore(t *testing.T) {
+	t.Parallel()
+
+	launchers := []LaunchCore{
+		mustParseLauncher(t, "/media/fat/_RA_Cores/NES.mgl", raNESLauncher),
+		mustParseLauncher(t, "/media/fat/_Other/Plain.mgl", plainNESLauncher),
+		mustParseLauncher(t, "/media/fat/_RA_Cores/SNES.mgl", raSNESLauncher),
+	}
+
+	got := setNamesOfLaunchers(launchers)
+
+	want := map[string][]string{"RA_NES": {"FDS", "NES", "NESMusic"}, "RA_SNES": {"SNES", "SNESMusic"}}
+	seen := make(map[string][]string)
+	for _, entry := range got {
+		seen[entry.SetName] = append(seen[entry.SetName], entry.System.Id)
+	}
+	for setName, systems := range want {
+		if strings.Join(seen[setName], ",") != strings.Join(systems, ",") {
+			t.Fatalf("%s: got %v, want %v", setName, seen[setName], systems)
+		}
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("unexpected setnames: %v", seen)
 	}
 }
 

--- a/pkg/games/rbf_test.go
+++ b/pkg/games/rbf_test.go
@@ -57,6 +57,45 @@ func TestMatchRBFByLaunchNameAndPath(t *testing.T) {
 	}
 }
 
+func TestParseRBFStripsOnlyTheReleaseDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path      string
+		shortName string
+		mglName   string
+	}{
+		{"/media/fat/_Console/NES_20240310.rbf", "NES", "_Console/NES"},
+		{"/media/fat/_Console/NES_Alt_20240102.rbf", "NES_Alt", "_Console/NES_Alt"},
+		{"/media/fat/_Console/NES_Alt.rbf", "NES_Alt", "_Console/NES_Alt"},
+		{"/media/fat/_RA_Cores/Cores/NES.rbf", "NES", "_RA_Cores/Cores/NES"},
+		{"/media/fat/_Console/NeoGeoPocket-Color.rbf", "NeoGeoPocket-Color", "_Console/NeoGeoPocket-Color"},
+	}
+	for _, tt := range tests {
+		info := ParseRBF(tt.path)
+		if info.ShortName != tt.shortName || info.MGLName != tt.mglName {
+			t.Fatalf("%s: got %q %q, want %q %q", tt.path, info.ShortName, info.MGLName, tt.shortName, tt.mglName)
+		}
+	}
+}
+
+func TestMatchRBFKeepsUndatedVariantApart(t *testing.T) {
+	t.Parallel()
+
+	rbfFiles := []RBFInfo{
+		ParseRBF("/media/fat/_Console/NES_20240310.rbf"),
+		ParseRBF("/media/fat/_Console/NES_Alt.rbf"),
+	}
+	stock, ok := matchRBF(rbfFiles, "_Console/NES")
+	if !ok || stock.Filename != "NES_20240310.rbf" {
+		t.Fatalf("stock core: got %+v", stock)
+	}
+	alt, ok := matchRBF(rbfFiles, "_Console/NES_Alt")
+	if !ok || alt.Filename != "NES_Alt.rbf" {
+		t.Fatalf("undated variant: got %+v", alt)
+	}
+}
+
 func TestMatchSystemLaunchCoresKeepsVariantsAndNewestRelease(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/games/rbf_test.go
+++ b/pkg/games/rbf_test.go
@@ -1,0 +1,130 @@
+// mrext
+// Copyright (c) 2026 mrext contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of mrext.
+//
+// mrext is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// mrext is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with mrext. If not, see <http://www.gnu.org/licenses/>.
+
+package games
+
+import (
+	"testing"
+)
+
+func TestMatchRBFByLaunchNameAndPath(t *testing.T) {
+	t.Parallel()
+
+	rbfFiles := []RBFInfo{
+		ParseRBF("/media/fat/_Console/NES_20240310.rbf"),
+		ParseRBF("/media/fat/_Console/NES_Alt_20240102.rbf"),
+	}
+
+	tests := []struct {
+		name  string
+		want  string
+		found bool
+	}{
+		{"_Console/NES", "NES_20240310.rbf", true},
+		{"_console/nes_alt", "NES_Alt_20240102.rbf", true},
+		{"/media/fat/_Console/NES_Alt_20240102.rbf", "NES_Alt_20240102.rbf", true},
+		{"NES", "", false},
+		{"_Console/NES_20240310", "", false},
+		{"../menu", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		info, ok := matchRBF(rbfFiles, tt.name)
+		if ok != tt.found {
+			t.Fatalf("%q: found %v, want %v", tt.name, ok, tt.found)
+		}
+		if info.Filename != tt.want {
+			t.Fatalf("%q: got %q, want %q", tt.name, info.Filename, tt.want)
+		}
+	}
+}
+
+const (
+	raNESLauncher = "<mistergamedescription>\n\t<rbf>_RA_Cores/Cores/NES</rbf>\n" +
+		"\t<setname same_dir=\"1\">RA_NES</setname>\n</mistergamedescription>"
+	raSNESLauncher = "<mistergamedescription><rbf>_RA_Cores/Cores/SNES</rbf>" +
+		"<setname same_dir=\"1\">RA_SNES</setname></mistergamedescription>"
+	datedNESLauncher = "<mistergamedescription><rbf>_Console/NES_20240310</rbf>" +
+		"<setname>NES_Dated</setname></mistergamedescription>"
+	plainNESLauncher = "<mistergamedescription><rbf>_Console/NES</rbf></mistergamedescription>"
+	nesGameLauncher  = "<mistergamedescription><rbf>_Console/NES</rbf>" +
+		"<file delay=\"1\" type=\"f\" index=\"0\" path=\"x.nes\"/></mistergamedescription>"
+)
+
+func TestParseMGLLauncherSkipsGameLaunchers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"core only", plainNESLauncher, true},
+		{"with game", nesGameLauncher, false},
+		{"no rbf", "<mistergamedescription><setname>X</setname></mistergamedescription>", false},
+		{"not xml", "hello", false},
+	}
+	for _, tt := range tests {
+		_, ok := parseMGLLauncher("/media/fat/_Other/"+tt.name+".mgl", []byte(tt.data))
+		if ok != tt.want {
+			t.Fatalf("%s: got %v, want %v", tt.name, ok, tt.want)
+		}
+	}
+
+	core, ok := parseMGLLauncher("/media/fat/_Other/Plain.mgl", []byte(plainNESLauncher))
+	if !ok || core.Name != "Plain" || core.SetName != "" || core.Launch != "_Other/Plain.mgl" {
+		t.Fatalf("launcher without setname: %+v", core)
+	}
+}
+
+func TestMatchMGLLauncherByRelativeAndAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	launchers := []LaunchCore{
+		mustParseLauncher(t, "/media/fat/_RA_Cores/NES.mgl", raNESLauncher),
+	}
+
+	tests := []struct {
+		name  string
+		found bool
+	}{
+		{"_RA_Cores/NES.mgl", true},
+		{"_ra_cores/nes.MGL", true},
+		{"/media/fat/_RA_Cores/NES.mgl", true},
+		{"NES.mgl", false},
+		{"../_RA_Cores/NES.mgl", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		_, ok := matchMGLLauncher(launchers, tt.name)
+		if ok != tt.found {
+			t.Fatalf("%q: found %v, want %v", tt.name, ok, tt.found)
+		}
+	}
+}
+
+func mustParseLauncher(t *testing.T, path, data string) LaunchCore {
+	t.Helper()
+	core, ok := parseMGLLauncher(path, []byte(data))
+	if !ok {
+		t.Fatalf("%s did not parse as a core launcher", path)
+	}
+	return core
+}

--- a/pkg/mister/launchers.go
+++ b/pkg/mister/launchers.go
@@ -38,19 +38,45 @@ import (
 	"github.com/wizzomafizzo/mrext/pkg/utils"
 )
 
+// ErrRBFOverrideUnsupported is returned when a core is given for a launch
+// file that already names its own core.
+var ErrRBFOverrideUnsupported = errors.New("rbf override does not apply to mra and mgl files")
+
+// SystemRBF returns the rbf a generated MGL launches for a system: the
+// set_core override from remote.ini when there is one, otherwise the catalog
+// core. The value is the short form an MGL accepts, such as _Console/NES.
+func SystemRBF(cfg *config.UserConfig, system *games.System) string {
+	for _, setCore := range cfg.Systems.SetCore {
+		parts := s.SplitN(setCore, ":", 2)
+		if len(parts) == 2 && s.EqualFold(parts[0], system.Id) {
+			return parts[1]
+		}
+	}
+	return system.Rbf
+}
+
 func GenerateMgl(cfg *config.UserConfig, system *games.System, path, override string) (string, error) {
+	return GenerateMglWithCore(cfg, system, nil, path, override)
+}
+
+// GenerateMglWithCore is GenerateMgl with a specific core. The launch core
+// swaps the rbf, and its setname when it has one, and nil keeps the system
+// default from SystemRBF. Slots, delays and everything else stay whatever
+// the catalog says for the system.
+func GenerateMglWithCore(
+	cfg *config.UserConfig, system *games.System, launch *games.LaunchCore, path, override string,
+) (string, error) {
 	if system == nil {
 		return "", errors.New("no system supplied for MGL generation")
 	}
 
 	core := games.CatalogCore(system)
-
-	// Preserve legacy per-system RBF overrides.
-	for _, setCore := range cfg.Systems.SetCore {
-		parts := s.SplitN(setCore, ":", 2)
-		if len(parts) == 2 && s.EqualFold(parts[0], system.Id) {
-			core.RBF = parts[1]
-			break
+	core.RBF = SystemRBF(cfg, system)
+	if launch != nil {
+		core.RBF = launch.RBF
+		if launch.SetName != "" {
+			core.SetName = launch.SetName
+			core.SetNameSameDir = launch.SetNameSameDir
 		}
 	}
 
@@ -94,13 +120,13 @@ func launchFile(path string) error {
 	return nil
 }
 
-func launchTempMgl(cfg *config.UserConfig, system *games.System, path string) error {
+func launchTempMgl(cfg *config.UserConfig, system *games.System, launch *games.LaunchCore, path string) error {
 	override, err := games.RunSystemHook(cfg, system, path)
 	if err != nil {
 		return fmt.Errorf("run system hook: %w", err)
 	}
 
-	mgl, err := GenerateMgl(cfg, system, path, override)
+	mgl, err := GenerateMglWithCore(cfg, system, launch, path, override)
 	if err != nil {
 		return err
 	}
@@ -130,7 +156,19 @@ func LaunchShortCore(path string) error {
 }
 
 func LaunchGame(cfg *config.UserConfig, system *games.System, path string) error {
-	switch s.ToLower(filepath.Ext(path)) {
+	return LaunchGameWithCore(cfg, system, path, nil)
+}
+
+// LaunchGameWithCore launches a game with a core other than the system
+// default, and nil behaves as LaunchGame. Launch files that name their own
+// core, .mra and .mgl, return ErrRBFOverrideUnsupported when a core is given.
+func LaunchGameWithCore(cfg *config.UserConfig, system *games.System, path string, launch *games.LaunchCore) error {
+	ext := s.ToLower(filepath.Ext(path))
+	if launch != nil && (ext == ".mra" || ext == ".mgl") {
+		return ErrRBFOverrideUnsupported
+	}
+
+	switch ext {
 	case ".mra":
 		err := launchFile(path)
 		if err != nil {
@@ -148,7 +186,7 @@ func LaunchGame(cfg *config.UserConfig, system *games.System, path string) error
 			}
 		}
 	default:
-		err := launchTempMgl(cfg, system, path)
+		err := launchTempMgl(cfg, system, launch, path)
 		if err != nil {
 			return err
 		}
@@ -378,7 +416,7 @@ func LaunchGenericFile(cfg *config.UserConfig, path string) error {
 			return fmt.Errorf("unknown file type: %s", ext)
 		}
 
-		err = launchTempMgl(cfg, &system, path)
+		err = launchTempMgl(cfg, &system, nil, path)
 		if err != nil {
 			return err
 		}

--- a/pkg/mister/launchers_test.go
+++ b/pkg/mister/launchers_test.go
@@ -20,6 +20,7 @@
 package mister
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,6 +63,93 @@ func TestGenerateMglPreservesRBFOverride(t *testing.T) {
 	}
 	if !strings.Contains(got, "<rbf>_Console/CustomNES</rbf>") {
 		t.Fatalf("custom RBF missing: %s", got)
+	}
+}
+
+func TestGenerateMglWithCoreOverridesSetCore(t *testing.T) {
+	t.Parallel()
+
+	system, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.UserConfig{Systems: config.SystemsConfig{SetCore: []string{"nes:_Console/CustomNES"}}}
+
+	alt := &games.LaunchCore{RBF: "_Console/NES_Alt"}
+	got, err := GenerateMglWithCore(cfg, system, alt, "/media/fat/games/NES/Mario.nes", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "<rbf>_Console/NES_Alt</rbf>") {
+		t.Fatalf("requested RBF missing: %s", got)
+	}
+	if strings.Contains(got, "<setname") {
+		t.Fatalf("plain core file must not add a setname: %s", got)
+	}
+
+	got, err = GenerateMglWithCore(cfg, system, nil, "/media/fat/games/NES/Mario.nes", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "<rbf>_Console/CustomNES</rbf>") {
+		t.Fatalf("no core should keep set_core: %s", got)
+	}
+}
+
+func TestGenerateMglWithLauncherSetsSetName(t *testing.T) {
+	t.Parallel()
+
+	system, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ra := &games.LaunchCore{RBF: "_RA_Cores/Cores/NES", SetName: "RA_NES", SetNameSameDir: true}
+	got, err := GenerateMglWithCore(&config.UserConfig{}, system, ra, "/media/fat/games/NES/Mario.nes", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"<rbf>_RA_Cores/Cores/NES</rbf>",
+		"<setname same_dir=\"1\">RA_NES</setname>",
+		"path=\"../../../../../media/fat/games/NES/Mario.nes\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in: %s", want, got)
+		}
+	}
+}
+
+func TestSystemRBFPrefersSetCore(t *testing.T) {
+	t.Parallel()
+
+	system, err := games.GetSystem("NES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := SystemRBF(&config.UserConfig{}, system); got != "_Console/NES" {
+		t.Fatalf("catalog RBF: got %q", got)
+	}
+	cfg := &config.UserConfig{Systems: config.SystemsConfig{
+		SetCore: []string{"SNES:_Console/Other", "nes:_Console/CustomNES"},
+	}}
+	if got := SystemRBF(cfg, system); got != "_Console/CustomNES" {
+		t.Fatalf("set_core RBF: got %q", got)
+	}
+}
+
+func TestLaunchGameWithCoreRejectsLauncherFiles(t *testing.T) {
+	t.Parallel()
+
+	system, err := games.GetSystem("Arcade")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"/media/fat/_Arcade/Pooyan.mra", "/media/fat/_Games/Mario.MGL"} {
+		err := LaunchGameWithCore(&config.UserConfig{}, system, path, &games.LaunchCore{RBF: "_Console/NES"})
+		if !errors.Is(err, ErrRBFOverrideUnsupported) {
+			t.Fatalf("%s: got %v, want ErrRBFOverrideUnsupported", path, err)
+		}
 	}
 }
 

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -147,6 +147,20 @@ func generateNameMap(logger trackerLogger) []NameMapping {
 		}
 	}
 
+	// Launchers such as _RA_Cores/NES.mgl run a system's core under their
+	// own setname, which is what MiSTer then reports as the core name.
+	launcherNames, err := games.LauncherSetNames()
+	if err != nil {
+		logger.Error("error reading core launchers: %s", err)
+	}
+	for _, launcher := range launcherNames {
+		nameMap = append(nameMap, NameMapping{
+			CoreName: launcher.SetName,
+			System:   launcher.System.Id,
+			Name:     launcher.System.Name,
+		})
+	}
+
 	arcadeDbEntries, err := metadata.ReadArcadeDB()
 	if err != nil {
 		logger.Error("error reading arcade db: %s", err)


### PR DESCRIPTION
`POST /games/launch` takes an optional `rbf`. Remote builds the MGL as
before and only swaps the core, so slots, delays and hooks stay whatever
the catalog says. The value is a core file in the short form an MGL uses,
`_Console/NES_Alt`, or an MGL launcher, `_RA_Cores/NES.mgl`, whose `rbf`
and `setname` are used. Only files the existing two-level scan can see are
accepted, otherwise `400`. Sending it with an `.mra` or `.mgl` game path is
a `400` too, since those name their own core. `set_core` in `remote.ini`
keeps working for a plain launch; a request value wins over it.

Launchers are the point: RetroAchievements cores are installed as one MGL
per system pointing at a core in a subfolder, with a setname that gives it
its own config. A core file alone could not reach them.

`GET /systems/{id}/rbfs` lists what a client can send: the catalog core,
any suffixed build beside it, and any launcher whose core is one of those,
each with the value to send back, a display name, the core, the setname
and a `default` flag. Separate commit, drop it if you want the override
alone.

Third commit: the tracker learns the launcher setnames at startup, so a
game running under `RA_NES` reports `system: NES` instead of an empty
string.

Tests cover lookup by name and path, the per-system match, launcher
parsing, the setname mapping, and the MGL output with and without a
setname. `go test ./...`, `golangci-lint run ./...` (v2.13.2) and the
`linux/arm` build pass. Verified on a SuperStation One: the NES listing
shows the stock core, an alternate build and `RA_NES`; a launch through
the launcher produces an MGL with the RA core and setname and MiSTer
reports `RA_NES`; a plain launch is unchanged.

Side note: when we talked about this I had a plain rbf override in mind.
That version worked, then turned out useless for the RA cores on my own
card, which is what led to accepting launchers too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to list available cores and launchers for each system.
  * Added support for selecting a specific core when launching a game.
  * Added core and launcher details, including default-core indicators, to API responses.
  * Improved tracking of games launched through core-specific launchers.

* **Bug Fixes**
  * Unsupported core overrides now return clear client errors.
  * Core and launcher discovery is more resilient when individual files cannot be read.

* **Documentation**
  * Updated Remote API documentation with core listing and core-selection examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->